### PR TITLE
std/srfi: clean up redefinitions of receive

### DIFF
--- a/src/std/srfi/133.ss
+++ b/src/std/srfi/133.ss
@@ -3,6 +3,7 @@
 ;;; SRFI-133: R7RS-compatible vector library
 package: std/srfi
 
+(import :std/srfi/8)
 ;; Constructors
 (export vector-unfold vector-unfold-right vector-copy vector-reverse-copy
         vector-append vector-concatenate vector-append-subvectors)

--- a/src/std/srfi/134.ss
+++ b/src/std/srfi/134.ss
@@ -4,6 +4,7 @@
 package: std/srfi
 
 (import :std/srfi/1
+        :std/srfi/8
         :std/srfi/9
         :std/srfi/121)
 (export ideque ideque-tabulate ideque-unfold ideque-unfold-right

--- a/src/std/srfi/43.ss
+++ b/src/std/srfi/43.ss
@@ -3,6 +3,7 @@
 ;;; SRFI-43: vector library
 package: std/srfi
 
+(import :std/srfi/8)
 (export
   ;; * Constructors
   make-vector vector

--- a/src/std/srfi/srfi-133.scm
+++ b/src/std/srfi/srfi-133.scm
@@ -81,7 +81,7 @@
 ;;; Utilities
 
 ;;; SRFI 8, too trivial to put in the dependencies list.
-(define-syntax receive
+#;(define-syntax receive
   (syntax-rules ()
     ((receive ?formals ?producer ?body1 ?body2 ...)
      (call-with-values (lambda () ?producer)
@@ -1368,4 +1368,3 @@
         (begin
           (vector-set! result at (string-ref str i))
           (loop (+ at 1) (+ i 1)))))))
-

--- a/src/std/srfi/srfi-134.scm
+++ b/src/std/srfi/srfi-134.scm
@@ -39,7 +39,7 @@
 ;; Requires srfi-1, srfi-9, srfi-121.
 
 ;; some compatibility stuff
-(define-syntax receive
+#;(define-syntax receive
   (syntax-rules ()
     ((_ binds mv-expr body ...)
      (let-values ((binds mv-expr)) body ...))))

--- a/src/std/srfi/srfi-43.scm
+++ b/src/std/srfi/srfi-43.scm
@@ -83,7 +83,7 @@
 ;;; Utilities
 
 ;;; SRFI 8, too trivial to put in the dependencies list.
-(define-syntax receive
+#;(define-syntax receive
   (syntax-rules ()
     ((receive ?formals ?producer ?body1 ?body2 ...)
      (call-with-values (lambda () ?producer)


### PR DESCRIPTION
A few srfis contained private definitions; pruned and imported srfi/8 instead.