### PR TITLE
prelude: define system-version

### DIFF
--- a/src/bootstrap/gerbil/core.ssi
+++ b/src/bootstrap/gerbil/core.ssi
@@ -552,6 +552,7 @@ namespace: gerbil/core
                     (keyword-dispatch keyword-dispatch)
                     (gerbil-version-string gerbil-version-string)
                     (gerbil-system-version-string gerbil-system-version-string)
+                    (system-version system-version)
                     (gerbil-system gerbil-system)
                     (system-type system-type)
                     (gerbil-runtime-smp? gerbil-runtime-smp?))

--- a/src/gerbil/prelude/core.ss
+++ b/src/gerbil/prelude/core.ss
@@ -257,7 +257,7 @@ package: gerbil
     ;; keyword argument dispatch
     keyword-dispatch
     ;; gerbil specifics
-    gerbil-version-string gerbil-system-version-string
+    gerbil-version-string gerbil-system-version-string system-version
     ;; system type information
     gerbil-system system-type
     ;; voodoo doll


### PR DESCRIPTION
It was missing; and it's very useful for cond-expand compile time evaluation.