### PR TITLE
polydactyl gerbil

### DIFF
--- a/doc/guide/intro.md
+++ b/doc/guide/intro.md
@@ -790,6 +790,19 @@ allows you to refer to relative modules with a short module path and
 still load a library module. Relative module paths are meaningless
 outside the context of a library module.
 
+### Core Gerbil Variants
+
+As of `Gerbil v0.16-DEV-259-g13646d64` gerbil comes with a custom language
+prelude, `:gerbil/polydactyl`, that treats square brackets as plain parentheses
+-- instead of the reader expanding them to `@list` forms.
+The language is otherwise the same as `:gerbil/core`.
+
+To use it, add the following lang declaration to your module:
+```
+#lang :gerbil/polydactyl
+
+;; ... code ...
+```
 
 ## Standard Library
 

--- a/src/lang/build.ss
+++ b/src/lang/build.ss
@@ -1,10 +1,11 @@
-#!/usr/bin/env gxi
+#!/usr/bin/env gxi-build-script
 ;; -*- Gerbil -*-
 
 (import :std/build-script)
 
 (defbuild-script
-  `("scheme/stubs"
+  `(;; standard scheme
+    "scheme/stubs"
     "scheme/base-etc"
     "scheme/base-vectors"
     (gxc: "scheme/base-ports" "-e" "(include \"~~lib/_gambit#.scm\")")
@@ -38,4 +39,9 @@
     "scheme/r5rs"
     "scheme/r5rs-null"
     "scheme/r7rs"
+    ;; gerbil variants
+    (gxc: "gerbil/polydactyl" "-e" "(include \"~~lib/_gambit#.scm\")")
     ))
+
+;; necessary because gxi-build-script doesn't autoinvoke main
+(main)

--- a/src/lang/gerbil/polydactyl.ss
+++ b/src/lang/gerbil/polydactyl.ss
@@ -1,0 +1,29 @@
+;;; -*- Gerbil -*-
+;;; © vyzo
+;;; Polydactyl Gerbil prelude
+;;; This is :gerbil/core with a readtable that treats [] as plain parentheses.
+
+(import :gerbil/core
+        (for-syntax :gerbil/gambit/readtables))
+(export (import: :gerbil/core)
+        (for-syntax read-module-body))
+
+(module _gambit
+  (export #t)
+  (extern namespace: #f macro-readtable-brace-keyword-set!))
+
+(import (for-syntax _gambit))
+
+(begin-syntax
+  (def *readtable*
+    (let (rt (##make-standard-readtable))
+      (macro-readtable-brace-keyword-set! rt '@method)
+      rt))
+
+  (def (read-module-body port)
+    (parameterize ((current-readtable *readtable*))
+      (let lp ((body []))
+        (let (next (read-syntax port))
+          (if (eof-object? next)
+            (reverse body)
+            (lp (cons next body))))))))


### PR DESCRIPTION
`:gerbil/polydactyl` is a new custom language prelude that treats square brackets as plain parentheses; the language is otherwise the same as `:gerbil/core`.

To use it:
```
#lang :gerbil/polydactyl

;; ... code ...
```
