### PR TITLE
admit empty headers in http responses

### DIFF
--- a/src/std/net/request.ss
+++ b/src/std/net/request.ss
@@ -230,7 +230,7 @@ package: std/net
   (pregexp "([0-9]{3})\\s+(.*)"))
 
 (def header-line-rx
-  (pregexp "([^:]+):\\s+(.*)"))
+  (pregexp "([^:]+):\\s*(.*)?"))
 
 (def (http-request-read-response! req)
   (let* ((port (request-port req))


### PR DESCRIPTION
http-get bombs when it sees an empty header; for example:
```
> (http-get "https://raw.githubusercontent.com/vyzo/gerbil-simsub/master/gerbil.pkg")
*** ERROR IN std/net/request#http-request -- http-request-read-response!: [io-error] Malformed header
--- irritants: #<input-output-port #10 (tcp-client "raw.githubusercontent.com" 443)> X-Geo-Block-List: 
```

This fixes the header rx to accept empty headers, which appear as empty strings.