### PR TITLE
Alist to json

### DIFF
--- a/src/std/text/json.ss
+++ b/src/std/text/json.ss
@@ -19,7 +19,7 @@ package: std/text
 (import :gerbil/gambit/ports
         :gerbil/gambit/bits
         :std/error
-        :std/misc/list
+        (only-in :std/misc/list alist?)
         (only-in :std/srfi/1 reverse!))
 (export read-json write-json
         string->json-object json-object->string


### PR DESCRIPTION
Added functionality to write-json from alist. This is already done internally when writing a table. Why not get alist for free? Old behavior resulted in an error before, so no change to previous behavior. One can now do:

```
(write-json '((a . 5) (b . 7)) (current-output-port)) 
;;> {"a":5,"b":7}
```