### PR TITLE
Fix c++ compilation.

### DIFF
--- a/src/lang/scheme/time-impl.ss
+++ b/src/lang/scheme/time-impl.ss
@@ -43,7 +43,7 @@ static long ffi_get_jiffies ()
   goto err;
  }
 
- int r = clock_gettime (CLOCK_MONOTONIC, &ts);
+ int r; r = clock_gettime (CLOCK_MONOTONIC, &ts);
  if (r)
  {
   perror ("clock_gettime");

--- a/src/std/text/_zlib.scm
+++ b/src/std/text/_zlib.scm
@@ -96,7 +96,7 @@ static ___SCMOBJ ffi_free (void *ptr)
 
 static z_stream *ffi_make_z_stream ()
 {
- z_stream *zs = malloc (sizeof (z_stream));
+ z_stream *zs = (z_stream *)malloc (sizeof (z_stream));
  if (zs) {
   memset (zs, 0, sizeof (z_stream));
  }


### PR DESCRIPTION
Got some minor errors when compiling with g++ compiler on macOS.

1. (void *) return must be cast in c++.
2. Cant jump (GOTO) place in between declaration and definition. Split it.