### PR TITLE
Double Ended Queues

### DIFF
--- a/doc/reference/misc.md
+++ b/doc/reference/misc.md
@@ -157,6 +157,120 @@ Please document me!
 Please document me!
 
 
+## Deques
+::: tip usage
+(import :std/misc/deque)
+:::
+
+### deque
+::: tip usage
+```
+(deque ...)
+```
+:::
+
+Please document me!
+
+### make-deque
+::: tip usage
+```
+(make-deque ...)
+```
+:::
+
+Please document me!
+
+### deque?
+::: tip usage
+```
+(deque? ...)
+```
+:::
+
+Please document me!
+
+### deque-length
+::: tip usage
+```
+(deque-length ...)
+```
+:::
+
+Please document me!
+
+### deque-empty?
+::: tip usage
+```
+(deque-empty? ...)
+```
+:::
+
+Please document me!
+
+### push-front!
+::: tip usage
+```
+(push-front! ...)
+```
+:::
+
+Please document me!
+
+### pop-front!
+::: tip usage
+```
+(pop-front! ...)
+```
+:::
+
+Please document me!
+
+### peek-front
+::: tip usage
+```
+(peek-front ...)
+```
+:::
+
+Please document me!
+
+### push-back!
+::: tip usage
+```
+(push-back! ...)
+```
+:::
+
+Please document me!
+
+### pop-back!
+::: tip usage
+```
+(pop-back! ...)
+```
+:::
+
+Please document me!
+
+### peek-back
+::: tip usage
+```
+(peek-back ...)
+```
+:::
+
+Please document me!
+
+### deque-&gt;list
+::: tip usage
+```
+(deque->list ...)
+```
+:::
+
+Please document me!
+
+
 
 ## List utilities
 ::: tip usage
@@ -555,11 +669,17 @@ be used in `with-destroy` forms and other primitives that use the destroy
 idiom.
 
 
-
 ## Priority Queues
 ::: tip usage
 (import :std/misc/pqueue)
 :::
+
+### pqueue
+```
+(defsyntax pqueue ...)
+```
+
+Priority queue type, for user-defined generics.
 
 ### make-pqueue
 ::: tip usage
@@ -658,10 +778,17 @@ Please document me!
 Please document me!
 
 
-## Deques
+## Simple Queues
 ::: tip usage
 (import :std/misc/queue)
 :::
+
+### queue
+```
+(defsyntax queue ...)
+```
+
+Queue type, for user-defined generics.
 
 ### make-queue
 ::: tip usage
@@ -743,7 +870,6 @@ Please document me!
 :::
 
 Please document me!
-
 
 
 ## Sourceable Representation

--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -190,6 +190,7 @@
     "misc/repr"
     "misc/queue"
     "misc/pqueue"
+    "misc/deque"
     "misc/lru"
     "misc/string"
     "misc/sync"

--- a/src/std/misc/deque.ss
+++ b/src/std/misc/deque.ss
@@ -65,9 +65,10 @@ package: std/misc
       (set! (&deque-length dq)
         (1+ len)))))
 
-(def (pop-front! dq)
+(def (pop-front! dq (default absent-obj))
   (with ((deque front back len) dq)
-    (if front
+    (cond
+     (front
       (let (next (&node-next front))
         (set! (&deque-front dq) next)
         (if next
@@ -75,12 +76,15 @@ package: std/misc
           (set! (&deque-back dq) #f))
         (set! (&deque-length dq)
           (1- len))
-        (&node-e front))
-      (error "Cannot pop; empty deque" dq))))
+        (&node-e front)))
+     ((eq? default absent-obj)
+      (error "Cannot pop; empty deque" dq))
+     (else default))))
 
-(def (pop-back! dq)
+(def (pop-back! dq (default absent-obj))
   (with ((deque front back len) dq)
-    (if back
+    (cond
+     (back
       (let (prev (&node-prev back))
         (set! (&deque-back dq) prev)
         (if prev
@@ -88,20 +92,28 @@ package: std/misc
           (set! (&deque-front dq) #f))
         (set! (&deque-length dq)
           (1- len))
-        (&node-e back))
-      (error "Cannot pop; empty deque" dq))))
+        (&node-e back)))
+     ((eq? default absent-obj)
+      (error "Cannot pop; empty deque" dq))
+     (else default))))
 
-(def (peek-front dq)
+(def (peek-front dq (default absent-obj))
   (with ((deque front) dq)
-    (if front
-      (&node-e front)
-      (error "Cannot peek; empty deque"))))
+    (cond
+     (front
+      (&node-e front))
+     ((eq? default absent-obj)
+      (error "Cannot peek; empty deque"))
+     (else default))))
 
-(def (peek-back dq)
+(def (peek-back dq (default absent-obj))
   (with ((deque _ back) dq)
-    (if back
-      (&node-e back)
-      (error "Cannot peek; empty deque"))))
+    (cond
+     (back
+      (&node-e back))
+     ((eq? default absent-obj)
+      (error "Cannot peek; empty deque"))
+     (else default))))
 
 (def (deque->list dq)
   (with ((deque _ back) dq)

--- a/src/std/misc/deque.ss
+++ b/src/std/misc/deque.ss
@@ -1,0 +1,112 @@
+;;; -*- Gerbil -*-
+;;; (C) vyzo at hackzen.org
+;;; double ended queues
+package: std/misc
+
+(export deque make-deque deque? deque-length
+        deque-empty?
+        push-front! pop-front! peek-front
+        push-back! pop-back! peek-back
+        deque->list)
+(declare
+  (fixnum)
+  (not safe))
+
+(defstruct node (e prev next)
+  constructor: :init!
+  final: #t unchecked: #t)
+
+(defmethod {:init! node}
+  (lambda (self e)
+    (struct-instance-init! self e)))
+
+(def (make-node/prev e prev)
+  (let (new (make-node e))
+    (set! (&node-prev new) prev)
+    (set! (&node-next prev) new)
+    new))
+
+(def (make-node/next e next)
+  (let (new (make-node e))
+    (set! (&node-next new) next)
+    (set! (&node-prev next) new)
+    new))
+
+(defstruct deque (front back length)
+  constructor: :init!
+  final: #t unchecked: #t)
+
+(defmethod {:init! deque}
+  (lambda (self)
+    (struct-instance-init! self #f #f 0)))
+
+(def (deque-empty? dq)
+  (zero? (&deque-length dq)))
+
+(def (push-front! dq v)
+  (with ((deque front back len) dq)
+    (let (new (if front
+                (make-node/next v front)
+                (make-node v)))
+      (set! (&deque-front dq) new)
+      (unless back
+        (set! (&deque-back dq) new))
+      (set! (&deque-length dq)
+        (1+ len)))))
+
+(def (push-back! dq v)
+  (with ((deque front back len) dq)
+    (let (new (if back
+                (make-node/prev v back)
+                (make-node v)))
+      (set! (&deque-back dq) new)
+      (unless front
+        (set! (&deque-front dq) new))
+      (set! (&deque-length dq)
+        (1+ len)))))
+
+(def (pop-front! dq)
+  (with ((deque front back len) dq)
+    (if front
+      (let (next (&node-next front))
+        (set! (&deque-front dq) next)
+        (if next
+          (set! (&node-prev next) #f)
+          (set! (&deque-back dq) #f))
+        (set! (&deque-length dq)
+          (1- len))
+        (&node-e front))
+      (error "Cannot pop; empty deque" dq))))
+
+(def (pop-back! dq)
+  (with ((deque front back len) dq)
+    (if back
+      (let (prev (&node-prev back))
+        (set! (&deque-back dq) prev)
+        (if prev
+          (set! (&node-next prev) #f)
+          (set! (&deque-front dq) #f))
+        (set! (&deque-length dq)
+          (1- len))
+        (&node-e back))
+      (error "Cannot pop; empty deque" dq))))
+
+(def (peek-front dq)
+  (with ((deque front) dq)
+    (if front
+      (&node-e front)
+      (error "Cannot peek; empty deque"))))
+
+(def (peek-back dq)
+  (with ((deque _ back) dq)
+    (if back
+      (&node-e back)
+      (error "Cannot peek; empty deque"))))
+
+(def (deque->list dq)
+  (with ((deque _ back) dq)
+    (let lp ((n back) (r []))
+      (if n
+        (lp (&node-prev n)
+            (cons (&node-e n) r))
+        r))))

--- a/src/std/misc/pqueue.ss
+++ b/src/std/misc/pqueue.ss
@@ -3,7 +3,7 @@
 ;;; heap based priority queues
 package: std/misc
 
-(export make-pqueue pqueue? pqueue-empty? pqueue-size
+(export pqueue make-pqueue pqueue? pqueue-empty? pqueue-size
         pqueue-peek pqueue-pop! pqueue-push!)
 
 (defstruct pqueue (e cmp prio)
@@ -32,10 +32,12 @@ package: std/misc
       (error "empty pqueue")
       (heap-top e))))
 
-(def (pqueue-pop! pq)
+(def (pqueue-pop! pq (default absent-obj))
   (with ((pqueue e cmp) pq)
     (if (##fxzero? (heap-size e))
-      (error "empty pqueue")
+      (if (eq? default absent-obj)
+        (error "Cannot pop; empty pqueue")
+        default)
       (let (obj (heap-top e))
         (heap-pop! e cmp)
         obj))))

--- a/src/std/misc/queue.ss
+++ b/src/std/misc/queue.ss
@@ -3,7 +3,7 @@
 ;;; imperative queues
 package: std/misc
 
-(export make-queue queue? queue-length
+(export queue make-queue queue? queue-length
         queue-empty? non-empty-queue?
         enqueue! enqueue-front! dequeue!
         queue->list)
@@ -51,7 +51,7 @@ package: std/misc
         (set! (&queue-length q)
           (fx1+ length))))))
 
-(def (dequeue! q)
+(def (dequeue! q (default absent-obj))
   (with ((queue front back length) q)
     (cond
      ((eq? front back)
@@ -68,8 +68,9 @@ package: std/misc
         (set! (&queue-length q)
           (fx1- length))
         v))
-     (else
-      (error "cannot dequeue; empty queue" q)))))
+     ((eq? default absent-obj)
+      (error "cannot dequeue; empty queue" q))
+     (else default))))
 
 (def (queue->list q)
   (foldr cons [] (queue-front q)))


### PR DESCRIPTION
Adds `:std/misc/deque` implementing (imperative) double ended queues.
Also normalizes the queue pop interface in `:std/misc/queue` and `:std/misc/pqueue` for an optional default value.