### PR TITLE
be consistent with package management tools: it's CPPFLAGS.

### DIFF
--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -1,7 +1,7 @@
 ;; -*- Gerbil -*-
 
 (def ldflags (env-ldflags))
-(def ccflags (env-ccflags))
+(def cppflags (env-cppflags))
 
 (def build-spec
   `("build-config"
@@ -51,14 +51,14 @@
     "text/json"
     ,@(if config-enable-libyaml
         `((gsc: "text/libyaml"
-                "-cc-options" ,(ccflags "")
+                "-cc-options" ,(cppflags "")
                 "-ld-options" ,(ldflags "-lyaml"))
           (ssi: "text/libyaml")
           "text/yaml")
         '())
     ,@(if config-enable-zlib
         `((gsc: "text/_zlib"
-                "-cc-options" ,(ccflags "")
+                "-cc-options" ,(cppflags "")
                 "-ld-options" ,(ldflags "-lz"))
           (ssi: "text/_zlib")
           "text/zlib")
@@ -117,7 +117,7 @@
         '())
     ;; :std/crypto
     (gsc: "crypto/libcrypto"
-          "-cc-options" ,(ccflags "")
+          "-cc-options" ,(cppflags "")
           "-ld-options" ,(ldflags "-lcrypto")
           "-e" "(include \"~~lib/_gambit#.scm\")")
     (ssi: "crypto/libcrypto")
@@ -153,28 +153,28 @@
     (gxc: "db/conpool" "-e" "(include \"~~lib/_gambit#.scm\")")
     ,@(if config-enable-sqlite
         `((gsc: "db/_sqlite"
-                "-cc-options" ,(ccflags "")
+                "-cc-options" ,(cppflags "")
                 "-ld-options" ,(ldflags "-lsqlite3"))
           (ssi: "db/_sqlite")
           "db/sqlite")
         '())
     ,@(if config-enable-mysql
         `((gsc: "db/_mysql"
-                "-cc-options" ,(ccflags "")
+                "-cc-options" ,(cppflags "")
                 "-ld-options" ,(ldflags "-lpthread -lmysqlclient"))
           (ssi: "db/_mysql")
           "db/mysql")
         '())
     ,@(if config-enable-lmdb
         `((gsc: "db/_lmdb"
-                "-cc-options" ,(ccflags "")
+                "-cc-options" ,(cppflags "")
                 "-ld-options" ,(ldflags "-llmdb"))
           (ssi: "db/_lmdb")
           "db/lmdb")
         '())
     ,@(if config-enable-leveldb
         `((gsc: "db/_leveldb"
-                "-cc-options" ,(ccflags "")
+                "-cc-options" ,(cppflags "")
                 "-ld-options" ,(ldflags "-lleveldb"))
           (ssi: "db/_leveldb")
           "db/leveldb")

--- a/src/std/make.ss
+++ b/src/std/make.ss
@@ -10,7 +10,7 @@ package: std
         "sort")
 (export make make-depgraph make-depgraph/spec
         shell-config
-        env-ccflags
+        env-cppflags
         env-ldflags)
 
 ;; buildspec: [<build> ...]
@@ -223,9 +223,9 @@ package: std
    (else
     identity)))
 
-(def (env-ccflags)
+(def (env-cppflags)
   (cond
-   ((getenv "CCFLAGS" #f)
+   ((getenv "CPPFLAGS" #f)
     => (lambda (flags)
          (lambda (more)
            (if (string-empty? more)


### PR DESCRIPTION
Per @edw comments in #18, it is preferable for the variable to be called `CPPFLAGS` as documented by the various package management tools.
In the principle of least surprise, use the same variable.