### PR TITLE
iterators for srfis

### DIFF
--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -49,6 +49,7 @@
     "srfi/124"
     "srfi/125"
     "srfi/127"
+    "srfi/127-iter"
     "srfi/128"
     "srfi/132"
     "srfi/133"

--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -45,6 +45,7 @@
     "srfi/116"
     "srfi/117"
     "srfi/121"
+    "srfi/121-iter"
     "srfi/124"
     "srfi/125"
     "srfi/127"

--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -35,6 +35,7 @@
     (gxc: "srfi/13" "-cc-options" "--param max-gcse-memory=300000000")
     "srfi/19"
     "srfi/41"
+    "srfi/41-iter"
     (gxc: "srfi/42" "-cc-options" "--param max-gcse-memory=300000000")
     "srfi/43"
     "srfi/78"

--- a/src/std/srfi/121-iter.ss
+++ b/src/std/srfi/121-iter.ss
@@ -1,0 +1,21 @@
+;;; -*- Gerbil -*-
+;;; © vyzo
+;;; Iterators for SRFI-121 generators
+package: std/srfi
+
+(import :std/iter
+        :std/srfi/121)
+(export in-generator)
+
+(def (in-generator g)
+  (def (value it)
+    (with ((iterator e) it)
+      (when (iter-nil? (car e))
+        (let* ((v ((cdr e)))
+               (v (if (eof-object? v) iter-end v)))
+          (set! (car e) v)))
+      (car e)))
+  (def (next it)
+    (with ((iterator e) it)
+      (set! (car e) iter-nil)))
+  (make-iterator (cons iter-nil g) void value next))

--- a/src/std/srfi/127-iter.ss
+++ b/src/std/srfi/127-iter.ss
@@ -1,0 +1,18 @@
+;;; -*- Gerbil -*-
+;;; © vyzo
+;;; Iterators for SRFI-127 lazy sequences
+package: std/srfi
+
+(import :std/iter
+        :std/srfi/127)
+(export in-lseq)
+
+(def (in-lseq ls)
+  (def (value it)
+    (with ((iterator e) it)
+      (if (pair? e)
+        (car e)
+        iter-end)))
+  (def (next it)
+    (set! (iterator-e it) (lseq-cdr (iterator-e it))))
+  (make-iterator ls void value next))

--- a/src/std/srfi/41-iter.ss
+++ b/src/std/srfi/41-iter.ss
@@ -1,0 +1,27 @@
+;;; -*- Gerbil -*-
+;;; © vyzo
+;;; Iterators for SRFI-41 streams
+package: std/srfi
+
+(import :std/generic
+        :std/iter
+        :std/srfi/41)
+(export in-stream)
+
+(defsyntax stream-t
+  (make-runtime-struct-info
+   runtime-identifier: (quote-syntax stream-type)))
+
+(defmethod (:iter (s stream-t))
+  (in-stream s))
+
+(def (in-stream s)
+  (def (value it)
+    (let (e (iterator-e it))
+      (if (stream-pair? e)
+        (stream-car e)
+        iter-end)))
+  (def (next it)
+    (set! (iterator-e it)
+      (stream-cdr (iterator-e it))))
+  (make-iterator s void value next))

--- a/src/std/srfi/41.ss
+++ b/src/std/srfi/41.ss
@@ -5,6 +5,7 @@ package: std/srfi
 
 (import :std/srfi/9)
 (export
+  stream-type
   stream-lazy stream-eager stream-delay stream-force
   stream-null stream-pair? stream-null?
   stream-cons stream-car stream-cdr


### PR DESCRIPTION
Adds support for iterating over srfi sequence types
- std/srfi/41-iter: lazy streams -- `in-stream`, generic `:iter` on stream type
- std/srfi/121-iter: generators -- `in-generator`
- std/srfi/127-iter: lseqs -- `in-lseq`