### PR TITLE
fix: in-range not handling negative stepping

### DIFF
--- a/doc/reference/iterators.md
+++ b/doc/reference/iterators.md
@@ -125,7 +125,8 @@ and incrementing by `step`.
 :::
 
 Creates an iterator that starts with a current value of `start` (default `0`),
-stops when the current value is greater or equal to `end`,
+stops when the current value is greater or equal to `end`
+(smaller or equal to `end` in case `step` is negative),
 increments the current value by `step` at each iteration (default `1`),
 returns at each iteration the current value before incrementation.
 

--- a/src/std/iter-test.ss
+++ b/src/std/iter-test.ss
@@ -59,17 +59,22 @@
           (displayln x)))
       (check-output (test-for-5-in-range) "5\n7\n9\n")
 
-      (def (test-for-6)
-        (for (x (my-generator 3))
+      (def (test-for-6-in-range)
+        (for (x (in-range 7 4 -1))
           (displayln x)))
-      (check-output (test-for-6) "0\n1\n2\n")
+      (check-output (test-for-6-in-range) "7\n6\n5\n")
 
       (def (test-for-7)
+        (for (x (my-generator 3))
+          (displayln x)))
+      (check-output (test-for-7) "0\n1\n2\n")
+
+      (def (test-for-8)
         (for (x (in-range (hash (a 1) (b 2) (c 3))))
           (displayln x)))
       (check-equal? (with-catch
                      error-object?
-                     test-for-7)
+                     test-for-8)
         #t))
 
     (test-case "test folding macros"
@@ -99,6 +104,14 @@
       (def (test-for/collect-3)
         (for/collect (x (my-generator 3)) x))
       (check (test-for/collect-3) => '(0 1 2))
+
+      (def (test-for/collect-4)
+        (for/collect (x (in-range 3 5 -1)) x))
+      (check (test-for/collect-4) => '())
+
+      (def (test-for/collect-5)
+        (for/collect (x (in-range 5 3)) x))
+      (check (test-for/collect-5) => '())
 
       (def (test-for/fold-1)
         (for/fold (r []) ((x '(1 2 3)))

--- a/src/std/iter-test.ss
+++ b/src/std/iter-test.ss
@@ -69,13 +69,10 @@
           (displayln x)))
       (check-output (test-for-7) "0\n1\n2\n")
 
-      (def (test-for-8)
+      (def (test-for-8-not-real)
         (for (x (in-range (hash (a 1) (b 2) (c 3))))
           (displayln x)))
-      (check-equal? (with-catch
-                     error-object?
-                     test-for-8)
-        #t))
+      (check-equal? (with-catch exception? test-for-8-not-real) #t))
 
     (test-case "test folding macros"
       (def (test-for/collect-0)
@@ -109,9 +106,17 @@
         (for/collect (x (in-range 3 5 -1)) x))
       (check (test-for/collect-4-up-by-neg) => '())
 
-      (def (test-for/collect-5-down-by-pos)
+      (def (test-for/collect-4-down-by-pos)
+        (for/collect (x (in-range 5 3 1)) x))
+      (check (test-for/collect-4-down-by-pos) => '())
+
+      (def (test-for/collect-5-down-inference-neg)
         (for/collect (x (in-range 5 3)) x))
-      (check (test-for/collect-5-down-by-pos) => '())
+      (check (test-for/collect-5-down-inference-neg) => '(5 4))
+
+      (def (test-for/collect-6-same-start-end)
+        (for/collect (x (in-range 5 5)) x))
+      (check (test-for/collect-6-same-start-end) => '())
 
       (def (test-for/fold-1)
         (for/fold (r []) ((x '(1 2 3)))

--- a/src/std/iter-test.ss
+++ b/src/std/iter-test.ss
@@ -59,10 +59,10 @@
           (displayln x)))
       (check-output (test-for-5-in-range) "5\n7\n9\n")
 
-      (def (test-for-6-in-range)
+      (def (test-for-6-in-range-by-neg)
         (for (x (in-range 7 4 -1))
           (displayln x)))
-      (check-output (test-for-6-in-range) "7\n6\n5\n")
+      (check-output (test-for-6-in-range-by-neg) "7\n6\n5\n")
 
       (def (test-for-7)
         (for (x (my-generator 3))
@@ -105,13 +105,13 @@
         (for/collect (x (my-generator 3)) x))
       (check (test-for/collect-3) => '(0 1 2))
 
-      (def (test-for/collect-4)
+      (def (test-for/collect-4-up-by-neg)
         (for/collect (x (in-range 3 5 -1)) x))
-      (check (test-for/collect-4) => '())
+      (check (test-for/collect-4-up-by-neg) => '())
 
-      (def (test-for/collect-5)
+      (def (test-for/collect-5-down-by-pos)
         (for/collect (x (in-range 5 3)) x))
-      (check (test-for/collect-5) => '())
+      (check (test-for/collect-5-down-by-pos) => '())
 
       (def (test-for/fold-1)
         (for/fold (r []) ((x '(1 2 3)))

--- a/src/std/iter.ss
+++ b/src/std/iter.ss
@@ -140,17 +140,18 @@ package: std
   ((count start step) (iter-in-iota start count step)))
 
 (def (iter-in-range start end step)
+  (unless (and (real? start) (real? end) (real? step))
+    (error "Parameters are of wrong type (start:real end:real step:real)."
+      [start end step]))
+  (def cmp (if (##negative? step) ##> ##<))
   (def (next it)
     (with ((iterator e) it)
-      (if (< e end)
+      (if (cmp e end)
         (begin
-          (set! (&iterator-e it) (+ e step))
+          (set! (&iterator-e it) (##+ e step))
           e)
         iter-end)))
-  (if (and (real? start) (real? end) (real? step))
-    (make-iterator start next)
-    (error "Parameters are of wrong type (start:real end:real step:real)."
-      [start end step])))
+  (make-iterator start next))
 
 (def* in-range
   ((end) (iter-in-range 0 end 1))

--- a/src/std/iter.ss
+++ b/src/std/iter.ss
@@ -143,12 +143,12 @@ package: std
   (unless (and (real? start) (real? end) (real? step))
     (error "Parameters are of wrong type (start:real end:real step:real)."
       [start end step]))
-  (def cmp (if (##negative? step) ##> ##<))
+  (def cmp (if (negative? step) > <))
   (def (next it)
     (with ((iterator e) it)
       (if (cmp e end)
         (begin
-          (set! (&iterator-e it) (##+ e step))
+          (set! (&iterator-e it) (+ e step))
           e)
         iter-end)))
   (make-iterator start next))

--- a/src/std/iter.ss
+++ b/src/std/iter.ss
@@ -139,11 +139,7 @@ package: std
   ((count start) (iter-in-iota start count 1))
   ((count start step) (iter-in-iota start count step)))
 
-(def (iter-in-range start end step)
-  (unless (and (real? start) (real? end) (real? step))
-    (error "Parameters are of wrong type (start:real end:real step:real)."
-      [start end step]))
-  (def cmp (if (negative? step) > <))
+(def (iter-in-range start end (step 1) (cmp <))
   (def (next it)
     (with ((iterator e) it)
       (if (cmp e end)
@@ -154,9 +150,15 @@ package: std
   (make-iterator start next))
 
 (def* in-range
-  ((end) (iter-in-range 0 end 1))
-  ((start end) (iter-in-range start end 1))
-  ((start end step) (iter-in-range start end step)))
+  ((end) (iter-in-range 0 end))
+  ((start end)
+   (if (> start end)
+     (iter-in-range start end -1 >)
+     (iter-in-range start end)))
+  ((start end step)
+   (if (negative? step)
+     (iter-in-range start end step >)
+     (iter-in-range start end step <))))
 
 (def (in-naturals (start 0) (step 1))
   (def (next it)

--- a/src/std/iter.ss
+++ b/src/std/iter.ss
@@ -139,7 +139,7 @@ package: std
   ((count start) (iter-in-iota start count 1))
   ((count start step) (iter-in-iota start count step)))
 
-(def (iter-in-range start end (step 1) (cmp <))
+(def (iter-in-range start end step cmp)
   (def (next it)
     (with ((iterator e) it)
       (if (cmp e end)
@@ -150,11 +150,11 @@ package: std
   (make-iterator start next))
 
 (def* in-range
-  ((end) (iter-in-range 0 end))
+  ((end) (iter-in-range 0 end 1 <))
   ((start end)
    (if (> start end)
      (iter-in-range start end -1 >)
-     (iter-in-range start end)))
+     (iter-in-range start end  1 <)))
   ((start end step)
    (if (negative? step)
      (iter-in-range start end step >)


### PR DESCRIPTION
this patch matches racket's behaviour, so no negative step inference in case of `(in-range 5 3)`.

Note: `(for (x (in-range 3 5 -1)) (displayln x))` no longer loops indefinitely.