### PR TITLE
Update MacOS homebrew $PATH instructions

### DIFF
--- a/doc/guide/README.md
+++ b/doc/guide/README.md
@@ -65,7 +65,7 @@ $ brew install gerbil-scheme
 To get around some brew specific paths, set the following in your environment.
 Most likely you'll want to add them to your `~/.bashrc`, `~/.zsh`
 ```
-$ export PATH=/usr/local/opt/gambit-scheme/current/bin:$PATH
+$ export PATH=/usr/local/opt/gambit-scheme/current/bin:/usr/local/opt/gerbil-scheme/libexec/bin:$PATH
 $ export GERBIL_HOME=/usr/local/opt/gerbil-scheme/libexec
 ```
 


### PR DESCRIPTION
Fix gxi failing with:
*** ERROR IN ##main -- No such file or directory
(load "/usr/local/lib/gxi-init")
in Homebrew 2.1.6 MacOS 10.14.5