### PR TITLE
postgresql-driver: Change "db" to "database" in StartupMessage

### DIFF
--- a/src/std/db/postgresql-driver.ss
+++ b/src/std/db/postgresql-driver.ss
@@ -177,7 +177,7 @@ package: std/db
   (start-logger!)
   (DEBUG "STARTUP")
   (try
-   (send! ['StartupMessage ["user" . user] (if db [["db" . db]] []) ...])
+   (send! ['StartupMessage ["user" . user] (if db [["database" . db]] []) ...])
    (recv!
     (['AuthenticationRequest what . rest]
      (DEBUG "AUTHENTICATION REQUEST " what)


### PR DESCRIPTION
  fixes [io-error] unrecognized configuration parameter "db"
  --- irritants: (S .FATAL) (V . FATAL) (C . 42704)
  (M . unrecognized configuration parameter "db") (F . guc.c)
  (L . 5968) (R . set_config_option)