### PR TITLE
add missing dot in delete-duplicates! signature

### DIFF
--- a/src/std/srfi/srfi-1.scm
+++ b/src/std/srfi/srfi-1.scm
@@ -1225,7 +1225,7 @@
 
 ;;; right-duplicate deletion
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; delete-duplicates delete-duplicates!
+;;; duplicates delete-duplicates!
 ;;;
 ;;; Beware -- these are N^2 algorithms. To efficiently remove duplicates
 ;;; in long lists, sort the list to bring duplicates together, then use a
@@ -1242,7 +1242,7 @@
 		 (new-tail (recur (delete x tail elt=))))
 	    (if (eq? tail new-tail) lis (cons x new-tail)))))))
 
-(define (delete-duplicates! lis maybe-=)
+(define (delete-duplicates! lis . maybe-=)
   (let ((elt= (:optional maybe-= equal?)))
     (check-arg procedure? elt= delete-duplicates!)
     (let recur ((lis lis))


### PR DESCRIPTION
It's a bug/typo in the original reference implementation.