### PR TITLE
libcrypto ffi: compatibility with openssl-1.1.x; EVP_dss1 exists no longer

### DIFF
--- a/src/std/crypto/libcrypto.scm
+++ b/src/std/crypto/libcrypto.scm
@@ -109,7 +109,6 @@ END-C
 
 (define-c-lambda/const-pointer EVP_md5 () EVP_MD*)
 (define-c-lambda/const-pointer EVP_sha1 () EVP_MD*)
-(define-c-lambda/const-pointer EVP_dss1 () EVP_MD*)
 (define-c-lambda/const-pointer EVP_sha224 () EVP_MD*)
 (define-c-lambda/const-pointer EVP_sha256 () EVP_MD*)
 (define-c-lambda/const-pointer EVP_sha384 () EVP_MD*)
@@ -386,7 +385,7 @@ static BIGNUM *ffi_DH_pub_key (DH *dh)
 #else
  BIGNUM const *pub;
  DH_get0_key (dh, &pub, NULL);
- return pub;
+ return (BIGNUM*) pub;
 #endif
 }
 

--- a/src/std/crypto/libcrypto.ssi
+++ b/src/std/crypto/libcrypto.ssi
@@ -10,7 +10,7 @@ package: std/crypto
   EVP_MD? EVP_MD_CTX?
   EVP_MD_CTX_create EVP_DigestInit EVP_DigestUpdate EVP_DigestFinal
   EVP_MD_CTX_copy
-  EVP_md5 EVP_sha1 EVP_dss1 EVP_sha224 EVP_sha256 EVP_sha384 EVP_sha512
+  EVP_md5 EVP_sha1 EVP_sha224 EVP_sha256 EVP_sha384 EVP_sha512
   EVP_MD_type EVP_MD_pkey_type EVP_MD_size EVP_MD_block_size EVP_MD_name
   EVP_MD_CTX_md EVP_MD_CTX_type EVP_MD_CTX_size EVP_MD_CTX_block_size
   EVP_get_digestbyname EVP_get_digestbynid


### PR DESCRIPTION
Hello,
this PR should close issue #9. Code compiles cleanly now, but i haven't tested it otherwise.
Is there a testsuite covering libcrypto ffi anywhere (directly or otherwise)?

EVP_dss1 is no longer available under OpenSSL-1.1.x.  This is what the Manpage for OpenSSL-1.0.0
has to say:
> EVP_dss() and EVP_dss1() return EVP_MD structures for SHA and SHA1 digest algorithms but using DSS ( DSA ) for the signature algorithm. Note: there is no need to use these pseudo-digests in OpenSSL 1.0.0 and later, they are however retained for compatibility. 

So i've chosen to remove that function from the library entirely.
Works for you?