### PR TITLE
compiler: use .scmx extension for executable stubs 

### DIFF
--- a/src/gerbil/compiler/driver.ss
+++ b/src/gerbil/compiler/driver.ss
@@ -101,7 +101,7 @@ namespace: gxc
                                  output-scm output-bin status))))))
 
   (let* ((output-bin (compile-exe-output-file ctx opts))
-         (output-scm (string-append output-bin ".scm")))
+         (output-scm (string-append output-bin ".scmx")))
     (create-directory* (path-directory output-scm))
     (compile-stub output-scm output-bin)
     (unless (current-compile-keep-scm)
@@ -212,7 +212,7 @@ namespace: gxc
                                  output-scm output-bin status))))))
 
   (let* ((output-bin (compile-exe-output-file ctx opts))
-         (output-scm (string-append output-bin ".scm")))
+         (output-scm (string-append output-bin ".scmx")))
     (compile-stub output-scm output-bin)
     (unless (current-compile-keep-scm)
       (delete-file output-scm))))


### PR DESCRIPTION
this to avoid ovewriting source code that uses the .scm exension.

Fixes #315 