### PR TITLE
Raise an error when in-range arguments are not integers.

### DIFF
--- a/src/std/iter-test.ss
+++ b/src/std/iter-test.ss
@@ -3,7 +3,9 @@
 ;;; :std/iter unit-tests
 
 (import :std/test
-        :std/iter)
+        :std/iter
+        (only-in :std/sugar hash)
+        (only-in :gerbil/core error-object? with-catch))
 (export iter-test)
 
 (def (my-generator n)
@@ -45,7 +47,15 @@
       (def (test-for-6)
         (for (x (my-generator 3))
           (displayln x)))
-      (check-output (test-for-6) "0\n1\n2\n"))
+      (check-output (test-for-6) "0\n1\n2\n")
+
+      (def (test-for-7)
+        (for (x (in-range (hash (a 1) (b 2) (c 3))))
+          (displayln x)))
+      (check-equal? (with-catch
+                     (lambda (e) (error-object? e))
+                     test-for-7)
+        #t))
 
     (test-case "test folding macros"
       (def (test-for/collect-0)

--- a/src/std/iter-test.ss
+++ b/src/std/iter-test.ss
@@ -53,7 +53,7 @@
         (for (x (in-range (hash (a 1) (b 2) (c 3))))
           (displayln x)))
       (check-equal? (with-catch
-                     (lambda (e) (error-object? e))
+                     error-object?
                      test-for-7)
         #t))
 

--- a/src/std/iter.ss
+++ b/src/std/iter.ss
@@ -129,7 +129,9 @@ package: std
             (set! (cdr e) (##fx- limit 1))
             value)
           iter-end))))
-  (make-iterator (cons start count) next))
+  (if (andmap integer? [start count step])
+    (make-iterator (cons start count) next)
+    (error "Parameters start, count and step must be integers." [start count step])))
 
 (def* in-range
   ((count) (iter-in-range 0 count 1))

--- a/src/std/iter.ss
+++ b/src/std/iter.ss
@@ -129,9 +129,10 @@ package: std
             (set! (cdr e) (##fx- limit 1))
             value)
           iter-end))))
-  (if (andmap integer? [start count step])
+  (if (and (number? start) (integer? count) (number? step))
     (make-iterator (cons start count) next)
-    (error "Parameters start, count and step must be integers." [start count step])))
+    (error "Parameters are of wrong type (count:number start:integer step:number)."
+      [count start step])))
 
 (def* in-range
   ((count) (iter-in-range 0 count 1))


### PR DESCRIPTION
This PR fixes https://github.com/vyzo/gerbil/issues/296.

However I believe this warrants a somewhat larger discussion about error handling/type checking.

First of all, this is an explicit run-time type check. From my limited understanding, this code will be compiled as-is. I.e. Gambit will handle types on its own and then at run-time the `in-range` function will do its own type checking - always. Can we structure the code such that the run-time check is performed at compile-time by gambit?

Secondly, is there a cleaner/simpler way to add such checks to functions?

Lastly, these checks could be used in a lot of different places in the code. Is it desirable to do so or should we let the programmer handle it?

I am asking these questions as a somewhat naive Scheme programmer.