### PR TITLE
misc: add slice procedure

### DIFF
--- a/doc/reference/misc.md
+++ b/doc/reference/misc.md
@@ -960,6 +960,48 @@ otherwise an empty list is returned.
 ```
 :::
 
+### slice
+``` scheme
+(slice lst start [limit = #f]) -> list
+  lst   := proper list
+  start := start index
+  limit := number of items to take from lst
+```
+
+Returns a list from `lst`, starting from the left at `start`,
+containing `limit` elements.
+
+::: tip Examples:
+``` scheme
+> (slice [1 2 3 4] 2)
+(3 4)
+
+> (slice [1 2 3 4] 2 1)
+(3)
+```
+:::
+
+### slice-right
+``` scheme
+(slice-right lst start [limit = #f]) -> list
+  lst   := proper list
+  start := start index from the right of lst
+  limit := number of items to take from lst
+```
+
+Returns a list from `lst`, starting from the right at `start`,
+containing `limit` elements.
+
+::: tip Examples:
+``` scheme
+> (slice-right [1 2 3 4] 2)
+(1 2)
+
+> (slice-right [1 2 3 4] 2 1)
+(2)
+```
+:::
+
 ## LRU caches
 ::: tip To use the bindings from this module:
 ``` scheme

--- a/src/std/misc/list-test.ss
+++ b/src/std/misc/list-test.ss
@@ -119,4 +119,12 @@
     (test-case "test when-list-or-empty"
       (check-equal? (when-list-or-empty 1 "a") [])
       (check-equal? (when-list-or-empty [1] "a") "a")
-      (check-equal? (when-list-or-empty [] "a") []))))
+      (check-equal? (when-list-or-empty [] "a") []))
+    (test-case "test slice"
+      (check-equal? (slice [1 2 3 4] 2) [3 4])
+      (check-equal? (slice [1 2 3 4] 2 1) [3])
+      (check-equal? (slice [1 2 3 4] 0) [1 2 3 4]))
+    (test-case "test slice-right"
+      (check-equal? (slice-right [1 2 3 4] 2) [1 2])
+      (check-equal? (slice-right [1 2 3 4] 2 1) [2])
+      (check-equal? (slice-right [1 2 3 4] 0) [1 2 3 4]))))

--- a/src/std/misc/list.ss
+++ b/src/std/misc/list.ss
@@ -18,7 +18,10 @@ package: std/misc
   flatten
   flatten1
   rassoc
-  when-list-or-empty)
+  when-list-or-empty
+  slice slice-right)
+
+(import (only-in :std/srfi/1 drop drop-right take take-right))
 
 ;; This function checks if the list is a proper association-list.
 ;; ie it has the form [[key1 . val1] [key2 . val2]]
@@ -213,3 +216,21 @@ package: std/misc
    (if (not (pair? list))
      []
      (begin body body* ...))))
+
+;; Returns a list from lst, starting from the left at start,
+;; containing limit elements.
+;; (slice [1 2 3 4] 2)   => (3 4)
+;; (slice [1 2 3 4] 2 1) => (3)
+(def (slice lst start (limit #f))
+  (if limit
+    (take (drop lst start) limit)
+    (drop lst start)))
+
+;; Returns a list from lst, starting from the right at start,
+;; containing limit elements.
+;; (slice-right [1 2 3 4] 2)   => (1 2)
+;; (slice-right [1 2 3 4] 2 1) => (2)
+(def (slice-right lst start (limit #f))
+  (if limit
+    (take-right (drop-right lst start) limit)
+    (drop-right lst start)))


### PR DESCRIPTION
Some `slice` functions in other languages take as second parameter an optional index. But I like the limit approach more, since it boils down to take-n-elements. The other possible change to this function is that it could take a negative index as first parameter and therefor make the `slice-right` function unnecessary. Again, I like the explicit nature of `slice-right` and think that not too much functionality should be packed into one function.