### PR TITLE
Add rassoc function to std/misc/list

### DIFF
--- a/doc/reference/misc.md
+++ b/doc/reference/misc.md
@@ -603,6 +603,31 @@ Removes one layer of a nested proper list.
 
 Removes all nested layers of a proper list.
 
+### rassoc
+``` scheme
+(rassoc elem alist [cmp = eqv?])
+
+  elem  := element to search for in alist
+  alist := association lists
+  cmp   := comparison predicate, optional
+```
+
+Rassoc is similar to assoc, but instead of comparing *elem* with the first
+element of each pair in *alist* the optional predicate *cmp* (which defaults to
+`eqv?`) will compare with the pair's second element.
+
+Returns the first pair in *alist* whose cdr satisfies the predicate *cmp*, or `#f`
+otherwise.
+
+::: tip Examples:
+``` scheme
+(rassoc 2 '((a . 1) (b . 2) (c . 3)))      => (b . 2)
+(rassoc "a" '((1 . "a") (2 . "b")))        => #f (eqv? is used by default)
+(rassoc "a" '((1 . "a") (2 . "b")) equal?) => (1 . "a")
+(rassoc 2 '(1 2 3))                        => #f (not an alist)
+```
+:::
+
 ### when-list-or-empty
 ::: tip usage
 ```

--- a/src/std/misc/list-test.ss
+++ b/src/std/misc/list-test.ss
@@ -106,6 +106,16 @@
       (check-equal? (flatten1 '((1) ((2)) 3)) '(1 (2) 3))
       (check-equal? (flatten1 '(1 2 ())) '(1 2))
       (check-equal? (flatten1 '(1 2 (()))) '(1 2 ())))
+    (test-case "test rassoc"
+      (check-equal? (rassoc 2 '((a . 1) (b . 2) (c . 3))) '(b . 2))
+      (check-equal? (rassoc "a" '((1 . "a") (2 . "b"))) #f)
+      (check-equal? (rassoc "a" '((1 . "a") (2 . "b")) equal?) '(1 . "a"))
+      (check-equal? (rassoc 2 '(1 2 3)) #f)
+      (check-equal? (rassoc 2 '()) #f)
+      (check-equal? (rassoc 3 '((a . 1) (b . 2))) #f)
+      (check-equal? (rassoc 2 '((a . 1) 2 (b . 2))) #f)
+      (check-equal? (rassoc 2 '((a . 1) '() (b . 2))) #f)
+      (check-equal? (rassoc '() '((a . 1) (b . 2))) #f))
     (test-case "test when-list-or-empty"
       (check-equal? (when-list-or-empty [1] "a") "a")
       (check-equal? (when-list-or-empty [] "a") []))))

--- a/src/std/misc/list-test.ss
+++ b/src/std/misc/list-test.ss
@@ -114,7 +114,7 @@
       (check-equal? (rassoc 2 '()) #f)
       (check-equal? (rassoc 3 '((a . 1) (b . 2))) #f)
       (check-equal? (rassoc 2 '((a . 1) 2 (b . 2))) #f)
-      (check-equal? (rassoc 2 '((a . 1) '() (b . 2))) #f)
+      (check-equal? (rassoc 2 '((a . 1) '() (b . 2))) '(b . 2))
       (check-equal? (rassoc '() '((a . 1) (b . 2))) #f))
     (test-case "test when-list-or-empty"
       (check-equal? (when-list-or-empty [1] "a") "a")

--- a/src/std/misc/list.ss
+++ b/src/std/misc/list.ss
@@ -17,6 +17,7 @@ package: std/misc
   push!
   flatten
   flatten1
+  rassoc
   when-list-or-empty)
 
 ;; This function checks if the list is a proper association-list.
@@ -190,6 +191,20 @@ package: std/misc
 	    (else (cons v acc))))
 	 []
 	 list-of-lists))
+
+;; Returns the first pair in alist whose cdr satisfies cmpf, or #f otherwise.
+;; Analog to assoc, but checks cdr instead of car.
+;; (rassoc 2 '((a . 1) (b . 2) (c . 3)))      => (b . 2)
+;; (rassoc "a" '((1 . "a") (2 . "b")))        => #f
+;; (rassoc "a" '((1 . "a") (2 . "b")) equal?) => (1 . "a")
+(def (rassoc x alist (cmpf eqv?))
+  (let loop ((lst alist))
+    (match lst
+      ([(? pair? head) . tail]
+       (if (cmpf x (cdr head))
+         head
+         (loop tail)))
+      (else #f))))
 
 ;; Macro which evaluates the body only if the passed value is
 ;; a non-empty list, otherwise an empty list is returned.


### PR DESCRIPTION
Adding rassoc which is similar to the regular assoc func, but compares cdr instead of car. Allows searching for 2nd pair element (with eqv? as default predicate in this case): `(rassoc 2 '((a . 1) (b . 2) (c . 3))) => (b . 2)`

Inspiration came from rassoc in common lisp: http://clhs.lisp.se/Body/f_rassoc.htm

Furthermore, what do you think about the doc styling? Am I free to apply this style to other undocumented std functions as well?