### PR TITLE
fix std/misc/uuid#string->uuid and confine regex to hex vals

### DIFF
--- a/src/std/misc/uuid.ss
+++ b/src/std/misc/uuid.ss
@@ -52,7 +52,7 @@ package: std/misc
   (pregexp "[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}"))
 
 (def uuid-re-capture
-  (pregexp "([0-9a-z]{8})-([0-9a-z]){4}-([0-9a-z]{4})-([0-9a-z]{4})-([0-9a-z]{12})"))
+  (pregexp "([0-9a-z]{8})-([0-9a-z]{4})-([0-9a-z]{4})-([0-9a-z]{4})-([0-9a-z]{12})"))
 
 (def (text->uuid str)
   (if (pregexp-match uuid-re str)

--- a/src/std/misc/uuid.ss
+++ b/src/std/misc/uuid.ss
@@ -49,10 +49,10 @@ package: std/misc
     (make-uuid hash #f)))
 
 (def uuid-re
-  (pregexp "[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}"))
+  (pregexp "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"))
 
 (def uuid-re-capture
-  (pregexp "([0-9a-z]{8})-([0-9a-z]{4})-([0-9a-z]{4})-([0-9a-z]{4})-([0-9a-z]{12})"))
+  (pregexp "([0-9a-fA-F]{8})-([0-9a-fA-F]{4})-([0-9a-fA-F]{4})-([0-9a-fA-F]{4})-([0-9a-fA-F]{12})"))
 
 (def (text->uuid str)
   (if (pregexp-match uuid-re str)


### PR DESCRIPTION
`(uuid->string (string->uuid "52e1c499-a964-49f1-16cc-583f417eb62f"))` fails right now, because regex captures four single groups.

While we are at it: change regex so that it allows the whole range of hex chars, but discards other alphabet chars.