### PR TITLE
use parent copy of gerbil checkout.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,19 @@ from ubuntu:latest
 MAINTAINER gerbil@cons.io
 
 RUN apt update -y
-RUN apt install -y libsqlite3-dev build-essential git autoconf libsnappy1v5 libleveldb1v5 zlib1g-dev libssl-dev pkg-config  libyaml-dev libmysqlclient-dev liblmdb-dev libleveldb-dev rsync
+RUN apt install -y libsqlite3-dev build-essential git autoconf libsnappy1v5 libleveldb1v5 zlib1g-dev libssl-dev pkg-config  libyaml-dev libmysqlclient-dev liblmdb-dev libleveldb-dev rsync texinfo
 
 RUN git config --global url.https://github.com/.insteadOf git://github.com/
 RUN cd /root && git clone https://github.com/gambit/gambit
-RUN cd /root && git clone https://github.com/vyzo/gerbil
 
 RUN cd /root/gambit && ./configure --prefix=/usr/local/gambit --enable-single-host --enable-openssl --enable-default-runtime-options=f8,-8,t8 --enable-poll
 RUN cd /root/gambit && make -j4
 RUN cd /root/gambit && make install
 
+COPY . /root/gerbil
+
 ENV PATH "/usr/local/gambit/bin:$PATH"
+
 RUN sed -i -e 's/mysql #f/mysql #t/g' /root/gerbil/src/std/build-features.ss
 RUN sed -i -e 's/yaml #f/yaml #t/g' /root/gerbil/src/std/build-features.ss
 RUN sed -i -e 's/leveldb #f/leveldb #t/g' /root/gerbil/src/std/build-features.ss


### PR DESCRIPTION
Use copy to push the checkout context to the container. 
Add makeinfo for doc building.