### PR TITLE
Polydactyl as a first class language in gxi

### DIFF
--- a/doc/guide/intro.md
+++ b/doc/guide/intro.md
@@ -797,11 +797,16 @@ prelude, `:gerbil/polydactyl`, that treats square brackets as plain parentheses
 -- instead of the reader expanding them to `@list` forms.
 The language is otherwise the same as `:gerbil/core`.
 
-To use it, add the following lang declaration to your module:
+To use it in a module, add the following lang declaration to the top of your file:
 ```
 #lang :gerbil/polydactyl
 
 ;; ... code ...
+```
+
+To use it in the interpreter, start gxi by specifying `polydactyl` as the language:
+```
+$ gxi --lang polydactyl
 ```
 
 ## Standard Library

--- a/src/gerbil/runtime/gx-gambc.scm
+++ b/src/gerbil/runtime/gx-gambc.scm
@@ -35,6 +35,7 @@
   (string->symbol (getenv "GERBIL_LANG" "gerbil")))
 
 (define (_gx#load-gxi #!optional (hook-expander? #t))
+  (define +readtable+ _gx#*readtable*)
   (_gx#init-gx!)
   (let* ((core (gx#import-module ':gerbil/core))
          (pre  (gx#make-prelude-context core)))
@@ -44,6 +45,9 @@
       (case lang
         ((gerbil)
          (gx#eval-syntax '(import :gerbil/core)))
+        ((polydactyl)
+         (gx#eval-syntax '(import :gerbil/polydactyl))
+         (set! +readtable+ (gx#eval-syntax '|gerbil/polydactyl[1]#*readtable*|)))
         ((r7rs)
          (gx#eval-syntax '(import :scheme/r7rs :scheme/base)))
         (else
@@ -61,7 +65,7 @@
     (set! ##main-readtable _gx#*readtable*)
     (for-each
       (lambda (port)
-        (input-port-readtable-set! port _gx#*readtable*))
+        (input-port-readtable-set! port +readtable+))
       (list ##stdin-port ##console-port))
     (for-each
       (lambda (port)
@@ -80,7 +84,7 @@
         (gx#eval-syntax `(include ,init-file)))))
 
   (case (gerbil-lang)
-    ((gerbil)
+    ((gerbil polydactyl)
      (load-init "init.ss"))
     ((r7rs)
      (load-init "r7rs-init.ss"))))


### PR DESCRIPTION
You can now do `gxi --lang polydactyl` and it will hook the stdin/console readtables to use polydactyl parentheses.
