### PR TITLE
misc/list: group

### DIFF
--- a/doc/reference/misc.md
+++ b/doc/reference/misc.md
@@ -2008,6 +2008,26 @@ split the list `lst` into a list-of-lists using the unary procedure `proc`.
 ```
 :::
 
+### group
+``` scheme
+(group lst [test = equal?]) -> list
+
+  lst  := proper list
+  test := optional, binary predicate
+```
+group consecutive elements of the list `lst` into a list-of-lists.
+
+::: tip Examples:
+``` scheme
+(group [1 2 2 3 1 1])
+> ((1) (2 2) (3) (1 1))
+
+(import :std/sort)
+(group (sort [1 2 2 3 1 1] <) eqv?)
+> ((1 1 1) (2 2) (3))
+```
+:::
+
 ## LRU caches
 ::: tip To use the bindings from this module:
 ``` scheme

--- a/src/std/misc/list-test.ss
+++ b/src/std/misc/list-test.ss
@@ -150,4 +150,10 @@
     (test-case "test split"
       (check-equal? (split '(1 2 a 3 4) (cut equal? <> 'a)) [[1 2] [3 4]])
       (check-equal? (split '(1 2 "hi" ()) string?) [[1 2] [[]]])
-      (check-equal? (split [] number?) []))))
+      (check-equal? (split [] number?) []))
+    (test-case "test group"
+      (check-equal? (group [1 2 2 3 1]) [[1] [2 2] [3] [1]])
+      (check-equal? (group []) [])
+      (check-equal? (group [1]) [[1]])
+      (check-equal? (group [1 []]) [[1] [[]]])
+      (check-equal? (group ["aa" "aa" "b"]) [["aa" "aa"] ["b"]]))))

--- a/src/std/misc/list.ss
+++ b/src/std/misc/list.ss
@@ -22,7 +22,8 @@ package: std/misc
   slice slice-right
   slice! slice-right!
   butlast
-  split)
+  split
+  group)
 
 (import (only-in :std/srfi/1 drop drop-right drop-right! take take-right take! reverse!))
 
@@ -285,3 +286,21 @@ package: std/misc
       (if (pair? cur)
 	(snoc (reverse! cur) acc)
 	acc)))))
+
+;; group consecutive elements of the list lst into a list-of-lists.
+;;
+;; Example:
+;;  (group [1 2 2 3 1 1]) => ((1) (2 2) (3) (1 1))
+(def (group lst (test equal?))
+  (def (helper)
+    (let loop ((rest lst) (buf []) (acc []))
+      (match rest
+	([it . rest]
+	 (if (or (null? buf) (test it (car buf)))
+	   (loop rest (cons it buf) acc)
+	   (loop rest [it] (cons buf acc))))
+	(else (reverse! (cons buf acc))))))
+  (match lst
+    ([] lst)
+    ([a] [[a]])
+    (_ (helper))))


### PR DESCRIPTION
Inspired by Haskells [group](https://downloads.haskell.org/~ghc/latest/docs/html/libraries/base-4.13.0.0/Data-List.html#v:group) and [groupBy](https://hackage.haskell.org/package/groupBy-0.1.0.0/docs/Data-List-GroupBy.html) function.