### PR TITLE
Standard syntax utilities

### DIFF
--- a/doc/.vuepress/config.js
+++ b/doc/.vuepress/config.js
@@ -28,7 +28,7 @@ module.exports = {
             {
               collapsable: false,
               title: 'Gerbil Reference',
-              children:  ['', 'core-prelude', 'core-builtin', 'core-expander', 'stdlib', 'sugar', 'errors', 'getopt', 'format', 'logger', 'sort', 'regexp', 'generic', 'ref', 'iterators', 'coroutine', 'events', 'actor', 'requests', 'httpd', 'web', 'db', 'kvstore', 'sockets', 'net', 'protobuf', 'os', 'crypto', 'text', 'xml', 'parser', 'misc', 'lazy', 'amb', 'stxparam', 'foreign', 'srfi', 'test', 'debug', 'make']
+              children:  ['', 'core-prelude', 'core-builtin', 'core-expander', 'stdlib', 'sugar', 'errors', 'getopt', 'format', 'logger', 'sort', 'regexp', 'generic', 'ref', 'iterators', 'coroutine', 'events', 'actor', 'requests', 'httpd', 'web', 'db', 'kvstore', 'sockets', 'net', 'protobuf', 'os', 'crypto', 'text', 'xml', 'parser', 'misc', 'lazy', 'amb', 'stxparam', 'stxutil', 'foreign', 'srfi', 'test', 'debug', 'make']
             }
           ]
         },

--- a/doc/reference/stxutil.md
+++ b/doc/reference/stxutil.md
@@ -1,0 +1,32 @@
+# Syntax Utilities
+
+Utilities for expanders.
+
+::: tip To use the bindings from this module:
+``` scheme
+(import (for-syntax :std/stxutil))
+```
+:::
+
+## format-id
+```scheme
+(format-id ctx fmt arg ...) -> identifier
+
+  ctx := context identifier
+  fmt := a format string, as in :std/format
+  arg := a format argument; syntax objects are automatically unwrapped
+```
+
+Formats an identifier, using `fmt` as the format string and `ctx` as the syntactic context.
+
+::: tip Examples:
+```scheme
+(import (for-syntax :std/stxutil))
+(defsyntax (make-pred stx)
+  (syntax-case stx ()
+    ((_ id) (format-id #'id "~a?" #'id))))
+
+> (make-pred pair)
+=> #<procedure #8 pair?>
+```
+:::

--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -22,6 +22,7 @@
     "iter"
     "test"
     "stxparam"
+    "stxutil"
     "lazy"
     "amb"
     ;; debugging

--- a/src/std/stxutil.ss
+++ b/src/std/stxutil.ss
@@ -1,0 +1,16 @@
+;;; -*- Gerbil -*-
+;;; © vyzo
+;;; syntax utilities; import for-syntax
+package: std
+
+(import <expander-runtime>
+        :std/format)
+(export #t)
+
+;; format an identifier; see also stx-identifier
+;; ctx := template identifier
+;; fmt := format string
+;; args := format arguments, may be syntax objects
+(def (format-id ctx fmt . args)
+  (datum->syntax ctx (string->symbol (apply format fmt (map stx-e args)))
+                 (stx-source ctx)))


### PR DESCRIPTION
New module, `:std/stxutil`.
Just `format-id` for now, but we expect it to grow.