### PR TITLE
Quote paren-face in gerbil.el

### DIFF
--- a/etc/gerbil.el
+++ b/etc/gerbil.el
@@ -418,9 +418,6 @@
      (1 font-lock-builtin-face)))
 
   (gerbil-fontlock-add
-   '("\\([()]\\)"
-     (1 paren-face)))
-  (gerbil-fontlock-add
    '("\\([{}]\\|\\[\\|\\]\\)"
      (1 font-lock-variable-name-face)))
   )


### PR DESCRIPTION
This seems to fix the following error I got when trying to use [rainbow-delimiter](https://github.com/Fanael/rainbow-delimiters) with `gerbil-mode`:
```
Error during redisplay: (jit-lock-function 1) signaled (void-variable paren-face)
Error during redisplay: (jit-lock-function 501) signaled (void-variable paren-face)
Error during redisplay: (jit-lock-function 1001) signaled (void-variable paren-face)
```