### PR TITLE
begin-ffi macro

### DIFF
--- a/doc/.vuepress/config.js
+++ b/doc/.vuepress/config.js
@@ -28,7 +28,7 @@ module.exports = {
             {
               collapsable: false,
               title: 'Gerbil Reference',
-              children:  ['', 'core-prelude', 'core-builtin', 'core-expander', 'stdlib', 'sugar', 'errors', 'getopt', 'format', 'logger', 'sort', 'regexp', 'generic', 'ref', 'iterators', 'coroutine', 'events', 'actor', 'requests', 'httpd', 'web', 'db', 'kvstore', 'sockets', 'net', 'protobuf', 'os', 'crypto', 'text', 'xml', 'parser', 'misc', 'lazy', 'amb', 'stxparam', 'srfi', 'test', 'debug', 'make']
+              children:  ['', 'core-prelude', 'core-builtin', 'core-expander', 'stdlib', 'sugar', 'errors', 'getopt', 'format', 'logger', 'sort', 'regexp', 'generic', 'ref', 'iterators', 'coroutine', 'events', 'actor', 'requests', 'httpd', 'web', 'db', 'kvstore', 'sockets', 'net', 'protobuf', 'os', 'crypto', 'text', 'xml', 'parser', 'misc', 'lazy', 'amb', 'stxparam', 'foreign', 'srfi', 'test', 'debug', 'make']
             }
           ]
         },

--- a/doc/reference/foreign.md
+++ b/doc/reference/foreign.md
@@ -1,0 +1,46 @@
+# Utilities for FFI Programming
+
+::: tip usage
+(import :std/foreign)
+:::
+
+## begin-ffi
+::: tip usage
+```
+(begin-ffi (id ...) body ...)
+
+; expands to
+(extern id ...)
+(begin-foreign
+  (namespace (<module-namespace> id ...))
+  prelude-macros ...
+  prelude-decls ...
+  body ...
+  prelude-defs ...
+```
+:::
+
+The following prelude macros are available within the body:
+```
+(define-c-lambda id args ret [name/code])
+(define-const id)
+(define-const* id)
+(define-guard guard defn)
+```
+
+The following declarations are included before the body:
+```
+#include <stdlib.h>
+#define U8_DATA(u8vector) ...
+#define U8_LEN(u8vector) ...
+static ___SCMOBJ ffi_free (void *ptr);
+```
+
+The following definitions are included after the body:
+
+```
+#ifndef ___HAVE_FFI_FREE
+#define ___HAVE_FFI_FREE
+___SCMOBJ ffi_free (void *ptr) { ...}
+#endif
+```

--- a/etc/gerbil.el
+++ b/etc/gerbil.el
@@ -229,6 +229,7 @@
                 while
                 let-hash
                 for for* for/collect
+                begin-ffi
                 )
               'scheme-indent-function 1)
   (gerbil-put '(syntax-case ast-case core-syntax-case core-ast-case
@@ -275,7 +276,7 @@
                        "error" "raise"
                        "let/cc" "let/esc"
                        "unwind-protect"
-                       "begin-foreign"
+                       "begin-foreign" "begin-ffi"
                        "cut"
                        "with" "with*"
                        "match" "match*"

--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -2,6 +2,7 @@
 (def build-spec
   `((gxc: "build-config" dep: ("build-features.ss"))
     "interactive"
+    "foreign"
     "format"
     "pregexp"
     "sort"

--- a/src/std/foreign.ss
+++ b/src/std/foreign.ss
@@ -1,0 +1,87 @@
+;;; -*- Gerbil -*-
+;;; © vyzo
+;;; FFI macros
+package: std
+
+(export begin-ffi)
+
+(defsyntax (begin-ffi stx)
+  (def (namespace-def ns ids)
+    (if (null? ids) []
+        (with-syntax ((prefix (string-append (if (symbol? ns) (symbol->string ns) ns) "#"))
+                      ((id ...) ids))
+          [#'(namespace (prefix id ...))])))
+
+  (def (prelude-macros)
+    '((define-macro (define-guard guard defn)
+        (if (eval `(cond-expand (,guard #t) (else #f)))
+          '(begin)
+          (begin
+            (eval `(define-cond-expand-feature ,guard))
+            defn)))
+      (define-macro (define-c-lambda id args ret #!optional (name #f))
+        (let ((name (or name (symbol->string id))))
+          `(define ,id
+             (c-lambda ,args ,ret ,name))))
+      (define-macro (define-const symbol)
+        (let* ((str (symbol->string symbol))
+               (ref (string-append "___return (" str ");")))
+          `(define ,symbol
+             ((c-lambda () int ,ref)))))
+      (define-macro (define-const* symbol)
+        (let* ((str (symbol->string symbol))
+               (code (string-append
+                      "#ifdef " str "\n"
+                      "___return (___FIX (" str "));\n"
+                      "#else \n"
+                      "___return (___FAL);\n"
+                      "#endif")))
+          `(define ,symbol
+             ((c-lambda () scheme-object ,code)))))))
+
+  (def (prelude-c-decls)
+    '((c-declare "#include <stdlib.h>")
+      (c-declare "static ___SCMOBJ ffi_free (void *ptr);")
+      (c-declare #<<END-C
+#ifndef ___HAVE_FFI_U8VECTOR
+#define ___HAVE_FFI_U8VECTOR
+#define U8_DATA(obj) ___CAST (___U8*, ___BODY_AS (obj, ___tSUBTYPED))
+#define U8_LEN(obj) ___HD_BYTES (___HEADER (obj))
+#endif
+END-C
+)
+      ))
+
+  (def (prelude-c-defs)
+    '((c-declare #<<END-C
+#ifndef ___HAVE_FFI_FREE
+#define ___HAVE_FFI_FREE
+___SCMOBJ ffi_free (void *ptr)
+{
+ free (ptr);
+ return ___FIX (___NO_ERR);
+}
+#endif
+END-C
+)
+      ))
+
+  (syntax-case stx ()
+    ((_ (id ...) body ...)
+     (identifier-list? #'(id ...))
+     (if (module-context? (current-expander-context))
+       (let (ns (or (module-context-ns (current-expander-context))
+                    (expander-context-id (current-expander-context))))
+         (with-syntax (((nsdef ...) (namespace-def ns #'(id ...)))
+                       ((macros ...) (prelude-macros))
+                       ((c-decls ...) (prelude-c-decls))
+                       ((c-defs ...) (prelude-c-defs)))
+           #'(begin
+               (extern id ...)
+               (begin-foreign
+                 macros ...
+                 c-decls ...
+                 nsdef ...
+                 body ...
+                 c-defs ...))))
+       (raise-syntax-error #f "Illegal expansion context; not in module context" stx)))))

--- a/src/std/net/httpd/handler.ss
+++ b/src/std/net/httpd/handler.ss
@@ -4,6 +4,7 @@
 package: std/net/httpd
 
 (import :gerbil/gambit/os
+        :std/foreign
         :std/net/socket
         :std/net/bio
         :std/text/utf8
@@ -246,14 +247,8 @@ package: std/net/httpd
         (for-each (cut http-response-chunk res <>) chunks)
         (http-response-end res)))))
 
-(extern http-date)
-(begin-foreign
-  (namespace ("std/net/httpd/handler#" http-date))
-  (define-macro (define-c-lambda id args ret #!optional (name #f))
-    (let ((name (or name (##symbol->string id))))
-      `(define ,id
-         (c-lambda ,args ,ret ,name))))
 
+(begin-ffi (http-date)
   (c-declare #<<END-C
 #include <time.h>
 #include <string.h>

--- a/src/std/os/error.ss
+++ b/src/std/os/error.ss
@@ -3,6 +3,7 @@
 ;;; OS errors
 package: std/os
 
+(import :std/foreign)
 (export raise-os-error
         check-os-error
         do-retry-nonblock
@@ -42,25 +43,9 @@ package: std/os
      (if r r
          (error "Error allocating memory" 'make)))))
 
-(extern strerror EAGAIN EINTR EINPROGRESS EWOULDBLOCK)
-(begin-foreign
+(begin-ffi (strerror EAGAIN EINTR EINPROGRESS EWOULDBLOCK)
   (c-declare "#include <errno.h>")
   (c-declare "#include <string.h>")
-
-  (define-macro (define-c-lambda id args ret #!optional (name #f))
-    (let ((name (or name (##symbol->string id))))
-      `(define ,id
-         (c-lambda ,args ,ret ,name))))
-
-  (define-macro (define-const symbol)
-    (let* ((str (##symbol->string symbol))
-           (ref (##string-append "___return (" str ");")))
-      `(define ,symbol
-         ((c-lambda () int ,ref)))))
-
-  (namespace ("std/os/error#"
-              strerror
-              EAGAIN EINTR EWOULDBLOCK EINPROGRESS))
 
   (define-const EAGAIN)
   (define-const EINTR)

--- a/src/std/os/pid.ss
+++ b/src/std/os/pid.ss
@@ -3,18 +3,12 @@
 ;;; OS pid
 package: std/os
 
+(import :std/foreign)
 (export getpid getppid)
-(extern getpid getppid)
-(begin-foreign
+
+(begin-ffi (getpid getppid)
   (c-declare "#include <sys/types.h>")
   (c-declare "#include <unistd.h>")
-
-  (define-macro (define-c-lambda id args ret #!optional (name #f))
-    (let ((name (or name (##symbol->string id))))
-      `(define ,id
-         (c-lambda ,args ,ret ,name))))
-
-  (namespace ("std/os/pid#" getpid getppid))
 
   (define-c-lambda getpid () int)
   (define-c-lambda getppid () int))


### PR DESCRIPTION
Adds a `begin-ffi` macro in `:std/foreign`, which simplifies writing foreign stubs.

The macro is used as following:
```
(begin-ffi (id ...) body ...)
```
It expands to an `extern` declaration for ids, and a `begin-foreign` where the body:
- contains a namespace declaration for the extern identifiers
- defines the common macros `define-c-lambda`, `define-guard`, `define-const`, and `define-const*`
- defines the `U8_DATA` and `U8_LEN` preprocessors macros
- defines a proper `ffi_free` procedure for foreign type release functions
