### PR TITLE
refine eof behaviour of bio-read-line

### DIFF
--- a/src/std/net/bio/input.ss
+++ b/src/std/net/bio/input.ss
@@ -306,7 +306,9 @@ package: std/net/bio
       (let (char (bio-read-char buf))
         (cond
          ((eof-object? char)
-          (list->string (reverse! chars)))
+          (if (null? chars)
+            (eof-object)
+            (list->string (reverse! chars))))
          ((eq? char sep)
           (list->string (reverse! (if include-sep? (cons sep chars) chars))))
          (else


### PR DESCRIPTION
refines eof behaviour of bio-read-line to; when there are no characters accumulated and eof has been encountered, then it should return eof instead of the empty line.