### PR TITLE
fix bug in kqueue-server socket constructor

### DIFF
--- a/src/std/net/socket/kqueue-server.ss
+++ b/src/std/net/socket/kqueue-server.ss
@@ -55,8 +55,9 @@ package: std/net/sockets
             (and (fd-io-out sock)
                  (make-!io-state)))
            (wait-out
-            (lambda (ssock timeo)
-              (io-state-wait-io! io-out timeo 'output)))
+            (and io-out
+                 (lambda (ssock timeo)
+                   (io-state-wait-io! io-out timeo 'output))))
            (close
             (lambda (ssock dir shutdown)
               (!!socket-server.close self ssock dir shutdown)))
@@ -120,7 +121,8 @@ package: std/net/sockets
                   (set! (!socket-state-io-out state) #f)
                   (close-io-out! io-out sock))
                 (close-port sock))
-               (else "Bad direction" dir)))
+               (else
+                (error "Bad direction" dir))))
             (else (void)))))))
 
   (def (shutdown!)


### PR DESCRIPTION
wait-out must be enabled only when the socket is open for output.

also, error in case of bad direction.