### PR TITLE
Input Subbuffers

### DIFF
--- a/doc/reference/net.md
+++ b/doc/reference/net.md
@@ -584,6 +584,24 @@ Please document me!
 
 Please document me!
 
+### open-delimited-input-buffer
+::: tip usage
+```
+(open-delimited-input-buffer ...)
+```
+:::
+
+Please document me!
+
+### delimited-input-buffer?
+::: tip usage
+```
+(delimited-input-buffer? ...)
+```
+:::
+
+Please document me!
+
 ### open-fixed-output-buffer
 ::: tip usage
 ```

--- a/src/std/net/bio.ss
+++ b/src/std/net/bio.ss
@@ -45,6 +45,8 @@ package: std/net
   bio-force-output
   ;; buffers
   open-input-buffer
+  open-delimited-input-buffer
+  delimited-input-buffer?
   open-fixed-output-buffer
   make-fixed-output-buffer
   open-chunked-output-buffer

--- a/src/std/net/bio/buffer.ss
+++ b/src/std/net/bio/buffer.ss
@@ -32,7 +32,7 @@ package: std/net/bio
          (have (fx- rhi rlo)))
     (if (fx> have limit)
       (begin
-        (set! rhi (fx+ rlo have))
+        (set! rhi (fx+ rlo limit))
         (set! limit 0))
       (begin
         (set! limit (fx- limit have))))

--- a/src/std/net/bio/buffer.ss
+++ b/src/std/net/bio/buffer.ss
@@ -73,7 +73,7 @@ package: std/net/bio
            (else
             (set! (&input-buffer-rlo buf)
               (&input-buffer-rlo xbuf))
-            (set! (&input-buffer-rlo buf)
+            (set! (&input-buffer-rhi buf)
               (fx+ (&input-buffer-rlo buf) have limit))
             (set! (&delimited-input-buffer-limit buf)
               0)

--- a/src/std/protobuf/io.ss
+++ b/src/std/protobuf/io.ss
@@ -88,9 +88,8 @@ package: std/protobuf
 
 ;; packed encoding
 (def (bio-read-packed bio-read-e buf)
-  ;; TODO: use subbuffers when they get implemented
-  (let* ((bytes (bio-read-delimited-bytes buf))
-         (buf (open-input-buffer bytes)))
+  (let* ((len (bio-read-varint buf))
+         (buf (open-delimited-input-buffer buf len)))
     (let lp ((r []))
       (if (eof-object? (bio-peek-u8 buf))
         (reverse r)
@@ -105,9 +104,8 @@ package: std/protobuf
 
 ;; map encoding
 (def (bio-read-key-value-pair bio-read-key-e bio-read-value-e buf)
-  ;; TODO: use subbuffers when they get implemented
-  (let* ((bytes (bio-read-delimited-bytes buf))
-         (buf (open-input-buffer bytes)))
+  (let* ((len (bio-read-varint buf))
+         (buf (open-delimited-input-buffer buf len)))
     (let lp ((key #f) (value #f))
       (if (eof-object? (bio-peek-u8 buf))
         (cons key value)
@@ -135,11 +133,8 @@ package: std/protobuf
 
 ;; length delimited objects
 (def (bio-read-delimited bio-read-e buf)
-  ;; TODO: use subbuffers when they get implemented
   (let* ((len (bio-read-varint buf))
-         (bytes (make-u8vector len))
-         (_ (bio-read-bytes bytes buf))
-         (buf (open-input-buffer bytes)))
+         (buf (open-delimited-input-buffer buf len)))
     (bio-read-e buf)))
 
 (def (bio-write-delimited x bio-write-e buf)


### PR DESCRIPTION
Add support for delimited input buffers, which allow us to read delimited values from a buffer without copying.