### PR TITLE
do not break when git cannot find any tags

### DIFF
--- a/src/gerbil/runtime/build.scm
+++ b/src/gerbil/runtime/build.scm
@@ -36,7 +36,7 @@
   (let* ((gx-version-path "gx-version.scm")
          (git-version
           (and (file-exists? "../../../.git")
-               (let* ((proc (open-process '(path: "git" arguments: ("describe" "--tags")
+               (let* ((proc (open-process '(path: "git" arguments: ("describe" "--tags" "--always")
                                                   show-console: #f)))
                       (version (read-line proc)))
                  (and (zero? (process-status proc))


### PR DESCRIPTION
In some cases (such building from a shallow clone created with `git clone --depth=1`) the command `git describe --tags` can fail. And then the `gx-version.scm` file is not created and then the whole build fails. Adding an `--always` parameter allows to continue the build.