### PR TITLE
group-in: A little import macro that reduces import boilerplate

### DIFF
--- a/doc/reference/core-prelude.md
+++ b/doc/reference/core-prelude.md
@@ -864,6 +864,24 @@ Import and export expander; rename a set by applying a prefix.
 
 Export expander; export all identifiers related with structs `struct-id ...`
 
+#### group-in
+```
+(import (group-in prefix mod ...))
+mod := id
+    |  (id mod ...)
+```
+
+Imports a group of common prefix library modules.
+
+Examples:
+```
+(import (group-in :std/misc (queue rbtree)))
+= (import :std/misc/queue :std/misc/rbtree)
+
+(import (group-in :std (misc queue rbtree) (net bio)))
+= (import :std/misc/queue :std/misc/rbtree :std/net/bio)
+```
+
 ## Runtime Symbol Bindings
 
 The runtime bindings exported by the prelude are all externs collected in nested modules,
@@ -2058,3 +2076,4 @@ Symbols related to thread programming; spawn and with-lock primitives.
     + [rename-in rename-out](#rename-in-rename-out)
     + [prefix-in prefix-out](#prefix-in-prefix-out)
     + [struct-out](#struct-out)
+    + [group-in](#group-in)

--- a/src/gerbil/prelude/core.ss
+++ b/src/gerbil/prelude/core.ss
@@ -3144,6 +3144,29 @@ package: gerbil
                    (cons in r))))))
          (cons begin: (foldl fold-e [] imports))))))
 
+  (defsyntax-for-import (group-in stx)
+    (def (flatten list-of-lists)
+      (foldr (lambda (v acc)
+	           (cond
+	            ((null? v) acc)
+	            ((pair? v) (append (flatten v) acc))
+	            (else (cons v acc))))
+	         []
+	         list-of-lists))
+
+    (def (expand-path top mod)
+      (syntax-case mod ()
+        ((nested mod ...)
+         (map (lambda (mod) (stx-identifier top top "/" mod))
+              (flatten (map (cut expand-path #'nested <>) #'(mod ...)))))
+        (id
+         (identifier? #'id)
+         (stx-identifier top top "/" #'id))))
+
+    (syntax-case stx ()
+      ((_ top mod ...)
+       (cons begin: (flatten (map (cut expand-path #'top <>) #'(mod ...)))))))
+
   (defsyntax-for-export (except-out stx)
     (syntax-case stx ()
       ((_ hd id ...)


### PR DESCRIPTION
This macro was concocted on irc, after chickendan suggested better ergonomics for imports.

You can do
```
(import (group-in :std/misc queue rbtree))
```
and it is equivalent to
```
(import :std/misc/queue :std/misc/rbtree)
```

Nesting also works:
```
(import (group-in :std (misc queue rbtree) (net bio)))
```