### PR TITLE
Modify string-prefix? argument order to match srfi-13

### DIFF
--- a/doc/reference/core-builtin.md
+++ b/doc/reference/core-builtin.md
@@ -1635,8 +1635,8 @@ Returns true if `str` is the empty string.
 ### string-prefix?
 ::: tip usage
 ```
-(string-prefix? str prefix)
-  str, prefix := string
+(string-prefix? prefix str)
+  prefix, str := string
 => boolean
 ```
 :::

--- a/src/bootstrap/gerbil/compiler/optimize-top__0.scm
+++ b/src/bootstrap/gerbil/compiler/optimize-top__0.scm
@@ -7950,7 +7950,7 @@
                 (lambda (_id21090_)
                   (if (uninterned-symbol? _id21090_)
                       (let ((_str21092_ (symbol->string _id21090_)))
-                        (if (string-prefix? _str21092_ '"opt-lambda")
+                        (if (string-prefix? '"opt-lambda" _str21092_)
                             '"%"
                             _id21090_))
                       _id21090_)))
@@ -7958,7 +7958,7 @@
                 (lambda (_id21085_ _name21086_)
                   (if (uninterned-symbol? _id21085_)
                       (let ((_str21088_ (symbol->string _id21085_)))
-                        (if (string-prefix? _str21088_ '"kw-lambda")
+                        (if (string-prefix? '"kw-lambda" _str21088_)
                             _name21086_
                             _id21085_))
                       _id21085_))))

--- a/src/bootstrap/gerbil/expander/module__0.scm
+++ b/src/bootstrap/gerbil/expander/module__0.scm
@@ -1186,7 +1186,7 @@
                                _dir14425_)))
                          (if _$e14429_
                              ((lambda (_prefix14432_)
-                                (if (string-prefix? _spath14388_ _prefix14432_)
+                                (if (string-prefix? _prefix14432_ _spath14388_)
                                     (let ((_ssi14434_
                                            (substring
                                             _ssi14392_

--- a/src/gerbil/compiler/optimize-top.ss
+++ b/src/gerbil/compiler/optimize-top.ss
@@ -404,7 +404,7 @@ namespace: gxc
   (def (opt-lambda-dispatch-name id)
     (if (uninterned-symbol? id)
       (let (str (symbol->string id))
-        (if (string-prefix? str "opt-lambda")
+        (if (string-prefix? "opt-lambda" str)
           "%"
           id))
       id))
@@ -412,7 +412,7 @@ namespace: gxc
   (def (kw-lambda-dispatch-name id name)
     (if (uninterned-symbol? id)
       (let (str (symbol->string id))
-        (if (string-prefix? str "kw-lambda")
+        (if (string-prefix? "kw-lambda" str)
           name
           id))
       id))

--- a/src/gerbil/expander/module.ss
+++ b/src/gerbil/expander/module.ss
@@ -428,7 +428,7 @@ namespace: gx
          (cond
           ((core-library-package-path-prefix dir)
            => (lambda (prefix)
-                (if (string-prefix? spath prefix)
+                (if (string-prefix? prefix spath)
                   (let ((ssi (substring ssi (string-length prefix) (string-length ssi)))
                         (src (substring src (string-length prefix) (string-length src))))
                     (resolve ssi src))

--- a/src/gerbil/runtime/gx-gambc0.scm
+++ b/src/gerbil/runtime/gx-gambc0.scm
@@ -1384,7 +1384,7 @@
 (define (string-empty? str)
   (##fxzero? (string-length str)))
 
-(define (string-prefix? str prefix)
+(define (string-prefix? prefix str)
   (let ((str-len (string-length str))
         (prefix-len (string-length prefix)))
     (and (##fx<= prefix-len str-len)

--- a/src/std/net/sasl.ss
+++ b/src/std/net/sasl.ss
@@ -56,7 +56,7 @@ package: std/net
                  (fail "Invalid server message; missing iteration count" msg))))
          (nonce (scram-context-nonce ctx)))
     (unless (and (fx> (string-length r) (string-length nonce))
-                 (string-prefix? r nonce))
+                 (string-prefix? nonce r))
       (fail "Invalid server nonce" r nonce))
     (set! (scram-context-sfm ctx) sfm)
     (set! (scram-context-r ctx) r)

--- a/src/std/protobuf/proto.ss
+++ b/src/std/protobuf/proto.ss
@@ -149,7 +149,7 @@ package: std/protobuf
            yid
            (let ((str (symbol->string (stx-e id)))
                  (pre (string-append (symbol->string (stx-e xid)) ".")))
-             (if (string-prefix? str pre)
+             (if (string-prefix? pre str)
                (stx-identifier id yid "." (substring str (string-length pre) (string-length str)))
                (lp rest)))))
         (else id))))

--- a/src/tools/gxpkg.ss
+++ b/src/tools/gxpkg.ss
@@ -241,7 +241,9 @@
   (cond
    ((equal? pkg "all")
     (fold-pkgs (pkg-list) pkg-update))
-   ((string-prefix? "github.com/" pkg)
+   ((or (string-prefix? "github.com/" pkg)
+        (string-prefix? "gitlab.com/" pkg)
+        (string-prefix? "bitbucket.org/" pkg))
     (pkg-update-git pkg))
    (else
     (error "Unknown package provider" pkg))))

--- a/src/tools/gxpkg.ss
+++ b/src/tools/gxpkg.ss
@@ -193,9 +193,9 @@
   (def (git-clone-url pkg)
     (string-append "https://" pkg ".git"))
   (cond
-   ((or (string-prefix? pkg "github.com/")
-        (string-prefix? pkg "gitlab.com/")
-        (string-prefix? pkg "bitbucket.org/"))
+   ((or (string-prefix? "github.com/" pkg)
+        (string-prefix? "gitlab.com/" pkg)
+        (string-prefix? "bitbucket.org/" pkg))
     (pkg-install-git pkg (git-clone-url pkg)))
    (else
     (error "Unknown package provider" pkg))))
@@ -241,7 +241,7 @@
   (cond
    ((equal? pkg "all")
     (fold-pkgs (pkg-list) pkg-update))
-   ((string-prefix? pkg "github.com/")
+   ((string-prefix? "github.com/" pkg)
     (pkg-update-git pkg))
    (else
     (error "Unknown package provider" pkg))))
@@ -325,9 +325,9 @@
       (when (file-exists? moddir)
         (for-each
           (lambda (file)
-            (when (or (string-prefix? file mod-dot)
-                      (string-prefix? file mod-us)
-                      (string-prefix? file mod-nested))
+            (when (or (string-prefix? mod-dot file)
+                      (string-prefix? mod-us file)
+                      (string-prefix? mod-nested file))
               (let (path (path-expand file moddir))
                 (delete-file path))))
           (directory-files moddir))))
@@ -340,7 +340,7 @@
         (for-each
           (lambda (file)
             (when (or (equal? file mod-self)
-                      (string-prefix? file mod-nested))
+                      (string-prefix? mod-nested file))
               (let (path (path-expand file static-libdir))
                 (delete-file path))))
           (directory-files static-libdir)))))


### PR DESCRIPTION
The arguments were reversed, which leads to confusion and potential bugs when importing srfi/13 in code that was already using `string-prefix?`.

Also fixes a bug in gxpkg discovered when auditing usages of `string-prefix?`: package update only accepted github as package provider.