### PR TITLE
when-list-or-empty helper macro

### DIFF
--- a/doc/reference/misc.md
+++ b/doc/reference/misc.md
@@ -603,6 +603,15 @@ Removes one layer of a nested proper list.
 
 Removes all nested layers of a proper list.
 
+### when-list-or-empty
+::: tip usage
+```
+(when-list-or-empty list body ...)
+```
+
+Macro which evaluates the body only if the passed value is
+a non-empty list, otherwise an empty list is returned.
+
 
 
 ## LRU caches

--- a/src/std/misc/list-test.ss
+++ b/src/std/misc/list-test.ss
@@ -105,4 +105,7 @@
       (check-equal? (flatten1 '(1 (2) (3) ((4)))) '(1 2 3 (4)))
       (check-equal? (flatten1 '((1) ((2)) 3)) '(1 (2) 3))
       (check-equal? (flatten1 '(1 2 ())) '(1 2))
-      (check-equal? (flatten1 '(1 2 (()))) '(1 2 ())))))
+      (check-equal? (flatten1 '(1 2 (()))) '(1 2 ())))
+    (test-case "test when-list-or-empty"
+      (check-equal? (when-list-or-empty [1] "a") "a")
+      (check-equal? (when-list-or-empty [] "a") []))))

--- a/src/std/misc/list.ss
+++ b/src/std/misc/list.ss
@@ -16,7 +16,8 @@ package: std/misc
   for-each!
   push!
   flatten
-  flatten1)
+  flatten1
+  when-list-or-empty)
 
 ;; This function checks if the list is a proper association-list.
 ;; ie it has the form [[key1 . val1] [key2 . val2]]
@@ -189,3 +190,11 @@ package: std/misc
 	    (else (cons v acc))))
 	 []
 	 list-of-lists))
+
+;; Macro which evaluates the body only if the passed value is
+;; a non-empty list, otherwise an empty list is returned.
+(defrules when-list-or-empty ()
+  ((_ list body body* ...)
+   (if (null? list)
+     []
+     body body* ...)))

--- a/src/std/run-tests.ss
+++ b/src/std/run-tests.ss
@@ -12,7 +12,7 @@
         "misc/list-test"
         "misc/channel-test"
         "misc/lru-test"
-	    "misc/func-test"
+        "misc/func-test"
         "misc/queue-test"
         "misc/deque-test"
         "misc/pqueue-test"


### PR DESCRIPTION
Little macro to cut a bit of boilerplate code that is often present in name-let loops.