### PR TITLE
gxtags: correctly handle non-locat positions

### DIFF
--- a/src/tools/gxtags.ss
+++ b/src/tools/gxtags.ss
@@ -241,8 +241,10 @@
             (lp (fx1+ i) offs))))))))
 
 (def (source-location-line locat)
-  (let (filepos (##position->filepos (##locat-position locat)))
-    (fx1+ (##filepos-line filepos))))
+  (if (##locat? locat)
+    (let (filepos (##position->filepos (##locat-position locat)))
+      (fx1+ (##filepos-line filepos)))
+    1))
 
 (def (try-import-module filename)
   (try


### PR DESCRIPTION
How about just return 1 if locat is not a vector?

fix #286 