### PR TITLE
std/make: fix foreign compilation prefix

### DIFF
--- a/src/std/make.ss
+++ b/src/std/make.ss
@@ -407,7 +407,8 @@ package: std
       => (lambda (ix)
            (path-expand (substring mod 0 ix)
                         (if prefix (path-expand prefix libdir) libdir))))
-     (else (path-expand "std" libdir))))
+     (prefix (path-expand prefix libdir))
+     (else libdir)))
 
   (create-directory* libpath)
   (message "... compile foreign " mod)


### PR DESCRIPTION
BUG: gsc-compile was placing foreign compilation artifacts under std instead of the prefix.