### PR TITLE
Add bindings to kqueue and kqueue-based socket server

### DIFF
--- a/doc/stdlib.md
+++ b/doc/stdlib.md
@@ -64,6 +64,7 @@
   * [std/os/socket](#stdossocket)
   * [std/os/epoll](#stdosepoll)
   * [std/os/inotify](#stdosinotify)
+  * [std/os/kqueue](#stdoskqueue)
 - [std/parser](#stdparser)
 - [std/pregexp](#stdpregexp)
 - [std/sort](#stdsort)
@@ -1339,6 +1340,72 @@ inotify for linux.
   IN_ISDIR
   IN_Q_OVERFLOW
   IN_UNMOUNT
+```
+
+### std/os/kqueue
+
+kqueue for BSD.
+
+```
+(require bsd)
+(import :std/os/kqueue)
+
+;; exports:
+    kqueue
+    make-kevents
+    kqueue-close
+    kqueue-wait
+    kqueue-kevent-add
+    kqueue-kevent-del
+    kevent-ident
+    kevent-filter
+    kevent-flags
+    kevent-fflags
+    kevent-data
+    kevent-udata
+    set-kevent-ident!
+    set-kevent-filter!
+    set-kevent-flags!
+    set-kevent-fflags!
+    set-kevent-data!
+    set-kevent-udata!
+    EV_ADD
+    EV_ENABLE
+    EV_DISABLE
+    EV_DISPATCH
+    EV_DELETE
+    EV_RECEIPT
+    EV_ONESHOT
+    EV_CLEAR
+    EV_EOF
+    EV_ERROR
+    EVFILT_READ
+    EVFILT_WRITE
+    EVFILT_VNODE
+    EVFILT_PROC
+    EVFILT_SIGNAL
+    EVFILT_TIMER
+    EVFILT_DEVICE
+    NOTE_DELETE
+    NOTE_WRITE
+    NOTE_EXTEND
+    NOTE_TRUNCATE
+    NOTE_LOWAT
+    NOTE_EOF
+    NOTE_DELETE
+    NOTE_WRITE
+    NOTE_EXTEND
+    NOTE_TRUNCATE
+    NOTE_ATTRIB
+    NOTE_LINK
+    NOTE_RENAME
+    NOTE_REVOKE
+    NOTE_EXIT
+    NOTE_FORK
+    NOTE_EXEC
+    NOTE_TRACK
+    NOTE_TRACKERR
+    NOTE_CHANGE
 ```
 
 ## std/parser

--- a/src/gerbil/expander/root.ss
+++ b/src/gerbil/expander/root.ss
@@ -214,6 +214,13 @@ namespace: gx
       (match (string-split (symbol->string sys-type) #\-)
         (["linux" . rest] (not (null? rest)))
         (else #f)))
+    (def (bsd-variant? sys-type)
+      (def bsd ["openbsd" "netbsd" "freebsd" "darwin"])
+      (def sys-prefix
+        (list->string
+         (filter char-alphabetic?
+                 (string->list (symbol->string sys-type)))))
+      (not (null? (member sys-prefix bsd))))
     (core-bind-feature! 'gerbil #f 0 self)
     (core-bind-feature! (gerbil-system) #f 0 self)
     (match (system-type)
@@ -221,7 +228,9 @@ namespace: gx
        (core-bind-feature! sys-cpu #f 0 self)
        (core-bind-feature! sys-type #f 0 self)
        (when (linux-variant? sys-type)
-         (core-bind-feature! 'linux #f 0 self)))
+         (core-bind-feature! 'linux #f 0 self))
+       (when (bsd-variant? sys-type)
+         (core-bind-feature! 'bsd #f 0 self)))
       (else (void)))
     (when (gerbil-runtime-smp?)
       (core-bind-feature! 'gerbil-smp #f 0 self))))

--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -99,6 +99,8 @@
         (linux
          `((gxc: "os/epoll" ,@(include-gambit-sharp))
            (gxc: "os/inotify" ,@(include-gambit-sharp))))
+        (bsd
+         `((gxc: "os/kqueue" ,@(include-gambit-sharp))))
         (else '()))
     ;; :std/net/bio
     "net/bio/input"
@@ -114,6 +116,8 @@
     ,@(cond-expand
         (linux
          '("net/socket/epoll-server"))
+        (bsd
+         '("net/socket/kqueue-server"))
         (else '()))
     "net/socket/server"
     "net/socket"

--- a/src/std/net/socket/kqueue-server.ss
+++ b/src/std/net/socket/kqueue-server.ss
@@ -1,0 +1,139 @@
+;;; -*- Gerbil -*-
+;;; (C) vyzo at hackzen.org
+;;; synchronous sockets  -- kqueue server implementation
+package: std/net/sockets
+
+(require bsd)
+(import :gerbil/gambit/threads
+        :gerbil/gambit/ports
+        :gerbil/gambit/misc
+        :std/net/socket/base
+        :std/net/socket/basic-server
+        :std/os/fd
+        :std/os/kqueue
+        :std/iter)
+(export kqueue-socket-server)
+
+(def (kqueue-socket-server)
+  (def fdtab (make-hash-table-eq))
+  (def kq (kqueue))
+  (def maxevts 8192)
+  (def evts (make-kevents maxevts))
+
+  (def ev-in (##fxior EVFILT_READ EV_EOF EV_ERROR))
+  (def ev-out (##fxior EVFILT_WRITE EV_EOF EV_ERROR))
+
+  (def (do-kevent)
+    (let (count (kqueue-wait kq evts maxevts))
+      (when (##fxpositive? count)
+        (let lp ((k 0))
+          (when (##fx< k count)
+            (let ((fd (kevent-ident evts k))
+                  (ready (kevent-flags evts k)))
+              (with ((!socket-state _ io-in io-out)
+                     (hash-ref fdtab fd))
+                (cond
+                 ((##fxpositive? (##fxand ready ev-in))
+                  (when io-in
+                    (io-state-signal-ready! io-in 'ready)))
+                 ((##fxpositive? (##fxand ready ev-out))
+                  (when io-out
+                    (io-state-signal-ready! io-out 'ready))))
+                (lp (##fx+ k 1)))))))))
+
+  (def (add-socket sock)
+    (let* ((self (current-thread))
+           (fd (fd-e sock))
+           (io-in
+            (and (fd-io-in sock)
+                 (make-!io-state)))
+           (wait-in
+            (and io-in
+                 (lambda (ssock timeo)
+                   (io-state-wait-io! io-in timeo 'input))))
+           (io-out
+            (and (fd-io-out sock)
+                 (make-!io-state)))
+           (wait-out
+            (lambda (ssock timeo)
+              (io-state-wait-io! io-out timeo 'output)))
+           (close
+            (lambda (ssock dir shutdown)
+              (!!socket-server.close self ssock dir shutdown)))
+           (ssock
+            (make-!socket sock wait-in wait-out close))
+           (state
+            (make-!socket-state sock io-in io-out))
+           (filter 0))
+      (when io-in
+        (set! filter (##fxior filter EVFILT_READ)))
+      (when io-out
+        (set! filter (##fxior filter EVFILT_WRITE)))
+      (make-will ssock (cut close <> 'inout #f))
+      (kqueue-kevent-add kq sock filter)
+      (hash-put! fdtab fd state)
+      ssock))
+
+  (def (close-socket ssock dir shutdown)
+    (def (close-io-in! io-in sock)
+      (io-state-close-in! io-in sock shutdown))
+    (def (close-io-out! io-out sock)
+      (io-state-close-out! io-out sock shutdown))
+
+    (with ((!socket sock wait-in wait-out) ssock)
+      (when (or wait-in wait-out)
+        (let (state (hash-get fdtab (fd-e sock)))
+          (match state
+            ((!socket-state _ io-in io-out)
+             (case dir
+               ((in)
+                (if io-out
+                  (kqueue-kevent-add kq sock EVFILT_WRITE)
+                  (begin
+                    (kqueue-kevent-del kq sock)
+                    (hash-remove! fdtab (fd-e sock))))
+                (set! (!socket-wait-in ssock) #f)
+                (set! (!socket-state-io-in state) #f)
+                (close-io-in! io-in sock)
+                (unless io-out
+                  (close-port sock)))
+               ((out)
+                (if io-in
+                  (kqueue-kevent-add kq sock EVFILT_READ)
+                  (begin
+                    (kqueue-kevent-del kq sock)
+                    (hash-remove! fdtab (fd-e sock))))
+                (set! (!socket-wait-out ssock) #f)
+                (set! (!socket-state-io-out state) #f)
+                (close-io-out! io-out sock)
+                (unless io-in
+                  (close-port sock)))
+               ((inout)
+                (kqueue-kevent-del kq sock)
+                (hash-remove! fdtab (fd-e sock))
+                (when io-in
+                  (set! (!socket-wait-in ssock) #f)
+                  (set! (!socket-state-io-in state) #f)
+                  (close-io-in! io-in sock))
+                (when io-out
+                  (set! (!socket-wait-out ssock) #f)
+                  (set! (!socket-state-io-out state) #f)
+                  (close-io-out! io-out sock))
+                (close-port sock))
+               (else "Bad direction" dir)))
+            (else (void)))))))
+
+  (def (shutdown!)
+    (close-port kq)
+    (for (state (in-hash-values fdtab))
+      (with ((!socket-state sock io-in io-out) state)
+        (when io-in
+          (io-state-close-in! io-in sock #f))
+        (when io-out
+          (io-state-close-out! io-out sock #f))
+        (close-port sock)))
+    ;; release refs to raw devices
+    (set! fdtab #f)
+    (set! kqueue #f))
+
+  (server-loop (fd-io-in kq) do-kevent add-socket close-socket shutdown!))

--- a/src/std/net/socket/server.ss
+++ b/src/std/net/socket/server.ss
@@ -13,7 +13,9 @@ package: std/net/socket
 
 (cond-expand
   (linux
-   (import :std/net/socket/epoll-server)))
+   (import :std/net/socket/epoll-server))
+  (bsd
+   (import :std/net/socket/kqueue-server)))
 
 ;; start the socket server -- takes a server implementation, eg epoll-server
 (def (start-socket-server! (impl (default-server-impl)))
@@ -39,5 +41,6 @@ package: std/net/socket
 (def (default-server-impl)
   (cond-expand
     (linux epoll-socket-server)
+    (bsd kqueue-socket-server)
     (else
      (error "No socket server implementation for this sytem" (system-type)))))

--- a/src/std/os/kqueue.ss
+++ b/src/std/os/kqueue.ss
@@ -1,0 +1,261 @@
+;;; -*- Gerbil -*-
+;;; (C) vyzo at hackzen.org
+;;; OS kqueue interface [bsd]
+package: std/os
+
+(require bsd)
+(import :gerbil/gambit/threads
+        (only-in :gerbil/gambit/ports close-port)
+        :std/os/error
+        :std/os/fd)
+(export kqueue kqueue-close
+        make-kevents kqueue-wait
+        kqueue-kevent-add kqueue-kevent-del
+        kevent-ident kevent-filter kevent-flags
+        kevent-fflags kevent-data kevent-udata
+        set-kevent-ident! set-kevent-filter! set-kevent-flags!
+        set-kevent-fflags! set-kevent-data! set-kevent-udata!
+        EV_ADD EV_ENABLE EV_DISABLE EV_DISPATCH EV_DELETE
+        EV_RECEIPT EV_ONESHOT EV_CLEAR EV_EOF EV_ERROR
+        EVFILT_READ EVFILT_WRITE EVFILT_VNODE EVFILT_PROC
+        EVFILT_SIGNAL EVFILT_TIMER EVFILT_DEVICE
+        NOTE_DELETE NOTE_WRITE NOTE_EXTEND NOTE_TRUNCATE NOTE_LOWAT
+        NOTE_EOF NOTE_DELETE NOTE_WRITE NOTE_EXTEND NOTE_TRUNCATE
+        NOTE_ATTRIB NOTE_LINK NOTE_RENAME NOTE_REVOKE NOTE_EXIT
+        NOTE_FORK NOTE_EXEC NOTE_TRACK NOTE_TRACKERR NOTE_CHANGE)
+
+(def (kqueue)
+  (let (fd (check-os-error (_kqueue) (kqueue)))
+    (fdopen fd 'in 'kqueue)))
+
+(def (kqueue-close kq)
+  (close-port kq))
+
+(def (make-kevents size)
+  (check-ptr (make_kevents size)))
+
+(def (kevent kqueue change-list nchanges event-list nevents timeout)
+  (check-os-error
+   (_kevent (fd-e kqueue) change-list nchanges event-list nevents timeout)
+   (kevent kqueue change-list nchanges event-list nevents timeout)))
+
+(def (kqueue-wait kqueue events nevents)
+  (kevent kqueue #f 0 events nevents #f))
+
+(def (kqueue-kevent-add kqueue dev filter)
+  (let (kevt (get-kevent-ptr))
+    (kevent_ident_set kevt 0 (fd-e dev))
+    (kevent_flags_set kevt 0 EV_ADD)
+    (kevent_filter_set kevt 0 filter)
+    (kevent kqueue kevt 1 #f 0 #f)))
+
+(def (kqueue-kevent-del kqueue dev)
+  (let (kevt (get-kevent-ptr))
+    (kevent_ident_set kevt 0 (fd-e dev))
+    (kevent_flags_set kevt 0 EV_DELETE)
+    (kevent kqueue kevt 1 #f 0 #f)))
+
+(def kevent-ptr-key
+  'std/os/kqueue#kevent-ptr)
+
+(def (get-kevent-ptr)
+  (cond
+   ((thread-local-get kevent-ptr-key)
+    => values)
+   (else
+    (let (kevent-ptr (check-ptr (make_kevents 1)))
+      (thread-local-set! kevent-ptr-key kevent-ptr)
+      kevent-ptr))))
+
+(def kevent-ident kevent_ident)
+(def kevent-filter kevent_filter)
+(def kevent-flags kevent_flags)
+(def kevent-fflags kevent_fflags)
+(def kevent-data kevent_data)
+(def kevent-udata kevent_udata)
+
+(def set-kevent-ident! kevent_ident_set)
+(def set-kevent-filter! kevent_filter_set)
+(def set-kevent-flags! kevent_flags_set)
+(def set-kevent-fflags! kevent_fflags_set)
+(def set-kevent-data! kevent_data_set)
+(def set-kevent-udata! kevent_udata_set)
+
+(extern
+  EV_ADD EV_ENABLE EV_DISABLE EV_DISPATCH
+  EV_DELETE EV_RECEIPT EV_ONESHOT EV_CLEAR EV_EOF EV_ERROR
+  EVFILT_READ EVFILT_WRITE EVFILT_VNODE EVFILT_PROC
+  EVFILT_SIGNAL EVFILT_TIMER EVFILT_DEVICE
+  NOTE_DELETE NOTE_WRITE NOTE_EXTEND NOTE_TRUNCATE NOTE_LOWAT
+  NOTE_EOF NOTE_DELETE NOTE_WRITE NOTE_EXTEND NOTE_TRUNCATE
+  NOTE_ATTRIB NOTE_LINK NOTE_RENAME NOTE_REVOKE NOTE_EXIT
+  NOTE_FORK NOTE_EXEC NOTE_TRACK NOTE_TRACKERR NOTE_CHANGE
+  _kqueue _kevent
+  make_kevents
+  kevent_ident kevent_ident_set
+  kevent_filter kevent_filter_set
+  kevent_flags kevent_flags_set
+  kevent_fflags kevent_fflags_set
+  kevent_data kevent_data_set
+  kevent_udata kevent_udata_set
+  ev_set)
+
+(begin-foreign
+  (c-declare "#include <errno.h>")
+  (c-declare "#include <stdlib.h>")
+  (c-declare "#include <sys/types.h>")
+  (c-declare "#include <sys/event.h>")
+  (c-declare "#include <sys/time.h>")
+
+  (define-macro (define-c-lambda id args ret #!optional (name #f))
+    (let ((name (or name (##symbol->string id))))
+      `(define ,id
+         (c-lambda ,args ,ret ,name))))
+
+  (define-macro (define-const symbol)
+    (let* ((str (##symbol->string symbol))
+           (ref (##string-append "___return (" str ");")))
+      `(define ,symbol
+         ((c-lambda () int ,ref)))))
+
+  (define-macro (define-with-errno symbol ffi-symbol args)
+    `(define (,symbol ,@args)
+       (declare (not interrupts-enabled))
+       (let ((r (,ffi-symbol ,@args)))
+         (if (##fx< r 0)
+           (##fx- (__errno))
+           r))))
+
+  (namespace ("std/os/kqueue#"
+              EV_ADD EV_ENABLE EV_DISABLE EV_DISPATCH
+              EV_DELETE EV_RECEIPT EV_ONESHOT EV_CLEAR EV_EOF EV_ERROR
+              EVFILT_READ EVFILT_WRITE EVFILT_VNODE EVFILT_PROC
+              EVFILT_SIGNAL EVFILT_TIMER EVFILT_DEVICE
+              NOTE_DELETE NOTE_WRITE NOTE_EXTEND NOTE_TRUNCATE NOTE_LOWAT
+              NOTE_EOF NOTE_DELETE NOTE_WRITE NOTE_EXTEND NOTE_TRUNCATE
+              NOTE_ATTRIB NOTE_LINK NOTE_RENAME NOTE_REVOKE NOTE_EXIT
+              NOTE_FORK NOTE_EXEC NOTE_TRACK NOTE_TRACKERR NOTE_CHANGE
+              kevent kevent* timespec timespec*
+              __errno __kqueue __kevent
+              _kqueue _kevent
+              make_kevents
+              kevent_ident kevent_ident_set
+              kevent_filter kevent_filter_set
+              kevent_flags kevent_flags_set
+              kevent_fflags kevent_fflags_set
+              kevent_data kevent_data_set
+              kevent_udata kevent_udata_set
+              ev_set
+              ))
+
+  ;; Filters
+  (define-const EV_ADD)
+  (define-const EV_ENABLE)
+  (define-const EV_DISABLE)
+  (define-const EV_DISPATCH)
+  (define-const EV_DELETE)
+  (define-const EV_RECEIPT)
+  (define-const EV_ONESHOT)
+  (define-const EV_CLEAR)
+  (define-const EV_EOF)
+  (define-const EV_ERROR)
+
+  ;; Flags
+  (define-const EVFILT_READ)
+  (define-const EVFILT_WRITE)
+  (define-const EVFILT_VNODE)
+  (define-const EVFILT_PROC)
+  (define-const EVFILT_SIGNAL)
+  (define-const EVFILT_TIMER)
+  (define-const EVFILT_DEVICE)
+
+  ;; Filter Flags
+  (define-const NOTE_DELETE)
+  (define-const NOTE_WRITE)
+  (define-const NOTE_EXTEND)
+  (define-const NOTE_TRUNCATE)
+  (define-const NOTE_LOWAT)
+  (define-const NOTE_EOF)
+  (define-const NOTE_DELETE)
+  (define-const NOTE_WRITE)
+  (define-const NOTE_EXTEND)
+  (define-const NOTE_TRUNCATE)
+  (define-const NOTE_ATTRIB)
+  (define-const NOTE_LINK)
+  (define-const NOTE_RENAME)
+  (define-const NOTE_REVOKE)
+  (define-const NOTE_EXIT)
+  (define-const NOTE_FORK)
+  (define-const NOTE_EXEC)
+  (define-const NOTE_TRACK)
+  (define-const NOTE_TRACKERR)
+  (define-const NOTE_CHANGE)
+
+  (c-declare "static ___SCMOBJ ffi_free (void *ptr);")
+
+  (c-define-type kevent (struct "kevent"))
+  (c-define-type kevent*
+    (pointer kevent (kevent*) "ffi_free"))
+  (c-define-type timespec (struct "timespec"))
+  (c-define-type timespec*
+    (pointer timespec (timespec*) "ffi_free"))
+
+  (define-c-lambda __errno () int
+    "___return (errno);")
+
+  (define-c-lambda __kqueue () int
+    "kqueue")
+  (define-c-lambda __kevent (int kevent* int kevent* int timespec*) int
+    "kevent")
+
+  (define-with-errno _kqueue __kqueue ())
+  (define-with-errno _kevent __kevent (kqfd chgs nchgs evts nevts timeo))
+
+  (define-c-lambda make_kevents (int) kevent*
+    "___return ((struct kevent*)malloc (___arg1 * sizeof (struct kevent)));")
+
+  (define-c-lambda kevent_ident (kevent* int) unsigned-int
+    "___return (___arg1[___arg2].ident);")
+  (define-c-lambda kevent_ident_set (kevent* int unsigned-int) void
+    "___arg1[___arg2].ident = ___arg3; ___return;")
+
+  (define-c-lambda kevent_filter (kevent* int) short
+    "___return (___arg1[___arg2].filter);")
+  (define-c-lambda kevent_filter_set (kevent* int short) void
+    "___arg1[___arg2].filter = ___arg3; ___return;")
+
+  (define-c-lambda kevent_flags (kevent* int) unsigned-short
+    "___return (___arg1[___arg2].flags);")
+  (define-c-lambda kevent_flags_set (kevent* int unsigned-short) void
+    "___arg1[___arg2].flags = ___arg3; ___return;")
+
+  (define-c-lambda kevent_fflags (kevent* int) unsigned-int
+    "___return (___arg1[___arg2].fflags);")
+  (define-c-lambda kevent_fflags_set (kevent* int unsigned-int) void
+    "___arg1[___arg2].fflags = ___arg3; ___return;")
+
+  (define-c-lambda kevent_data (kevent* int) int64
+    "___return (___arg1[___arg2].data);")
+  (define-c-lambda kevent_data_set (kevent* int int64) void
+    "___arg1[___arg2].data = ___arg3; ___return;")
+
+  (define-c-lambda kevent_udata (kevent* int) (pointer void)
+    "___return (___arg1[___arg2].udata);")
+  (define-c-lambda kevent_udata_set (kevent* int (pointer void)) void
+    "___arg1[___arg2].udata = ___arg3; ___return;")
+
+  (define-c-lambda ev_set
+    (kevent* int unsigned-int short unsigned-short unsigned-int int64 (pointer void)) void
+    "EV_SET(&___arg1[___arg2], ___arg3, ___arg4, ___arg5, ___arg6, ___arg7, ___arg8); ___return;")
+
+  (c-declare #<<END-C
+#ifndef __HAVE_FFI_FREE
+#define __HAVE_FFI_FREE
+___SCMOBJ ffi_free (void *ptr)
+{
+ free(ptr);
+ return ___FIX (___NO_ERR);
+}
+#endif
+END-C
+))


### PR DESCRIPTION
Greetings. I noticed that there were bindings to the linux epoll syscall in `std` and thought that it might be good to have some for the similar kqueue system on BSD.

I do not yet fully understand how the underlying IO mechanism works wihtin the Gambit layers, but I was able to get something working by following what was going on in `epoll.ss` and `epoll-server.ss`, changing what needed to be changed.

I tested this by making some socket servers as well as running a modified version of the `httpd-test` that starts up the socket server. I'd be happy to test further or commit some tests targeting the socket interface (I didn't see any) if desired. 