### PR TITLE
std/srfi/41: add missing exports

### DIFF
--- a/src/std/srfi/41.ss
+++ b/src/std/srfi/41.ss
@@ -12,6 +12,7 @@ package: std/srfi
   define-stream
   list->stream port->stream
   stream
+  stream?
   stream->list
   stream-append stream-concat
   stream-constant
@@ -25,6 +26,7 @@ package: std/srfi
   stream-let
   stream-map
   stream-match
+  stream-of
   stream-range
   stream-ref
   stream-reverse


### PR DESCRIPTION
While playing around with srfi-41 I realized that `stream-of` was missing from its export list. And to make the interface of the stream type complete I also added the `stream?` predicate.