### PR TITLE
Relative library module import paths

### DIFF
--- a/doc/guide/intro.md
+++ b/doc/guide/intro.md
@@ -516,7 +516,7 @@ it-is-an-error
 Identifiers are imported from a module with the `import` special
 form, which must appear at a top context (either top-level
 or module scope).
-It has the following syntax:
+It has roughly the following syntax (for full details see the reference):
 ```scheme
 (import <import-spec> ...)
 import-spec:
@@ -525,6 +525,8 @@ import-spec:
 module-path:
  identifier            ; top or module scope module
  :identifier           ; identifier with ':' prefix, library module
+ ./identifier          ; identifier with './' prefix, library relative module
+ ../identifier         ; identifier with '../' prefix, library relative module
  "path-to-module-file" ; file module, .ss extension optional
 ```
 
@@ -772,6 +774,22 @@ If the gerbil.pkg file is empty, then it is treated as an empty
 property list.  This allows you to simply touch a gerbil.pkg at the
 root of your source hierarchy when you don't need a custom prelude and
 use a directory structure that mimics your logical package structure.
+
+### Library Relative Module Paths
+
+As of `Gerbil v0.16-DEV-196-g41214a5`, you can use the dot notation to
+import library modules using a relative path within a library.  Within
+a library module `:A/B/C/D`, an import of `./E` will resolve to
+`:A/B/C/E`, while an import of `../E` will resolve to `:A/B/E`.
+Upwards traversals can be nested, so `../../E` will resolve to `:A/E`.
+Downwards traversals are also possible, so `../../E/G` wiil resolve to
+`:A/E/G`.
+
+Note that this is merely a syntactic convenience for `import` that
+allows you to refer to relative modules with a short module path and
+still load a library module. Relative module paths are meaningless
+outside the context of a library module.
+
 
 ## Standard Library
 

--- a/doc/reference/core-prelude.md
+++ b/doc/reference/core-prelude.md
@@ -35,20 +35,25 @@ Not implemented yet.
 (import import-spec ...)
 
 <import-spec>:
- (phi: dphi import-spec ...)  ; import at differential phase; phi: +1 imports for syntax
- (begin: import-spec ...)     ; group together import specs
- (runtime: module-path)       ; import a module as runtime dependency (no bindings)
+ (phi: dphi import-spec ...)                   ; import at differential phase; phi: +1 imports for syntax
+ (begin: import-spec ...)                      ; group together import specs
+ (runtime: module-path)                        ; import a module as runtime dependency (no bindings)
  (spec: module-path phi name src-phi src-name) ; fully specified import
- (macro macro-arg ....)       ; expand import expander `macro` with `macro-arg ...`
- module-path                  ; import a module
+ (macro macro-arg ....)                        ; expand import expander `macro` with `macro-arg ...`
+ module-path                                   ; import a module
 
 <module-path>:
- string                       ; string module path, relative to the source
- bound-identifier             ; module bound in the current context
- library-path                 ; library module path
+ string                                        ; source module path, relative to the current source
+ bound-identifier                              ; module bound in the current context
+ library-path                                  ; library module path
+ relative-library-path                         ; relative library module path
 
 <library-path>:
- ':' symbol ['/' symbol]+     ; library module path, with `/` as file system separator
+ ':' symbol ['/' symbol]*                      ; library module path, with `/` as file system separator
+
+<relative-library-path>:
+ './' symbol ['/' symbol]*                     ; library module path relative to the current library module
+ '../' ['../']* symbol ['/' symbol]*           ; relative library module path with package traversal
 ```
 
 Imports bindings to the current syntactic context. Must appear at top or module context.


### PR DESCRIPTION
This allows you to import relative to a library using the dot notation.
Within a library `:A/B/C`, an import of ~`.D`~ `./D` will resolve to `:A/B/D`.

