### PR TITLE
std/net/repl: write-u8vector for control codes

### DIFF
--- a/src/std/net/repl.ss
+++ b/src/std/net/repl.ss
@@ -119,7 +119,7 @@ package: std/net
           ((#\xfd)                      ; DO
            (when (char=? c #\x06)       ; timing mark
              (let (client (repl-state-client state))
-               (write-string "\xff\xfb\x06" client)
+               (write-u8vector '#u8(#xff #xfb #x06) client)
                (force-output client)))
            (loop 'input))
           ((#\xff)                      ; IAC


### PR DESCRIPTION
gambit v4.9.1 considers the escape sequences invalid; unicode it is...