### PR TITLE
Release v0.13 Notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,72 @@
+### 9-6-2018: Gerbil-v0.13
+
+The focus on performance, fixes, and documentation.
+
+- New documentation website: https://cons.io
+- prelude
+  - core:
+    - optimize case macro to do index-based binary search dispatch
+    - defconst macro
+  - gerbil/gambit/threads: thread-local variables
+- runtime
+  - the destroy method binding for ports was moved to :std/misc/ports
+- compiler
+  - full program optimization for static executables
+  - deterministic names for lifted opt-lambdas
+  - no longer needs GERBIL_CACHE to compile executables
+  - inline cons*, specialize 2 argument foldings (foldl, foldr, andmap, ormap, filter-map)
+  - inline values-count, values-ref, values->list
+  - compile time check values count where possible
+  - optimize keyword lambda dispatch
+  - sanitize core file names [#33]
+  - fix recursion bug in optimizer introduced symbol resolution
+  - fix handling of optimizer introduced symbols; if it's a naked symbol, it was introduced
+  - optimize match expansion; match tree fusion and common structural check elimination
+  - optimize syntax-case expansion
+  - optimize code for phi>0
+  - don't compile debug symbols in phi in env/src debug levels; use env/phi and src/phi instead
+  - arity checking for all direct calls to procedures of known arity
+- expander
+  - tuning and performance optimizations: 2x gxi startup time improvement
+  - #lang reader has a default read-module-body for sexp syntax
+- stdlib
+  - std/actor: send never queues messages for dead or uninitialized threads
+  - std/iter: speculatively inline list iteration in for macros
+  - std/make:
+    - static-include: build directive
+    - pkg-config helpers
+  - std/misc
+    - [new] std/misc/lru: LRU caches
+    - [new] std/misc/lazy: R7RS/SRFI-45 iterative lazy algorithm primives
+    - [new] std/misc/text: include-text macro
+  - std/net
+    - std/net/httpd:
+      - http-response-file for serving files
+      - http-response-chunk accepts range arguments
+    - std/net/websocket: hard close websockets
+    - std/net/socket: support kqueue server in BSDs
+  - std/text/utf8: string-utf8-length accepts substring range
+  - std/os
+    - std/os/fdio: add open system call
+    - std/os/socket: system undefined constants have a value of #f
+    - std/os/fcntl: more linux specific constants
+    - [new] std/os/kqueue: kqueue support for BSDs
+  - std/srfi/1: tune for dispatch perfomance
+- r7rs compliance
+  - read-string, write-string
+  - member, assoc, map, for-each
+  - case else =>
+  - guard
+  - string/vector->list string/vector-fill!
+  - fix eval in executables; implicitly load expander as needed
+  - implement input-port-open? and output-port-open?
+  - r7rs cond-expand, understands library features
+  - fix make-promise
+  - implement delay-force using :std/misc/lazy
+- tools
+  - gxprof samples at 1kHz
+
+
 ### 2-27-2018: Gerbil-v0.12
 
 The 1500 commit monster has landed!

--- a/README.md
+++ b/README.md
@@ -21,59 +21,11 @@ ahead of time compilation and compiled macros.
 <!-- tocstop -->
 
 # Installation
-## Source Code
 The source code for Gerbil is hosted on [Github](https://github.com/vyzo/gerbil),
 with the latest release available in [releases](https://github.com/vyzo/gerbil/releases).
 
-For the latest Gerbil, you can clone the repository:
-```
-$ git clone https://github.com/vyzo/gerbil.git
-```
-
-## Dependencies
-
-The latest Gerbil release (v0.12) requires Gambit v4.8.9.
-
-The core system has no dependencies outside Gambit, but the standard
-library has several mostly optional dependencies. The only hard dependency
-is `libcrypto` from OpenSSL; important parts of the standard library
-require it.
-
-All the other dependencies are soft.
-Most library modules with foreign dependencies are not built by default,
-with the exception of `zlib` and `sqlite`. These are ubiquitous, stable
-and generally useful enough to warrant being present by default;
-you can still disable them if you want for a minimal installation.
-
-In ubuntu, you can install the dependencies for a default installation with:
-```
-$ sudo apt-get install openssl libssl-dev sqlite3 libsqlite3-dev
-```
-
-The optional libraries can be enabled or disabled at build-time
-by editing `$GERBIL_HOME/src/std/build-features.ss`.
-You can also enable features later, by editing `build-features.ss` and
-running `./build.sh stdlib` in `$GERBIL_HOME/src/`.
-
-
-## Build Instructions
-After unpacking a release or checking out the source code from Github, let
-`$GERBIL_HOME` be the top directory of Gerbil.
-
-Then:
-```
-$ cd $GERBIL_HOME/src
-$ ./build.sh
-```
-
-If you are building in MacOSX and want to use the homebrew OpenSSL,
-then you need to specify appropriate `CPPFLAGS` and `LDFLAGS`.
-For instance:
-```
-$ LDFLAGS=-L/usr/local/opt/openssl/lib \
-  CPPFLAGS=-I/usr/local/opt/openssl/include \
-  ./build.sh
-```
+For installation instructions see the [Guide](doc/guide/README.md), rendered
+online [here](https://cons.io/guide/).
 
 # Using Gerbil
 The Gerbil interpreter is `$GERBIL_HOME/bin/gxi`, and the compiler is

--- a/doc/guide/README.md
+++ b/doc/guide/README.md
@@ -11,7 +11,7 @@ $ git clone https://github.com/vyzo/gerbil.git
 
 ## Dependencies
 
-The latest Gerbil release (v0.12) requires Gambit v4.8.9.
+The latest Gerbil release (v0.13) requires Gambit v4.9.0.
 
 The core system has no dependencies outside Gambit, but the standard
 library has several mostly optional dependencies. The only hard dependency


### PR DESCRIPTION
- Update the README to not duplicate documentation from the guide, where the installation instructions now live.
- Stated dependency on Gambit v4.9.0, mostly due to https://github.com/gambit/gambit/issues/352
- CHANGELOG for v0.13