### PR TITLE
New u8vector->uint function, delimiter param to u8vector->bytestring.

### DIFF
--- a/doc/reference/misc.md
+++ b/doc/reference/misc.md
@@ -463,15 +463,16 @@ Alias for `u8vector-reverse!`.
 
 ### u8vector->bytestring
 ``` scheme
-(u8vector->bytestring v) -> bytestring
+(u8vector->bytestring v (delim " ")) -> bytestring
 
   v := u8vector
+  delim := string
 ```
 
 Constructs a string of bytes in hexadecimal from `u8vector` *v*.
 
 Each byte is formatted as two uppercase hex characters using `std/format`
-and separated using `#\space` as a delimiter.
+and separated using `" "` as a delimiter.
 
 ::: tip Examples:
 ``` scheme
@@ -479,6 +480,8 @@ and separated using `#\space` as a delimiter.
 "FF 7F 0B 01 00"
 > (displayln (u8vector->bytestring (u8vector 255 127 11 1 0)))
 FF 7F 0B 01 00
+> (u8vector->bytestring (u8vector 1 2 3) "")
+"010203"
 ```
 :::
 
@@ -507,6 +510,46 @@ which assumes an encoding.
 #u8(70 70 32 65 66 32 48 48)
 ```
 :::
+
+### u8vector->uint
+``` scheme
+(u8vector->uint v (guard #t)) -> uint | void
+
+  v := u8vector
+  guard := boolean
+```
+
+Computes the `uint` representation of `u8vector` *v* for vector length up to 8.
+
+If *guard* is `#t` raises an exception on vectors of length greater than 8.
+
+If *guard* is `#f`, computation on longer vectors is allowed to proceed.
+
+::: tip Examples:
+``` scheme
+> (u8vector->uint #u8(0 1))
+1
+> (u8vector->uint (make-u8vector 2 #xFF))
+65535
+> (u8vector->uint (make-u8vector 8 #xFF))
+18446744073709551615
+> (equal? (- (expt 2 64) 1) (u8vector->uint (make-u8vector 8 #xFF)))
+#t
+> (u8vector->uint (make-u8vector 10 #xFF))
+*** ERROR IN (console)@7.1 -- Disable guard to compute on u8vectors of length > 8. #u8(255 255 255 255 255 255 255 255 255 255)
+> (u8vector->uint (make-u8vector 10 #xFF) #f)
+1208925819614629174706175
+> (equal? (- (expt 2 80) 1) (u8vector->uint (make-u8vector 10 #xFF) #f))
+#t
+```
+:::
+
+### bytevector->uint
+``` scheme
+(define-alias bytevector->uint u8vector->uint)
+```
+
+Alias for `u8vector->uint`.
 
 
 ## Asynchronous Completions

--- a/src/std/misc/bytes-test.ss
+++ b/src/std/misc/bytes-test.ss
@@ -4,6 +4,7 @@
 ;;; :std/misc/bytes test
 
 (import :std/test
+        (only-in :std/sugar try catch)
         :gerbil/gambit/exceptions
         :std/misc/bytes)
 (export bytes-test)
@@ -19,8 +20,14 @@
 (def u2 (u8vector 255 127 11 1 0))
 (def u2-bytestring "FF 7F 0B 01 00")
 
+(def u3 (u8vector 1 2 3))
+(def u3-bytestring "010203")
+
 (def bs0 "AB CD 00 12")
 (def bs0-u8vector (u8vector #xAB #xCD #x00 #x12))
+
+(def u4 (u8vector #xFF #xFF))
+(def u5 (make-u8vector 10 #xFF))
 
 (def bytes-test
   (test-suite "test :std/misc/bytes"
@@ -29,6 +36,11 @@
     (test-case "test bytevector-reverse!"
       (check-equal? (u1-reverse) u1-reversed))
     (test-case "test u8vector->bytestring"
-      (check-equal? (u8vector->bytestring u2) u2-bytestring))
+      (check-equal? (u8vector->bytestring u2) u2-bytestring)
+      (check-equal? (u8vector->bytestring u3 "") u3-bytestring))
     (test-case "test bytestring->u8vector"
-      (check-equal? (bytestring->u8vector bs0) bs0-u8vector))))
+      (check-equal? (bytestring->u8vector bs0) bs0-u8vector))
+    (test-case "test u8vector->uint"
+      (check-equal? (u8vector->uint u4) (- (expt 2 16) 1))
+      (check-equal? (try (u8vector->uint u5) (catch (e) #f)) #f)
+      (check-equal? (u8vector->uint u5 #f) (- (expt 2 80) 1)))))


### PR DESCRIPTION
Added a `delim` string parameter to `u8vector->bytestring`. I am still not sure if I want to use strings or chars. Note that `bytestring->u8vector` only accepts a character as delimiter. These functions should be allowed to cancel each other, which is currently not generally the case. It works well for my current needs.

New `u8vector->uint` function. There is a `guard` parameter to prevent runaway execution on vectors of length > 8. Setting `guard` to `#f` allows to compute large uints.

I have run some small benchmarks here: https://gist.github.com/belmarca/75360c45a61d450f29c5f85c1a9e0f58. It appears the function in the current PR is the fastest.