### PR TITLE
Nonblock poll

### DIFF
--- a/src/std/net/socket/epoll-server.ss
+++ b/src/std/net/socket/epoll-server.ss
@@ -25,7 +25,7 @@ package: std/net/socket
 
   (def (do-epoll)
     (let (count (epoll-wait epoll evts maxevts))
-      (when (##fxpositive? count)
+      (when (and count (##fxpositive? count))
         (let lp ((k 0))
           (when (##fx< k count)
             (let ((fd (epoll-event-fd evts k))

--- a/src/std/net/socket/kqueue-server.ss
+++ b/src/std/net/socket/kqueue-server.ss
@@ -25,7 +25,7 @@ package: std/net/sockets
 
   (def (do-kevent)
     (let (count (kqueue-wait kq evts maxevts))
-      (when (##fxpositive? count)
+      (when (and count (##fxpositive? count))
         (let lp ((k 0))
           (when (##fx< k count)
             (let ((fd (kevent-ident evts k))

--- a/src/std/os/epoll.ss
+++ b/src/std/os/epoll.ss
@@ -7,15 +7,18 @@ package: std/os
 (import :gerbil/gambit/threads
         (only-in :gerbil/gambit/ports close-port)
         :std/os/error
-        :std/os/fd)
+        :std/os/fd
+        :std/os/fcntl)
 (export epoll-create epoll-ctl-add epoll-ctl-mod epoll-ctl-del epoll-wait
         make-epoll-events epoll-event-fd epoll-event-events
         EPOLLIN EPOLLOUT EPOLLERR EPOLLHUP EPOLLET EPOLLONESHOT)
 
 (def (epoll-create)
-  (let (fd (check-os-error (_epoll_create 1024)
-             (epoll-create)))
-    (fdopen fd 'in 'epoll)))
+  (let* ((fd (check-os-error (_epoll_create 1024)
+               (epoll-create)))
+         (raw (fdopen fd 'in 'epoll)))
+    (fd-set-nonblock/closeonexec raw)
+    raw))
 
 (def (epoll-ctl-add epoll dev events)
   (epoll-ctl epoll EPOLL_CTL_ADD dev events))

--- a/src/std/os/fcntl.ss
+++ b/src/std/os/fcntl.ss
@@ -62,7 +62,8 @@ package: std/os
   (fd-setfd raw FD_CLOEXEC))
 
 (def (fd-set-nonblock/closeonexec raw)
-  (fd-setfd raw (##fxior O_NONBLOCK FD_CLOEXEC)))
+  (fd-setfl raw O_NONBLOCK)
+  (fd-setfd raw FD_CLOEXEC))
 
 ;;; FFI impl
 (begin-foreign

--- a/src/std/os/fcntl.ss
+++ b/src/std/os/fcntl.ss
@@ -61,6 +61,9 @@ package: std/os
 (def (fd-set-closeonexec raw)
   (fd-setfd raw FD_CLOEXEC))
 
+(def (fd-set-nonblock/closeonexec raw)
+  (fd-setfd raw (##fxior O_NONBLOCK FD_CLOEXEC)))
+
 ;;; FFI impl
 (begin-foreign
   (c-declare "#include <errno.h>")

--- a/src/std/os/fdio.ss
+++ b/src/std/os/fdio.ss
@@ -30,8 +30,7 @@ package: std/os
      (let* ((fd (check-os-error (_open path flags mode)
                   (open path flags mode)))
             (raw (fdopen fd (file-direction flags) 'file)))
-       (fd-set-nonblock raw)
-       (fd-set-closeonexec raw)
+       (fd-set-nonblock/closeonexec raw)
        raw))))
 
 (def (file-direction flags)

--- a/src/std/os/kqueue.ss
+++ b/src/std/os/kqueue.ss
@@ -7,7 +7,8 @@ package: std/os
 (import :gerbil/gambit/threads
         (only-in :gerbil/gambit/ports close-port)
         :std/os/error
-        :std/os/fd)
+        :std/os/fd
+        :std/os/fcntl)
 (export kqueue kqueue-close
         make-kevents kqueue-wait
         kqueue-kevent-add kqueue-kevent-del
@@ -28,8 +29,10 @@ package: std/os
    (export EVILT_DEVICE NOTE_TRUNCATE NOTE_EOF NOTE_CHANGE)))
 
 (def (kqueue)
-  (let (fd (check-os-error (_kqueue) (kqueue)))
-    (fdopen fd 'in 'kqueue)))
+  (let* ((fd (check-os-error (_kqueue) (kqueue)))
+         (raw (fdopen fd 'in 'kqueue)))
+    (fd-set-nonblock/closeonexec raw)
+    raw))
 
 (def (kqueue-close kq)
   (close-port kq))
@@ -144,7 +147,7 @@ package: std/os
               EVFILT_READ EVFILT_WRITE EVFILT_VNODE EVFILT_PROC
               EVFILT_SIGNAL EVFILT_TIMER EVFILT_DEVICE
               NOTE_DELETE NOTE_WRITE NOTE_EXTEND NOTE_TRUNCATE NOTE_LOWAT
-              NOTE_EOF 
+              NOTE_EOF
               NOTE_ATTRIB NOTE_LINK NOTE_RENAME NOTE_REVOKE NOTE_EXIT
               NOTE_FORK NOTE_EXEC NOTE_TRACK NOTE_TRACKERR NOTE_CHANGE
               kevent kevent* timespec timespec*

--- a/src/std/os/pipe.ss
+++ b/src/std/os/pipe.ss
@@ -20,10 +20,8 @@ package: std/os
          (ofd (pipe_ptr_ref ptr 1))
          (in (fdopen ifd 'in 'pipe))
          (out (fdopen ofd 'out 'pipe)))
-    (fd-set-nonblock in)
-    (fd-set-closeonexec in)
-    (fd-set-nonblock out)
-    (fd-set-closeonexec out)
+    (fd-set-nonblock/closeonexec in)
+    (fd-set-nonblock/closeonexec out)
     (values in out)))
 
 (begin-foreign

--- a/src/std/os/socket.ss
+++ b/src/std/os/socket.ss
@@ -151,8 +151,7 @@ package: std/os
   (let* ((fd (check-os-error (_socket domain type proto)
                (socket domain type proto)))
          (raw (fdopen fd dir 'socket)))
-    (fd-set-nonblock raw)
-    (fd-set-closeonexec raw)
+    (fd-set-nonblock/closeonexec raw)
     raw))
 
 (def (socket domain type (proto 0))


### PR DESCRIPTION
The file descriptors created by epoll and kqueue are set to nonblocking (and closeonexec).

Also extends fcntl to have a combined operation for the two flags, and uses it accordintly.