### PR TITLE
nonblock is useless for epoll and kqueue

### DIFF
--- a/src/std/net/socket/epoll-server.ss
+++ b/src/std/net/socket/epoll-server.ss
@@ -25,7 +25,7 @@ package: std/net/socket
 
   (def (do-epoll)
     (let (count (epoll-wait epoll evts maxevts))
-      (when (and count (##fxpositive? count))
+      (when (##fxpositive? count)
         (let lp ((k 0))
           (when (##fx< k count)
             (let ((fd (epoll-event-fd evts k))

--- a/src/std/net/socket/kqueue-server.ss
+++ b/src/std/net/socket/kqueue-server.ss
@@ -25,7 +25,7 @@ package: std/net/sockets
 
   (def (do-kevent)
     (let (count (kqueue-wait kq evts maxevts))
-      (when (and count (##fxpositive? count))
+      (when (##fxpositive? count)
         (let lp ((k 0))
           (when (##fx< k count)
             (let ((fd (kevent-ident evts k))

--- a/src/std/os/epoll.ss
+++ b/src/std/os/epoll.ss
@@ -17,7 +17,7 @@ package: std/os
   (let* ((fd (check-os-error (_epoll_create 1024)
                (epoll-create)))
          (raw (fdopen fd 'in 'epoll)))
-    (fd-set-nonblock/closeonexec raw)
+    (fd-set-closeonexec raw)
     raw))
 
 (def (epoll-ctl-add epoll dev events)

--- a/src/std/os/kqueue.ss
+++ b/src/std/os/kqueue.ss
@@ -31,7 +31,7 @@ package: std/os
 (def (kqueue)
   (let* ((fd (check-os-error (_kqueue) (kqueue)))
          (raw (fdopen fd 'in 'kqueue)))
-    (fd-set-nonblock/closeonexec raw)
+    (fd-set-closeonexec raw)
     raw))
 
 (def (kqueue-close kq)


### PR DESCRIPTION
Reverts the nonblock for kqueue and epoll fds, as it's useless.