### PR TITLE
fix: when-list-or-empty documentation and name doesn't match impl

### DIFF
--- a/src/std/misc/list-test.ss
+++ b/src/std/misc/list-test.ss
@@ -117,5 +117,6 @@
       (check-equal? (rassoc 2 '((a . 1) '() (b . 2))) '(b . 2))
       (check-equal? (rassoc '() '((a . 1) (b . 2))) #f))
     (test-case "test when-list-or-empty"
+      (check-equal? (when-list-or-empty 1 "a") [])
       (check-equal? (when-list-or-empty [1] "a") "a")
       (check-equal? (when-list-or-empty [] "a") []))))

--- a/src/std/misc/list.ss
+++ b/src/std/misc/list.ss
@@ -212,4 +212,4 @@ package: std/misc
   ((_ list body body* ...)
    (if (not (pair? list))
      []
-     body body* ...)))
+     (begin body body* ...))))

--- a/src/std/misc/list.ss
+++ b/src/std/misc/list.ss
@@ -210,6 +210,6 @@ package: std/misc
 ;; a non-empty list, otherwise an empty list is returned.
 (defrules when-list-or-empty ()
   ((_ list body body* ...)
-   (if (null? list)
+   (if (not (pair? list))
      []
      body body* ...)))


### PR DESCRIPTION
slight implementation change so that `(when-list-or-empty 10  10)` is longer expands to `10`, but `[]` instead. Docs and name suggest that expansion only happens when input param is a non-empty list.