### PR TITLE
kqueue-server update

### DIFF
--- a/src/std/os/_socket.scm
+++ b/src/std/os/_socket.scm
@@ -786,7 +786,7 @@ int ffi_socket_setsockopt_mreq (int fd, int level, int opt, ___SCMOBJ maddr, ___
 
 int ffi_socket_setsockopt_mreq_src (int fd, int level, int opt, ___SCMOBJ maddr, ___SCMOBJ iaddr, ___SCMOBJ saddr)
 {
-#ifndef __OpenBSD__
+#if !defined(__OpenBSD__) && !defined(__NetBSD__)
  struct ip_mreq_source mreq;
  socklen_t olen = sizeof (struct ip_mreq_source);
  memcpy (&mreq.imr_multiaddr, U8_DATA (maddr), sizeof (struct in_addr));

--- a/src/std/os/kqueue.ss
+++ b/src/std/os/kqueue.ss
@@ -408,10 +408,17 @@ package: std/os
   (define-c-lambda kevent_data_set (kevent* int int64) void
     "___arg1[___arg2].data = ___arg3; ___return;")
 
-  (define-c-lambda kevent_udata (kevent* int) (pointer void)
-    "___return (___arg1[___arg2].udata);")
-  (define-c-lambda kevent_udata_set (kevent* int (pointer void)) void
-    "___arg1[___arg2].udata = ___arg3; ___return;")
+  (cond-expand
+    (netbsd
+     (define-c-lambda kevent_udata (kevent* int) int
+       "___return (___arg1[___arg2].udata);")
+     (define-c-lambda kevent_udata_set (kevent* int int) void
+       "___arg1[___arg2].udata = ___arg3; ___return;"))
+    (else
+     (define-c-lambda kevent_udata (kevent* int) int
+       "___return ((long)(___arg1[___arg2].udata));")
+     (define-c-lambda kevent_udata_set (kevent* int int) void
+       "___arg1[___arg2].udata = (void *)((long)___arg3); ___return;")))
 
   (define-c-lambda ev_set
     (kevent* int unsigned-int short unsigned-short unsigned-int int64 (pointer void)) void


### PR DESCRIPTION
This update of kqueue-server works on OpenBSD, NetBSD and FreeBSD. I was not able to test it on OS X due to issues with OpenSSL. (I set the corresponding enviroment variables as suggested in the README.) Up to now I did not observe hangs or excessive event generation.

I put this pull request for discussion. Besides your suggestions for improvement some points which I would like to clarify are:

  1. Is it ok to error out if `EV_ERROR` is encountered in the event loop? In kqueue `EV_ERROR` means that something fundamental has gone wrong which would lead to an inconsistent state.
  2. I am using the same events array for the addition of events and for their retrieval assuming that `add-socket` will not be called during `do-kevent`. Is this assumption correct?
  3. I removed some code which is redundant as the kernel will take care of the cleanup of events. Please notify me if I missed something here.

A proposal for further development is the use of `EV_EOF` to close a socket direction immediately if the other side has shut down. But this would require even more restructuring of the code.