### PR TITLE
Fix vuepress bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ lib
 *.so
 
 src/std/build-deps
+src/gerbil/runtime/gx-version.scm

--- a/doc/build.sh
+++ b/doc/build.sh
@@ -2,5 +2,9 @@
 
 cd ${0%/*}
 
+# https://github.com/vuejs/vue-cli/issues/3407
+# terser 3.16 is broken
+npm install terser@3.14
+
 npm install
 npm run build

--- a/src/gerbil/runtime/gx-version.scm
+++ b/src/gerbil/runtime/gx-version.scm
@@ -1,1 +1,0 @@
-(define (gerbil-version-string) "v0.15")


### PR DESCRIPTION
The documentation build is failing because of a broken dependency.
See https://github.com/vuejs/vue-cli/issues/3407