### PR TITLE
Cothread: heavyweight coroutine threads

### DIFF
--- a/doc/guide/intro.md
+++ b/doc/guide/intro.md
@@ -1028,8 +1028,6 @@ For example:
 => 3
 > (continue cort)
 => 'end ; coroutine end
-> (continue cort)
-=> error: coroutine has ended
 ```
 
 ### Event Programming

--- a/doc/reference/coroutine.md
+++ b/doc/reference/coroutine.md
@@ -1,6 +1,15 @@
 # Coroutines
 
-The `:std/coroutine` library provides support for continuation-based coroutines.
+The `:std/coroutine` library provides support for continuation-based and thread-based coroutines.
+
+Continuation-based coroutines are created with `coroutine`, while thread-based coroutines are
+created with `cothread`. Both types of coroutine are resumed with `continue` and yield results
+with `yield`.
+
+Continuation-based coroutines are more lightweight, but by virtue of implementation they cannot
+use `yield` inside finalizer blocks.
+Thread-based coroutines are more heavyweight, but don't suffer from this problem as they have
+a delimited dynamic scope.
 
 ::: tip usage
 (import :std/coroutine)
@@ -18,7 +27,7 @@ The `:std/coroutine` library provides support for continuation-based coroutines.
 :::
 
 Creates a new coroutine that evaluates proc with arguments `(proc arg ...)`.
-The coroutine is initially a suspended continuation, which can be resumed
+The coroutine is initially a suspended continuation, and can be resumed
 with `continue`.
 
 ### coroutine?
@@ -31,16 +40,40 @@ with `continue`.
 
 Returns true if the object is a coroutine.
 
+### cothread
+::: tip usage
+```
+(cothread proc arg ...)
+  proc := procedure
+=> <cothread>
+```
+:::
+
+Creates a new cothread that evaluates proc with arguments `(proc arg ...)`.
+The thread is initially suspended, and can be resumed with `continue`.
+
+### cothread?
+::: tip usage
+```
+(cothread? obj)
+=> boolean
+```
+:::
+
+Returns true if the object is a cothread.
+
+
 ### continue
 ::: tip usage
 ```
-(continue cort arg ...)
-  cort := coroutine
+(continue co arg ...)
+  co := coroutine or cothread
 => any
 ```
 :::
 
-Resumes the coroutine continuation, with the arguments becoming the values of the last yield.
+Resumes the coroutine or cothread, with the arguments becoming the values of the last yield.
+If the continuable was in initial suspended state, then it is resumed and the arguments are ignored.
 
 ### yield
 ::: tip usage
@@ -49,7 +82,17 @@ Resumes the coroutine continuation, with the arguments becoming the values of th
 ```
 :::
 
-Continues execution of the main routine, with the arguments becoming the values of the last continue.
+Continues execution of the main routine or thread, with the arguments becoming the values of the last continue.
+
+### cothread-stop!
+::: tip usage
+```
+(cothread-stop! co)
+  co := cothread
+```
+:::
+
+Stops the execution of a cothread.
 
 ## Example
 

--- a/src/std/coroutine-test.ss
+++ b/src/std/coroutine-test.ss
@@ -1,0 +1,28 @@
+;;; -*- Gerbil -*-
+;;; © vyzo
+;;; :std/coroutine unit-test
+
+(import :std/test
+        :std/coroutine)
+(export coroutine-test)
+
+(def (1-to-n n)
+  (let lp ((i 1))
+    (when (<= i n)
+      (yield i)
+      (lp (1+ i))))
+  'end)
+
+(def (collect co)
+  (let lp ((r []))
+    (let (next (continue co))
+      (if (eq? next 'end)
+        (reverse r)
+        (lp (cons next r))))))
+
+(def coroutine-test
+  (test-suite "test :std/coroutine"
+    (test-case "test coroutine"
+      (check (collect (coroutine 1-to-n 10)) => '(1 2 3 4 5 6 7 8 9 10)))
+    (test-case "test cothread"
+      (check (collect (cothread 1-to-n 10)) => '(1 2 3 4 5 6 7 8 9 10)))))

--- a/src/std/coroutine.ss
+++ b/src/std/coroutine.ss
@@ -1,10 +1,12 @@
 ;;; -*- Gerbil -*-
 ;;; (C) vyzo
-;;; coroutines
+;;; coroutines and cothreads
 package: std
 
-(import :std/sugar)
-(export coroutine (rename: cort? coroutine?) continue yield)
+(import :gerbil/gambit/threads
+        :std/sugar)
+(export coroutine (rename: cort? coroutine?) continue yield
+        cothread cothread? cothread-stop!)
 
 (def current-coroutine
   (make-parameter #f))
@@ -12,11 +14,47 @@ package: std
 (defstruct cort (k end? res)
   final: #t)
 
+(defstruct cothr (mx cv state val)
+  final: #t)
+
 (def (coroutine proc . args)
   (let/cc k
-    (start k (if (null? args) proc (cut apply proc args)))))
+    (coroutine-start! k (if (null? args) proc (cut apply proc args)))))
 
-(def (start k thunk)
+(def (cothread proc . args)
+  (let* ((cothr (make-cothr (make-mutex 'coroutine)
+                            (make-condition-variable 'coroutine)
+                            'run #f))
+         (thread (make-thread
+                  (cut cothread-start! cothr proc args)
+                  'cothread)))
+    (set! (thread-specific thread) cothr)
+    (thread-start! thread)))
+
+(def (cothread? thread)
+  (and (thread? thread)
+       (cothr? (thread-specific thread))))
+
+(def (continue c . args)
+  (cond
+   ((cort? c)
+    (coroutine-continue! c args))
+   ((cothread? c)
+    (cothread-continue! (thread-specific c) args))
+   (else
+    (error "Illegal argument; not continuable" c))))
+
+(def (yield . args)
+  (cond
+   ((current-coroutine)
+    => (cut coroutine-yield! <> args))
+   ((cothr? (thread-specific (current-thread)))
+    (cothread-yield! (thread-specific (current-thread)) args))
+   (else
+    (error "Not in a coroutine continuation"))))
+
+;;; Implementation of coroutines
+(def (coroutine-start! k thunk)
   (let (c (make-cort #f #f #f))
     (parameterize ((current-coroutine c))
       (let/cc kk
@@ -31,7 +69,7 @@ package: std
             (set! (cort-k c) #f)
             (apply k res)))))))
 
-(def (continue c . args)
+(def (coroutine-continue! c args)
   (with ((cort k end? res) c)
     (if end?
       (apply values res)
@@ -39,13 +77,108 @@ package: std
         (set! (cort-k c) kk)
         (apply k args)))))
 
-(def (yield . args)
-  (cond
-   ((current-coroutine)
-    => (lambda (c)
-         (with ((cort k) c)
-           (let/cc kk
-             (set! (cort-k c) kk)
-             (apply k args)))))
-   (else
-    (error "Not in a coroutine continuation"))))
+(def (coroutine-yield! c args)
+  (with ((cort k) c)
+    (let/cc kk
+      (set! (cort-k c) kk)
+      (apply k args))))
+
+;;; Implementation of cothreads
+(def (cothread-start! c proc args)
+  (parameterize ((current-coroutine #f))
+    (try
+     (cothread-wait! c)
+     (let (val (apply proc args))
+       (cothread-signal! c 'end val))
+     (catch (e)
+       (cothread-signal! c 'error e)))))
+
+(def (cothread-stop! thread (val (void)))
+  (if (thread? thread)
+    (let (spec (thread-specific thread))
+      (if (cothr? spec)
+        (cothread-signal! spec 'end val)
+        (error "Not a coroutine thread" thread spec)))
+    (error "Expected coroutine thread" thread)))
+
+(def (cothread-continue! c val)
+  (with ((cothr mx cv state kont) c)
+    (mutex-lock! mx)
+    (case state
+      ((run)
+       (set! (cothr-val c) val)
+       (set! (cothr-state c) 'continue)
+       (condition-variable-signal! cv)
+       (mutex-unlock! mx cv)
+       (let lp ()
+         (mutex-lock! mx)
+         (let ((state (cothr-state c))
+               (kont (cothr-val c)))
+           (case state
+             ((continue)
+              (mutex-unlock! mx cv)
+              (lp))
+             ((yield)
+              (set! (cothr-state c) 'run)
+              (mutex-unlock! mx)
+              kont)
+             ((end)
+              (mutex-unlock! mx)
+              kont)
+             ((error)
+              (mutex-unlock! mx)
+              (raise kont))
+             (else
+              (mutex-unlock! mx)
+              (error "Illegal cothread state" state))))))
+      ((end)
+       (mutex-unlock! mx)
+       kont)
+      ((error)
+       (mutex-unlock! mx)
+       (raise kont))
+      (else
+       (error "Illegal cothread state" state)))))
+
+(def (cothread-yield! c args)
+  (let (kont (cothread-yield-values! c (apply values args)))
+    (cothread-wait! c)
+    kont))
+
+(def (cothread-yield-values! c val)
+  (with ((cothr mx cv state kont) c)
+    (mutex-lock! mx)
+    (case state
+      ((continue)
+       (set! (cothr-val c) val)
+       (set! (cothr-state c) 'yield)
+       (condition-variable-signal! cv)
+       (mutex-unlock! mx)
+       kont)
+      (else
+       (mutex-unlock! mx)
+       (error "Illegal cothread state" state)))))
+
+(def (cothread-signal! c state val)
+  (with ((cothr mx cv) c)
+    (mutex-lock! mx)
+    (unless (memq (cothr-state c) '(end error))
+      (set! (cothr-val c) val)
+      (set! (cothr-state c) state)
+      (condition-variable-signal! cv))
+    (mutex-unlock! mx)))
+
+(def (cothread-wait! c)
+  (with ((cothr mx cv) c)
+    (let lp ()
+      (mutex-lock! mx)
+      (let (state (cothr-state c))
+        (case state
+          ((run yield)
+           (mutex-unlock! mx cv)
+           (lp))
+          ((continue)
+           (mutex-unlock! mx))
+          (else
+           (mutex-unlock! mx)
+           (error "Illegal cothread state" state)))))))

--- a/src/std/run-tests.ss
+++ b/src/std/run-tests.ss
@@ -4,6 +4,7 @@
 (import :std/test
         "build-config"
         "generic-test"
+        "coroutine-test"
         "iter-test"
         "amb-test"
         "event-test"
@@ -50,6 +51,7 @@
 (def tests
   [generic-runtime-test
    generic-macro-test
+   coroutine-test
    iter-test
    amb-test
    event-test


### PR DESCRIPTION
Reinstates the old implementation of coroutines as cothreads.
The salient advantage is that cothreads can yield within finalizer blocks, as they don't swap continuations.