### PR TITLE
Tweak wrapper shell scripts

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh -eu
 
 die() {
     echo "*** ERROR; build failed"
@@ -20,7 +20,7 @@ build_stage2() {
     ./build_stdlib.sh || die
 }
 
-if [[ "xstage2" = "x$1" ]]; then
+if [[ "xstage2" = "x${1:-}" ]]; then
     echo "Building stage2 Gerbil"
     build_stage2
 else

--- a/src/build0.sh
+++ b/src/build0.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh -eu
 
 die() {
     "*** Build failed"

--- a/src/build1.sh
+++ b/src/build1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh -eu
 
 die() {
     "*** Build failed"
@@ -9,7 +9,7 @@ unset GERBIL_HOME
 export REGERBIL_HOME=$(dirname $(cd ${0%/*} && echo $PWD))
 export GERBIL_HOME=$REGERBIL_HOME/bootstrap/stage0
 
-if [[ "xfinal" = "x$1" ]]; then
+if [[ "xfinal" = "x${1:-}" ]]; then
     export GERBIL_TARGET=$REGERBIL_HOME
     final="[final]"
 else
@@ -39,4 +39,3 @@ echo ">>> finalizing build"
 cp -v boot/*.scm $GERBIL_TARGET/lib
 cp -v gerbil/gxi gerbil/gxc $GERBIL_TARGET/bin
 (cd $GERBIL_TARGET/bin && ln -s gxi gxi-script)
-

--- a/src/build2.sh
+++ b/src/build2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh -eu
 
 die() {
     "*** Build failed"
@@ -35,4 +35,3 @@ echo ">>> finalizing build"
 cp -v boot/*.scm $GERBIL_TARGET/lib
 cp -v gerbil/gxi gerbil/gxc $GERBIL_TARGET/bin
 (cd $GERBIL_TARGET/bin && ln -s gxi gxi-script)
-

--- a/src/build2_fini.sh
+++ b/src/build2_fini.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh -eu
 
 unset GERBIL_HOME
 export GERBIL_HOME=$(dirname $(cd ${0%/*} && echo $PWD))

--- a/src/build_stdlib.sh
+++ b/src/build_stdlib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh -eu
 
 export GERBIL_HOME=$(dirname $(cd ${0%/*} && echo $PWD))
 export PATH="$GERBIL_HOME/bin:$PATH"

--- a/src/gerbil/gxi
+++ b/src/gerbil/gxi
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh -eu
 
-if [ -z "$GERBIL_HOME" ]; then
+if [ -z "${GERBIL_HOME:-}" ]; then
     GERBIL_HOME=$(dirname $(cd ${0%/*} && echo $PWD))
     export GERBIL_HOME
 fi
@@ -15,8 +15,7 @@ if [ $# -gt 0 ]; then
 fi
 
 if [[ "x" = "x$@" ]]; then
-    gsi $GSIOPTIONS $GERBIL_HOME/lib/gxi-init $GERBIL_HOME/lib/gxi-interactive -
+    gsi ${GSIOPTIONS:-} $GERBIL_HOME/lib/gxi-init $GERBIL_HOME/lib/gxi-interactive -
 else
-    gsi $GSIOPTIONS $GERBIL_HOME/lib/gxi-init "$@"
+    gsi ${GSIOPTIONS:-} $GERBIL_HOME/lib/gxi-init "$@"
 fi
-


### PR DESCRIPTION
1- Use /bin/sh not /bin/bash so it will work on NixOS
(and hopefully also BSD and any minimalist Unix distributions).

2- Use options -eu to fail early on any error, and
to count undefined variables as errors.