### PR TITLE
Add tests for socket server

### DIFF
--- a/src/std/net/socket/kqueue-server.ss
+++ b/src/std/net/socket/kqueue-server.ss
@@ -32,13 +32,12 @@ package: std/net/socket
                   (ready (kevent-flags evts k)))
               (with ((!socket-state _ io-in io-out)
                      (hash-ref fdtab fd))
-                (cond
-                 ((##fxpositive? (##fxand ready ev-in))
+                (unless (##fxzero? (##fxand ready ev-in))
                   (when io-in
                     (io-state-signal-ready! io-in 'ready)))
-                 ((##fxpositive? (##fxand ready ev-out))
+                (unless (##fxzero? (##fxand ready ev-out))
                   (when io-out
-                    (io-state-signal-ready! io-out 'ready))))
+                    (io-state-signal-ready! io-out 'ready)))
                 (lp (##fx+ k 1)))))))))
 
   (def (add-socket sock)
@@ -64,14 +63,12 @@ package: std/net/socket
            (ssock
             (make-!socket sock wait-in wait-out close))
            (state
-            (make-!socket-state sock io-in io-out))
-           (filter 0))
+            (make-!socket-state sock io-in io-out)))
       (when io-in
-        (set! filter (##fxior filter EVFILT_READ)))
+        (kqueue-kevent-add kq sock EVFILT_READ EV_CLEAR NOTE_LOWAT 1))
       (when io-out
-        (set! filter (##fxior filter EVFILT_WRITE)))
+        (kqueue-kevent-add kq sock EVFILT_WRITE EV_CLEAR NOTE_LOWAT 1))
       (make-will ssock (cut close <> 'inout #f))
-      (kqueue-kevent-add kq sock filter)
       (hash-put! fdtab fd state)
       ssock))
 
@@ -89,9 +86,9 @@ package: std/net/socket
              (case dir
                ((in)
                 (if io-out
-                  (kqueue-kevent-add kq sock EVFILT_WRITE)
+                  (kqueue-kevent-disable kq sock EVFILT_READ)
                   (begin
-                    (kqueue-kevent-del kq sock)
+                    (kqueue-kevent-del kq sock EVFILT_READ)
                     (hash-remove! fdtab (fd-e sock))))
                 (set! (!socket-wait-in ssock) #f)
                 (set! (!socket-state-io-in state) #f)
@@ -100,9 +97,9 @@ package: std/net/socket
                   (close-port sock)))
                ((out)
                 (if io-in
-                  (kqueue-kevent-add kq sock EVFILT_READ)
+                  (kqueue-kevent-disable kq sock EVFILT_WRITE)
                   (begin
-                    (kqueue-kevent-del kq sock)
+                    (kqueue-kevent-del kq sock EVFILT_WRITE)
                     (hash-remove! fdtab (fd-e sock))))
                 (set! (!socket-wait-out ssock) #f)
                 (set! (!socket-state-io-out state) #f)
@@ -110,7 +107,8 @@ package: std/net/socket
                 (unless io-in
                   (close-port sock)))
                ((inout)
-                (kqueue-kevent-del kq sock)
+                (kqueue-kevent-del kq sock EVFILT_READ)
+                (kqueue-kevent-del kq sock EVFILT_WRITE)
                 (hash-remove! fdtab (fd-e sock))
                 (when io-in
                   (set! (!socket-wait-in ssock) #f)

--- a/src/std/net/socket/server-test.ss
+++ b/src/std/net/socket/server-test.ss
@@ -22,8 +22,13 @@
       (try
        (let lp ()
          (def len (ssocket-recv sock buf))
-         (ssocket-send sock buf 0 len)
-         (lp))
+         (if (= len 0)
+           (begin
+             (ssocket-close sock)
+             (values))
+           (begin
+             (ssocket-send sock buf 0 len)
+             (lp))))
        (catch (io-error? exn)
          (values))))
 

--- a/src/std/net/socket/server-test.ss
+++ b/src/std/net/socket/server-test.ss
@@ -62,6 +62,10 @@
       (def sock (ssocket-connect server-address))
       (ssocket-send sock (string->bytes "Hello"))
       (check (receive-data sock) => "Hello")
+      (ssocket-send sock (string->bytes "Test"))
+      (check (receive-data sock) => "Test")
+      (ssocket-send sock (string->bytes "1.2.3.4.5"))
+      (check (receive-data sock) => "1.2.3.4.5")
       (ssocket-close sock))
 
     (test-case "test socket-server multiple connections"

--- a/src/std/net/socket/server-test.ss
+++ b/src/std/net/socket/server-test.ss
@@ -35,7 +35,7 @@
     (def (run-echo-server address)
       (def sock (ssocket-listen address))
       (let lp ()
-        (spawn/group 'echo-server echo (ssocket-accept sock))
+        (spawn echo (ssocket-accept sock))
         (lp)))
 
     (def (start-echo-server! address)

--- a/src/std/net/socket/server-test.ss
+++ b/src/std/net/socket/server-test.ss
@@ -1,0 +1,75 @@
+;;; -*- Gerbil -*-
+;;; (C) vyzo at hackzen.org
+;;; Socket server tests
+
+(import :gerbil/gambit/threads
+        :std/misc/threads
+        :std/net/socket
+        :std/net/socket/base
+        :std/os/socket
+        :std/error
+        :std/sugar
+        :std/test)
+(export socket-server-test)
+
+(def socket-server-test
+  (test-suite "test :std/net/socket"
+
+    (def server-address "localhost:4242")
+
+    (def (echo sock)
+      (def buf (make-u8vector 256))
+      (try
+       (let lp ()
+         (def len (ssocket-recv sock buf))
+         (ssocket-send sock buf 0 len)
+         (lp))
+       (catch (io-error? exn)
+         (values))))
+
+    (def (run-echo-server address)
+      (def sock (ssocket-listen address))
+      (let lp ()
+        (spawn/group 'echo-server echo (ssocket-accept sock))
+        (lp)))
+
+    (def (start-echo-server! address)
+      (parameterize ((current-socket-server #f))
+        (start-socket-server!)
+        (let (echo-server (spawn/group 'echo-server run-echo-server address))
+          (values (current-socket-server) echo-server))))
+
+    (def (stop-echo-server! server)
+      (let (tgroup (thread-thread-group server))
+        (thread-group-kill! tgroup)))
+
+    (def (receive-data sock)
+      (def buf (make-u8vector 512))
+      (def len (ssocket-recv sock buf))
+      (bytes->string (subu8vector buf 0 len)))
+
+    (define-values (socket-server echo-server)
+      (start-echo-server! server-address))
+
+    (thread-sleep! 0.2)
+
+    (test-case "test socket-server"
+      (def sock (ssocket-connect server-address))
+      (ssocket-send sock (string->bytes "Hello"))
+      (check (receive-data sock) => "Hello")
+      (ssocket-close sock))
+
+    (test-case "test socket-server multiple connections"
+      (def conn-1 (ssocket-connect server-address))
+      (def conn-2 (ssocket-connect server-address))
+      (ssocket-send conn-2 (string->bytes "BBB"))
+      (ssocket-send conn-1 (string->bytes "AAA"))
+      (check (receive-data conn-1) => "AAA")
+      (check (receive-data conn-2) => "BBB")
+      (ssocket-close conn-1)
+      (ssocket-close conn-2))
+
+    (thread-sleep! 0.2)
+
+    (stop-echo-server! echo-server)
+    (stop-socket-server! socket-server)))

--- a/src/std/net/socket/server-test.ss
+++ b/src/std/net/socket/server-test.ss
@@ -50,7 +50,7 @@
 
     (def (receive-data sock)
       (def buf (make-u8vector 512))
-      (def len (ssocket-recv sock buf))
+      (def len (ssocket-recv sock buf 0 (u8vector-length buf) 5))
       (bytes->string (subu8vector buf 0 len)))
 
     (define-values (socket-server echo-server)

--- a/src/std/os/kqueue.ss
+++ b/src/std/os/kqueue.ss
@@ -50,15 +50,16 @@ package: std/os
 
 (def (kqueue-kevent-add kqueue dev filter)
   (let (kevt (get-kevent-ptr))
-    (kevent_ident_set kevt 0 (fd-e dev))
+    (kevent_ident_set kevt 0 (if (fd? dev) (fd-e dev) dev))
     (kevent_flags_set kevt 0 EV_ADD)
     (kevent_filter_set kevt 0 filter)
     (kevent kqueue kevt 1 #f 0 #f)))
 
-(def (kqueue-kevent-del kqueue dev)
+(def (kqueue-kevent-del kqueue dev filter)
   (let (kevt (get-kevent-ptr))
     (kevent_ident_set kevt 0 (fd-e dev))
     (kevent_flags_set kevt 0 EV_DELETE)
+    (kevent_filter_set kevt 0 filter)
     (kevent kqueue kevt 1 #f 0 #f)))
 
 (def kevent-ptr-key

--- a/src/std/run-tests.ss
+++ b/src/std/run-tests.ss
@@ -30,6 +30,10 @@
   (config-have-leveldb
    (import "db/leveldb-test")))
 
+(cond-expand
+  ((or linux bsd)
+   (import "net/socket/server-test")))
+
 (def tests
   [generic-runtime-test generic-macro-test
    iter-test
@@ -48,6 +52,11 @@
    (if config-enable-sqlite [sqlite-test] []) ...
    (if config-enable-lmdb [lmdb-test] []) ...
    (if config-enable-leveldb [leveldb-test] []) ...
+   (cond-expand
+     ((or linux bsd)
+      [socket-server-test])
+     (else []))
+   ...
    ])
 
 (apply run-tests! tests)


### PR DESCRIPTION
Closes #89.

Created a simple echo server for testing epoll or kqueue-based socket
servers, provide that the test script is run on linux or BSD,
respectively. Happy to add additional tests before merging if there
are any suggestions.

I wasn't quite sure of the best way to make use of cond-expand to take
care of the system-dependent aspects of these tests, so definitely
open to advice here, as well.

Tested on linux and OpenBSD.