### PR TITLE
rbtree: symbol-hash-cmp for hash based symbol ordering

### DIFF
--- a/doc/reference/misc.md
+++ b/doc/reference/misc.md
@@ -943,7 +943,7 @@ Otherwise an error is raised.
 Returns a list of the value contained in the queue, in order.
 
 
-## Red-Black Trees
+## Red Black Trees
 
 ::: tip usage
 (import :std/misc/rbtree)
@@ -956,7 +956,7 @@ Returns a list of the value contained in the queue, in order.
 ```
 :::
 
-Red-Black tree (rbtree) type.
+Red Black tree (rbtree) type.
 
 ### rbtree?
 ::: tip usage

--- a/doc/reference/misc.md
+++ b/doc/reference/misc.md
@@ -1194,6 +1194,18 @@ Comparison function for lexicographic string ordering.
 
 Comparison function for lexicographic symbol ordering.
 
+### symbol-hash-cmp
+::: tip usage
+```
+(symbol-hash-cmp a b)
+  a, b := symbol
+=> fixnum
+```
+:::
+
+Comparison function for symbol ordering based on their hashes;
+ties are broken by lexicographic ordering.
+
 
 ## Sourceable Representation
 ::: tip usage

--- a/src/std/misc/rbtree.ss
+++ b/src/std/misc/rbtree.ss
@@ -21,7 +21,8 @@ package: std/misc
         rbtree->listr
         list->rbtree
         string-cmp
-        symbol-cmp)
+        symbol-cmp
+        symbol-hash-cmp)
 
 ;; rbtree structure
 (defstruct rbtree (root cmp)
@@ -152,7 +153,19 @@ package: std/misc
         (##fx- len-a len-b)))))
 
 (def (symbol-cmp a b)
-  (string-cmp (symbol->string a) (symbol->string b)))
+  (if (eq? a b)
+    0
+    (string-cmp (symbol->string a) (symbol->string b))))
+
+(def (symbol-hash-cmp a b)
+  (if (eq? a b)
+    0
+    (let* ((ha (symbol-hash a))
+           (hb (symbol-hash b))
+           (ha-hb (##fx- ha hb)))
+      (if (##fxzero? ha-hb)
+        (string-cmp (symbol->string a) (symbol->string b))
+        ha-hb))))
 
 ;;; tree implementation
 


### PR DESCRIPTION
It is expected constant time, with lexicographic ordering only in case of hash collisions.