### PR TITLE
fix: error when trying to print u8vector representation

### DIFF
--- a/src/std/misc/repr.ss
+++ b/src/std/misc/repr.ss
@@ -80,7 +80,7 @@ package: std/misc
 
    ((u8vector? x) ;; u8vector: print as #u8(...), knowing that elements are all bytes.
     (display-separated (u8vector->list x) port
-                       prefix: "#u8(" separator: " " display-element: d suffix: ")"))
+                       prefix: "#u8(" separator: " " suffix: ")"))
 
    ((hash-table? x) ;; hash-table: print as (hash ...)
     (let* ((prefix0


### PR DESCRIPTION
`display-element` procedure is set to `d` which only takes a single arg, but
`display-serarated`'s body provides two. One could also add another optional port to
`d`, same as with `p`, but simply using the default port specified in
`display-separated`'s signature solves it as well.