### PR TITLE
sasl: rename client methods consuming server messages

### DIFF
--- a/doc/reference/net.md
+++ b/doc/reference/net.md
@@ -717,10 +717,10 @@ Please document me!
 
 Please document me!
 
-### scram-server-first-message!
+### scram-client-first-server-message!
 ::: tip usage
 ```
-(scram-server-first-message! ...)
+(scram-client-first-server-message! ...)
 ```
 :::
 
@@ -735,10 +735,10 @@ Please document me!
 
 Please document me!
 
-### scram-server-final-message!
+### scram-client-final-server-message!
 ::: tip usage
 ```
-(scram-server-final-message! ...)
+(scram-client-final-server-message! ...)
 ```
 :::
 

--- a/src/std/db/postgresql-driver.ss
+++ b/src/std/db/postgresql-driver.ss
@@ -164,12 +164,12 @@ package: std/db
       (send! ['SASLInitialResponse "SCRAM-SHA-256" msg])
       (recv!
        (['AuthenticationRequest 'AuthenticationSASLContinue msg]
-        (scram-server-first-message! ctx msg)
+        (scram-client-first-server-message! ctx msg)
         (let (msg (scram-client-final-message ctx))
           (send! ['SASLResponse msg])
           (recv!
            (['AuthenticationRequest 'AuthenticationSASLFinal msg]
-            (scram-server-final-message! ctx msg)
+            (scram-client-final-server-message! ctx msg)
             (recv!
              (['AuthenticationRequest 'AuthenticationOk]
               (start-driver! sock))))))))))

--- a/src/std/net/sasl-test.ss
+++ b/src/std/net/sasl-test.ss
@@ -12,9 +12,9 @@
     (def (check-scram-method scram-begin user pass r cfm sfm csm ssm)
       (def ctx (scram-begin user pass))
       (check (scram-client-first-message ctx r) => cfm)
-      (check (scram-server-first-message! ctx sfm) ? void?)
+      (check (scram-client-first-server-message! ctx sfm) ? void?)
       (check (scram-client-final-message ctx) => csm)
-      (check (scram-server-final-message! ctx ssm) ? void?))
+      (check (scram-client-final-server-message! ctx ssm) ? void?))
 
     (test-case "test SCRAM-SHA-1"
       ;; RFC 5802 test vector

--- a/src/std/net/sasl.ss
+++ b/src/std/net/sasl.ss
@@ -13,9 +13,9 @@ package: std/net
         scram-sha-1-begin
         scram-sha-256-begin
         scram-client-first-message
-        scram-server-first-message!
+        scram-client-first-server-message!
         scram-client-final-message
-        scram-server-final-message!)
+        scram-client-final-server-message!)
 
 ;; SCRAM RFC 5802
 (defstruct scram-context (h hmac user pass nonce cfm sfm r s i p v)
@@ -44,7 +44,7 @@ package: std/net
     (set! (scram-context-nonce ctx) nonce)
     (first-message cfm)))
 
-(def (scram-server-first-message! ctx sfm)
+(def (scram-client-first-server-message! ctx sfm)
   (let* ((msg (scram-parse-message sfm))
          (r (or (assget "r" msg)
                 (fail "Invalid server message; missing nonce" msg)))
@@ -84,7 +84,7 @@ package: std/net
       (set! (scram-context-v ctx) v)
       (final-message csm p))))
 
-(def (scram-server-final-message! ctx smsg)
+(def (scram-client-final-server-message! ctx smsg)
   (let* (msg (scram-parse-message smsg))
     (cond
      ((assget "e" msg)


### PR DESCRIPTION
More appropriate names, as this is the client api. 
That way, a server-side api can be added with the similar structure.