### PR TITLE
use seq-subseq in gerbil-send-string function

### DIFF
--- a/etc/gerbil.el
+++ b/etc/gerbil.el
@@ -33,7 +33,7 @@
         (string-len (length string)))
     (comint-check-source string)
     (comint-send-string (scheme-proc) string)
-    (gerbil-message (subseq string 0 (string-match "\n" string)))))
+    (gerbil-message (seq-subseq string 0 (string-match "\n" string)))))
 
 ;; -------
 


### PR DESCRIPTION
subseq is not defined on emacs 26.2 by default so use seq-subseq instead. This
is defined in seq.el and workes without additional require statements.

I'm not sure about backwards compatibility of using seq.el regarding older emacs versions.

Fixes #278 