### PR TITLE
Refactor stdlib to use format-id instead of stx-identifier.

### DIFF
--- a/src/std/actor/proto.ss
+++ b/src/std/actor/proto.ss
@@ -14,7 +14,8 @@ package: std/actor
         :std/misc/uuid
         :std/misc/completion
         :std/actor/message
-        :std/actor/xdr)
+        :std/actor/xdr
+        (for-syntax :std/stxutil))
 (export
   rpc-io-error? raise-rpc-io-error
   (struct-out actor-error remote-error rpc-error)
@@ -353,11 +354,11 @@ package: std/actor
 
   (def (generate-make-proto-info proto-id id extend calls events streams)
     (def (type-id id)
-      (stx-identifier proto-id proto-id "." id))
+      (format-id proto-id "~a.~a" proto-id id))
 
     (with-syntax* ((proto-id proto-id)
                    (id id)
-                   (proto::proto (stx-identifier #'proto-id #'proto-id "::proto"))
+                   (proto::proto (format-id #'proto-id "~a::proto" #'proto-id))
                    ((extend-id ...) extend)
                    ((call-id ...) (map type-id (map stx-car calls)))
                    ((event-id ...) (map type-id (map stx-car events)))
@@ -373,7 +374,7 @@ package: std/actor
   (def (generate-make-proto-registry proto-id id extend)
     (with-syntax*
         ((id id)
-         (proto::proto          (stx-identifier proto-id proto-id "::proto"))
+         (proto::proto          (format-id proto-id "~a::proto" proto-id))
          ((values extend-infos) (map syntax-local-value extend))
          ((extend::proto ...)   (map protocol-info-runtime-identifier extend-infos))
          (make-proto
@@ -396,17 +397,17 @@ package: std/actor
     (with-syntax*
         ((id id)
          ((call-id arg ...) call-spec)
-         (kall-id        (stx-identifier #'call-id proto-id "." #'call-id))
-         (kall-rt-id     (stx-identifier #'call-id #'id "." #'call-id "::t"))
-         (make-kall      (stx-identifier #'call-id "make-" #'kall-id))
-         (kall::t        (stx-identifier #'call-id #'kall-id "::t"))
-         (kall?          (stx-identifier #'call-id #'kall-id "?"))
-         (kall::xdr      (stx-identifier #'call-id #'kall-id "::xdr"))
-         (kall-xdr-read  (stx-identifier #'call-id "xdr-" #'kall-id "-read"))
-         (kall-xdr-write (stx-identifier #'call-id "xdr-" #'kall-id "-write"))
-         (!kall          (stx-identifier #'call-id "!" #'kall-id))
-         (!!kall         (stx-identifier #'call-id "!!" #'kall-id))
-         (proto::proto   (stx-identifier proto-id proto-id "::proto"))
+         (kall-id        (format-id #'call-id "~a.~a" proto-id #'call-id))
+         (kall-rt-id     (format-id #'call-id "~a.~a::t" #'id #'call-id))
+         (make-kall      (format-id #'call-id "make-~a" #'kall-id))
+         (kall::t        (format-id #'call-id "~a::t" #'kall-id))
+         (kall?          (format-id #'call-id "~a?" #'kall-id))
+         (kall::xdr      (format-id #'call-id "~a::xdr" #'kall-id))
+         (kall-xdr-read  (format-id #'call-id "xdr-~a-read" #'kall-id))
+         (kall-xdr-write (format-id #'call-id "xdr-~a-write" #'kall-id))
+         (!kall          (format-id #'call-id "!~a" #'kall-id))
+         (!!kall         (format-id #'call-id "!!~a" #'kall-id))
+         (proto::proto   (format-id proto-id "~a::proto" proto-id))
          (defn-kall
            #'(defstruct kall-id (arg ...) id: kall-rt-id final: #t))
          (defn-!kall
@@ -442,17 +443,17 @@ package: std/actor
     (with-syntax*
         ((id id)
          ((event-id arg ...) event-spec)
-         (kall-id        (stx-identifier #'event-id proto-id "." #'event-id))
-         (kall-rt-id     (stx-identifier #'event-id #'id "." #'event-id "::t"))
-         (make-kall      (stx-identifier #'event-id "make-" #'kall-id))
-         (kall::t        (stx-identifier #'event-id #'kall-id "::t"))
-         (kall?          (stx-identifier #'event-id #'kall-id "?"))
-         (kall::xdr      (stx-identifier #'event-id #'kall-id "::xdr"))
-         (kall-xdr-read  (stx-identifier #'event-id "xdr-" #'kall-id "-read"))
-         (kall-xdr-write (stx-identifier #'event-id "xdr-" #'kall-id "-write"))
-         (!kall          (stx-identifier #'event-id "!" #'kall-id))
-         (!!kall         (stx-identifier #'event-id "!!" #'kall-id))
-         (proto::proto   (stx-identifier proto-id proto-id "::proto"))
+         (kall-id        (format-id #'event-id "~a.~a" proto-id #'event-id))
+         (kall-rt-id     (format-id #'event-id "~a.~a::t" #'id #'event-id))
+         (make-kall      (format-id #'event-id "make-~a" #'kall-id))
+         (kall::t        (format-id #'event-id "~a::t" #'kall-id))
+         (kall?          (format-id #'event-id "~a?" #'kall-id))
+         (kall::xdr      (format-id #'event-id "~a::xdr" #'kall-id))
+         (kall-xdr-read  (format-id #'event-id "xdr-~a-read" #'kall-id))
+         (kall-xdr-write (format-id #'event-id "xdr-~a-write" #'kall-id))
+         (!kall          (format-id #'event-id "!~a" #'kall-id))
+         (!!kall         (format-id #'event-id "!!~a" #'kall-id))
+         (proto::proto   (format-id proto-id "~a::proto" proto-id))
          (defn-kall
            #'(defstruct kall-id (arg ...) id: kall-rt-id final: #t))
          (defn-!kall
@@ -486,17 +487,17 @@ package: std/actor
     (with-syntax*
         ((id id)
          ((call-id arg ...) stream-spec)
-         (kall-id        (stx-identifier #'call-id proto-id "." #'call-id))
-         (kall-rt-id     (stx-identifier #'call-id #'id "." #'call-id "::t"))
-         (make-kall      (stx-identifier #'call-id "make-" #'kall-id))
-         (kall::t        (stx-identifier #'call-id #'kall-id "::t"))
-         (kall?          (stx-identifier #'call-id #'kall-id "?"))
-         (kall::xdr      (stx-identifier #'call-id #'kall-id "::xdr"))
-         (kall-xdr-read  (stx-identifier #'call-id "xdr-" #'kall-id "-read"))
-         (kall-xdr-write (stx-identifier #'call-id "xdr-" #'kall-id "-write"))
-         (!kall          (stx-identifier #'call-id "!" #'kall-id))
-         (!!kall         (stx-identifier #'call-id "!!" #'kall-id))
-         (proto::proto   (stx-identifier proto-id proto-id "::proto"))
+         (kall-id        (format-id #'call-id "~a.~a" proto-id #'call-id))
+         (kall-rt-id     (format-id #'call-id "~a.~a::t" #'id #'call-id))
+         (make-kall      (format-id #'call-id "make-~a" #'kall-id))
+         (kall::t        (format-id #'call-id "~a::t" #'kall-id))
+         (kall?          (format-id #'call-id "~a?" #'kall-id))
+         (kall::xdr      (format-id #'call-id "~a::xdr" #'kall-id))
+         (kall-xdr-read  (format-id #'call-id "xdr-~a-read" #'kall-id))
+         (kall-xdr-write (format-id #'call-id "xdr-~a-write" #'kall-id))
+         (!kall          (format-id #'call-id "!~a" #'kall-id))
+         (!!kall         (format-id #'call-id "!!~a" #'kall-id))
+         (proto::proto   (format-id proto-id "~a::proto" proto-id))
          (defn-kall
            #'(defstruct kall-id (arg ...) id: kall-rt-id final: #t))
          (defn-!kall
@@ -533,7 +534,7 @@ package: std/actor
       ((struct-id struct-xdr-read structu-xdr-write)
        (with-syntax* (((values info) (syntax-local-value #'struct-id))
                       (struct::t     (runtime-type-identifier info))
-                      (proto::proto  (stx-identifier proto-id proto-id "::proto")))
+                      (proto::proto  (format-id proto-id "~a::proto" proto-id)))
          #'(hash-put! (!protocol-types proto::proto)
                       (##type-id struct::t)
                       (make-XDR struct-xdr-read struct-xdr-write))))
@@ -541,7 +542,7 @@ package: std/actor
        (with-syntax*
            (((values info) (syntax-local-value #'struct-id))
             (struct::t     (runtime-type-identifier info))
-            (proto::proto  (stx-identifier proto-id proto-id "::proto")))
+            (proto::proto  (format-id proto-id "~a::proto" proto-id)))
          #'(begin
              (hash-put! (!protocol-types proto::proto)
                         (##type-id struct::t)
@@ -558,10 +559,10 @@ package: std/actor
     (if (module-context? (current-expander-context))
       (cond
        ((module-context-ns (current-expander-context))
-        => (lambda (ns) (stx-identifier proto-id ns "#" proto-id)))
+        => (lambda (ns) (format-id proto-id "~a#~a" ns proto-id)))
        (else
         (let (mid (expander-context-id (current-expander-context)))
-          (stx-identifier proto-id mid "#" proto-id))))
+          (format-id proto-id "~a#~a" mid proto-id))))
       (genident proto-id)))
 
   (syntax-case stx ()
@@ -597,8 +598,8 @@ package: std/actor
         ([id . rest]
          (lp rest
              (cons* ['struct-out id]
-                    (stx-identifier id "!" id)
-                    (stx-identifier id "!!" id)
+                    (format-id id "!~a" id)
+                    (format-id id "!!~a" id)
                     mids)))
         (else mids))))
 

--- a/src/std/crypto/cipher.ss
+++ b/src/std/crypto/cipher.ss
@@ -6,7 +6,8 @@ package: std/crypto
 (import :gerbil/gambit/ports
         :std/text/utf8
         :std/crypto/libcrypto
-        :std/crypto/etc)
+        :std/crypto/etc
+        (for-syntax :std/stxutil))
 
 (export
   cipher make-cipher cipher? cipher-type cipher-ctx cipher-context
@@ -221,35 +222,35 @@ package: std/crypto
           ((evp-cipher
             (cond
              (len
-              (stx-identifier name "EVP_" name "_" len "_" mode))
+              (format-id name "EVP_~a_~a_~a" name len mode))
              (mode
-              (stx-identifier name "EVP_" name "_" mode))
+              (format-id name "EVP_~a_~a" name mode))
              (else
-              (stx-identifier name "EVP_" name))))
+              (format-id name "EVP_~a" name))))
            (cipher-t
             (cond
              (len
-              (stx-identifier name "cipher::" name "-" len "-" mode))
+              (format-id name "cipher::~a-~a-~a" name len mode))
              (mode
-              (stx-identifier name "cipher::" name "-" mode))
+              (format-id name "cipher::~a-~a" name mode))
              (else
-              (stx-identifier name "cipher::" name))))
+              (format-id name "cipher::~a" name))))
            (make-cipher-t
             (cond
              (len
-              (stx-identifier name "make-" name "-" len "-" mode "-cipher"))
+              (format-id name "make-~a-~a-~a-cipher" name len mode))
              (mode
-              (stx-identifier name "make-" name "-" mode "-cipher"))
+              (format-id name "make-~a-~a-cipher" name mode))
              (else
-              (stx-identifier name "make-" name "-cipher"))))
+              (format-id name "make-~a-cipher" name))))
            (cipher-t?
             (cond
              (len
-              (stx-identifier name name "-" len "-" mode "-cipher?"))
+              (format-id name "~a-~a-~a-cipher?" name len mode))
              (mode
-              (stx-identifier name name "-" mode "-cipher?"))
+              (format-id name "~a-~a-cipher?" name mode))
              (else
-              (stx-identifier name name "-cipher?")))))
+              (format-id name "~a-cipher?" name)))))
         #'(begin
             (def cipher-t (evp-cipher))
             (def (make-cipher-t)

--- a/src/std/crypto/digest.ss
+++ b/src/std/crypto/digest.ss
@@ -4,7 +4,8 @@
 package: std/crypto
 
 (import :std/crypto/libcrypto
-        :std/crypto/etc)
+        :std/crypto/etc
+        (for-syntax :std/stxutil))
 
 (export make-digest digest? digest-update! digest-update* digest-final!
         digest-size digest-name digest-copy)
@@ -68,10 +69,10 @@ package: std/crypto
   (syntax-case stx ()
     ((_ name)
      (with-syntax
-         ((digest-md-t (stx-identifier #'name "digest::" #'name))
-          (digest-md (stx-identifier #'name "EVP_" #'name))
-          (make-digest-t (stx-identifier #'name "make-" #'name "-digest"))
-          (digest-t? (stx-identifier #'name #'name "-digest?")))
+         ((digest-md-t   (format-id #'name "digest::~a" #'name))
+          (digest-md     (format-id #'name "EVP_~a" #'name))
+          (make-digest-t (format-id #'name "make-~a-digest" #'name))
+          (digest-t?     (format-id #'name "~a-digest?" #'name)))
        #'(begin
            (def digest-md-t (digest-md))
            (def (make-digest-t)

--- a/src/std/generic/macros.ss
+++ b/src/std/generic/macros.ss
@@ -4,6 +4,7 @@
 package: std/generic
 
 (import :std/generic/dispatch
+        (for-syntax :std/stxutil)
         (rename-in <MOP> (defmethod defmethod~)))
 (export #t (phi: +1 #t))
 
@@ -17,11 +18,11 @@ package: std/generic
   (def (generate-generic id default)
     (with-syntax* ((id id)
                    (default default)
-                   (dispatch-table-id (stx-identifier #'id #'id "::t"))
+                   (dispatch-table-id (format-id #'id "~a::t" #'id))
                    (dispatch-table
                     #'(def dispatch-table-id
                         (make-generic 'id default)))
-                   (procedure-id (stx-identifier #'id #'id "::apply"))
+                   (procedure-id (format-id #'id "~a::apply" #'id))
                    (procedure
                     (syntax/loc stx
                       (def (procedure-id . args)
@@ -56,7 +57,7 @@ package: std/generic
 (defsyntax (defbuiltin-type stx)
   (syntax-case stx ()
     ((_ id type-expr)
-     (with-syntax ((klass::t (stx-identifier #'id #'id "::t")))
+     (with-syntax ((klass::t (format-id #'id "~a::t" #'id)))
        #'(begin
            (def klass::t type-expr)
            (defsyntax id

--- a/src/std/os/socket.ss
+++ b/src/std/os/socket.ss
@@ -10,7 +10,8 @@ package: std/os
         :std/net/address
         :std/text/utf8
         :std/sugar
-        (only-in :gerbil/gambit/ports close-port))
+        (only-in :gerbil/gambit/ports close-port)
+        (for-syntax :std/stxutil))
 
 (export socket
         server-socket
@@ -521,12 +522,12 @@ package: std/os
 
 (defsyntax (@sockopt-getf stx)
   (syntax-case stx ()
-    ((_ id) (identifier? #'id) (stx-identifier #'id "socket-getsockopt-" #'id))
+    ((_ id) (identifier? #'id) (format-id #'id "socket-getsockopt-~a" #'id))
     ((_ #f) #f)))
 
 (defsyntax (@sockopt-setf stx)
   (syntax-case stx ()
-    ((_ id) (identifier? #'id) (stx-identifier #'id "socket-setsockopt-" #'id))
+    ((_ id) (identifier? #'id) (format-id #'id "socket-setsockopt-~a" #'id))
     ((_ #f) #f)))
 
 ;; this list is invariably incomplete, new ones get added all the time

--- a/src/std/parser/deflexer.ss
+++ b/src/std/parser/deflexer.ss
@@ -3,7 +3,7 @@
 ;;; std parser lexer generator
 package: std/parser
 
-(import (phi: +1 :std/parser/base :std/parser/rx-parser)
+(import (phi: +1 :std/parser/base :std/parser/rx-parser :std/stxutil)
         :std/parser/base
         :std/parser/rlang
         :std/parser/lexer)
@@ -74,8 +74,8 @@ package: std/parser
          (with-syntax* (((defn ...) defs)
                         ((lang ...) langs)
                         ((action ...) actions)
-                        (lexer::L (stx-identifier #'id #'id "::L" ))
-                        (lexer::R (stx-identifier #'id #'id "::R"))
+                        (lexer::L (format-id #'id "~a::L" #'id))
+                        (lexer::R (format-id #'id "~a::R" #'id))
                         (def::L (stx-wrap-source
                                  #'(def lexer::L [lang ...])
                                  (stx-source stx)))

--- a/src/std/parser/defparser.ss
+++ b/src/std/parser/defparser.ss
@@ -5,7 +5,8 @@ package: std/parser
 
 (import :std/parser/base
         :std/parser/rlang
-        :std/parser/lexer)
+        :std/parser/lexer
+        (for-syntax :std/stxutil))
 
 (export #t)
 
@@ -130,7 +131,7 @@ package: std/parser
            (reverse prods))))))
 
   (def (generate-prod-id base part)
-    (datum->syntax base (make-symbol (stx-e base) "::" part)))
+    (format-id base "~a::~a" base part))
 
   (def (wrap-source xstx where)
     (stx-wrap-source xstx (or (stx-source where) (stx-source stx))))

--- a/src/std/protobuf/proto.ss
+++ b/src/std/protobuf/proto.ss
@@ -6,7 +6,8 @@ package: std/protobuf
 (import :std/protobuf/macros
         (for-syntax :std/parser/base
                     :std/sugar
-                    :std/protobuf/proto-grammar))
+                    :std/protobuf/proto-grammar
+                    :std/stxutil))
 (export (except-out #t begin-module%%)
         (rename: begin-module%% %%begin-module)
         (import: :std/protobuf/macros)
@@ -73,7 +74,7 @@ package: std/protobuf
         ([hd . rest]
          (syntax-case hd (message enum field map oneof)
            ((enum enum-id . enum-body)
-            (with-syntax ((new-enum-id (stx-identifier #'enum-id id "." #'enum-id)))
+            (with-syntax ((new-enum-id (format-id #'enum-id "~a.~a" id #'enum-id)))
               (let (new-enum
                     (syntax/loc hd
                       (enum new-enum-id . enum-body)))
@@ -83,7 +84,7 @@ package: std/protobuf
                     (cons (cons #'enum-id #'new-enum-id)
                           subst)))))
            ((message message-id . message-body)
-            (with-syntax ((new-message-id (stx-identifier #'message-id id "." #'message-id)))
+            (with-syntax ((new-message-id (format-id #'message-id "~a.~a" id #'message-id)))
               (let (new-message
                     (syntax/loc hd
                       (message new-message-id . message-body)))
@@ -150,7 +151,7 @@ package: std/protobuf
            (let ((str (symbol->string (stx-e id)))
                  (pre (string-append (symbol->string (stx-e xid)) ".")))
              (if (string-prefix? pre str)
-               (stx-identifier id yid "." (substring str (string-length pre) (string-length str)))
+               (format-id id "~a.~a" yid (substring str (string-length pre) (string-length str)))
                (lp rest)))))
         (else id))))
 
@@ -269,7 +270,7 @@ package: std/protobuf
   (def (expand-import-path stx-path)
     (let (path (stx-e stx-path))
       (if (eq? (string-ref path 0) #\:) ; library path
-        (datum->syntax stx-path (string->symbol path) stx-path)
+        (format-id stx-path "~a" path)
         stx-path)))
 
   (def (expand-pkg pkg defs)

--- a/src/std/srfi/9.ss
+++ b/src/std/srfi/9.ss
@@ -3,6 +3,8 @@
 ;;; SRFI-13: charset library
 package: std/srfi
 
+(import (for-syntax :std/stxutil))
+
 (export define-record-type)
 
 (defsyntax (define-record-type stx)
@@ -35,10 +37,10 @@ package: std/srfi
   (def (module-type-id type-t)
     (cond
      ((module-context-ns (current-expander-context))
-      => (lambda (ns) (stx-identifier type-t ns "#" type-t)))
+      => (lambda (ns) (format-id type-t "~a#~a" ns type-t)))
      (else
       (let (mid (expander-context-id (current-expander-context)))
-        (stx-identifier type-t mid "#" type-t)))))
+        (format-id type-t "~a#~a" mid type-t)))))
 
   (def (generate-type type-id fields)
     (with-syntax ((klass type-id)


### PR DESCRIPTION
This PR cleans up #318 which had refactored `stx-identifier` in `std/make` and `std/build-config`. These need to have local imports and will thus not import `std/stxutil`.