### PR TITLE
Allow numbers in group-in components

### DIFF
--- a/doc/reference/core-prelude.md
+++ b/doc/reference/core-prelude.md
@@ -881,7 +881,7 @@ Examples:
 (import (group-in :std (misc queue rbtree) (net bio)))
 = (import :std/misc/queue :std/misc/rbtree :std/net/bio)
 
-(import (group-in :std sugar (srfi |1| |113| |133|)))
+(import (group-in :std sugar (srfi 1 113 133)))
 = (import :std/sugar :std/srfi/1 :std/srfi/113 :std/srfi/133)
 ```
 

--- a/src/gerbil/prelude/core.ss
+++ b/src/gerbil/prelude/core.ss
@@ -3160,7 +3160,7 @@ package: gerbil
          (map (lambda (mod) (stx-identifier top top "/" mod))
               (flatten (map (cut expand-path #'nested <>) #'(mod ...)))))
         (id
-         (identifier? #'id)
+         (or (identifier? #'id) (stx-fixnum? #'id))
          (stx-identifier top top "/" #'id))))
 
     (syntax-case stx ()


### PR DESCRIPTION
It's vexing to have to write `(group-in :std/srfi |1| |2| |3|)` instead of `(group-in :std/srfi 1 2 3)`.