### PR TITLE
Set GERBIL_HOME in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN sed -i -e 's/leveldb #f/leveldb #t/g' /root/gerbil/src/std/build-features.ss
 RUN sed -i -e 's/lmdb #f/lmdb #t/g' /root/gerbil/src/std/build-features.ss
 RUN cd /root/gerbil/src && ./build.sh
 
+ENV GERBIL_HOME "/root/gerbil"
 ENV PATH "/root/gerbil/bin:$PATH"
 
 CMD ["gxi"]


### PR DESCRIPTION
In the current `gerbil/scheme` container:

```
# cd
# pwd
/root
# which gxpkg
/root/gerbil/bin/gxpkg
# gxpkg
*** ERROR IN _gx#load-runtime! -- Cannot determine GERBIL_HOME
# export GERBIL_HOME=/root/gerbil
# gxpkg
Error: Missing command

Usage: gxpkg  <command> command-arg ...
```

Not sure whether or not this has to do with changing PATH a few days ago in PR #317. But by setting GERBIL_HOME explicitly, things work.