### PR TITLE
Advisory File Locking

### DIFF
--- a/doc/reference/os.md
+++ b/doc/reference/os.md
@@ -285,6 +285,9 @@ F_DUPFD
 FD_CLOEXEC
 ```
 
+## Advisory File Locking
+
+Please document me!
 
 ## Pipes
 ::: tip usage

--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -150,6 +150,7 @@
     (gxc: "os/fd" ,@(include-gambit-sharp))
     (gxc: "os/fdio" ,@(include-gambit-sharp))
     (gxc: "os/fcntl" ,@(include-gambit-sharp))
+    "os/flock"
     (gxc: "os/pipe" ,@(include-gambit-sharp))
     ,(cond-expand
        (linux

--- a/src/std/os/fcntl.ss
+++ b/src/std/os/fcntl.ss
@@ -9,11 +9,13 @@
 
 (def* fcntl
   ((raw cmd)
-   (check-os-error (_fcntl0 (fd-e raw) cmd)
-     (fcntl raw cmd)))
+   (let (fd (if (fd? raw) (fd-e raw) raw))
+     (check-os-error (_fcntl0 fd cmd)
+       (fcntl raw cmd))))
   ((raw cmd arg)
-   (check-os-error (_fcntl1 (fd-e raw) cmd arg)
-     (fcntl raw cmd arg))))
+   (let (fd (if (fd? raw) (fd-e raw) raw))
+     (check-os-error (_fcntl1 fd cmd arg)
+       (fcntl raw cmd arg)))))
 
 (def (fd-getfl raw)
   (fcntl raw F_GETFL))

--- a/src/std/os/fd.ss
+++ b/src/std/os/fd.ss
@@ -3,7 +3,7 @@
 ;;; OS File Descriptors
 
 (import :gerbil/gambit/ports)
-(export fdopen
+(export fdopen fdopen-port
         fd-e fd-io-in fd-io-out
         fd? fd-type? fd-type)
 
@@ -30,15 +30,21 @@
          (##raise-os-exception #f device open-raw-device direction id fd)
          (##make-raw-device-port direction device id [id fd] fd))))))
 
+(def (direction dir)
+  (case dir
+    ((in)    (macro-direction-in))
+    ((out)   (macro-direction-out))
+    ((inout) (macro-direction-inout))
+    (else
+     (error "Bad direction; must be in, out, or inout" dir))))
+
 (def (fdopen fd dir t)
-  (let (dirx
-        (case dir
-          ((in)(macro-direction-in))
-          ((out) (macro-direction-out))
-          ((inout) (macro-direction-inout))
-          (else
-           (error "Bad direction; must be in, out, or inout" dir))))
+  (let (dirx (direction dir))
     (open-raw-device dirx t fd)))
+
+(def (fdopen-port fd dir name)
+  (let (dirx (direction dir))
+    (##open-predefined dirx name fd)))
 
 (def (fd-e raw)
   (values (macro-raw-device-port-specific raw)))

--- a/src/std/os/fdio.ss
+++ b/src/std/os/fdio.ss
@@ -45,7 +45,7 @@
     (error "Unspecified file direction" flags))))
 
 ;;; FFI impl
-(begin-ffi (_read _write _open
+(begin-ffi (_read _write _open _close
             S_IRWXU S_IWUSR S_IRUSR S_IXUSR
             S_IRWXG S_IRGRP S_IWGRP S_IXGRP
             S_IRWXO S_IROTH S_IWOTH S_IXOTH)
@@ -78,7 +78,7 @@
            r))))
 
   ;; private
-  (namespace ("std/os/fdio#" __read __write __open __errno))
+  (namespace ("std/os/fdio#" __read __write __open __close __errno))
 
   (define-c-lambda __errno () int
     "___return (errno);")
@@ -92,10 +92,13 @@
     "ffi_fdio_write")
   (define-c-lambda __open (UTF-8-string int int) int
     "open")
+  (define-c-lambda __close (int) int
+    "close")
 
   (define-with-errno _read __read (fd bytes start end))
   (define-with-errno _write __write (fd bytes start end))
   (define-with-errno _open __open (path flags mode))
+  (define-with-errno _close __close (fd))
 
   (c-declare #<<END-C
 int ffi_fdio_read (int fd, ___SCMOBJ bytes, int start, int end)

--- a/src/std/os/fdio.ss
+++ b/src/std/os/fdio.ss
@@ -45,12 +45,29 @@
     (error "Unspecified file direction" flags))))
 
 ;;; FFI impl
-(begin-ffi (_read _write _open)
+(begin-ffi (_read _write _open
+            S_IRWXU S_IWUSR S_IRUSR S_IXUSR
+            S_IRWXG S_IRGRP S_IWGRP S_IXGRP
+            S_IRWXO S_IROTH S_IWOTH S_IXOTH)
+
   (c-declare "#include <unistd.h>")
   (c-declare "#include <errno.h>")
   (c-declare "#include <sys/types.h>")
   (c-declare "#include <sys/stat.h>")
   (c-declare "#include <fcntl.h>")
+
+  (define-const S_IRWXU)
+  (define-const S_IRUSR)
+  (define-const S_IWUSR)
+  (define-const S_IXUSR)
+  (define-const S_IRWXG)
+  (define-const S_IRGRP)
+  (define-const S_IWGRP)
+  (define-const S_IXGRP)
+  (define-const S_IRWXO)
+  (define-const S_IROTH)
+  (define-const S_IWOTH)
+  (define-const S_IXOTH)
 
   (define-macro (define-with-errno symbol ffi-symbol args)
     `(define (,symbol ,@args)

--- a/src/std/os/flock.ss
+++ b/src/std/os/flock.ss
@@ -44,10 +44,10 @@
 
   (let lp ()
     (unless (flock raw-or-fd op)
-      (thread-sleep! (random-real))
       (when deadline
         (unless (< deadline (##current-time-point))
           (raise-timeout 'flock "Deadline for flock operation exceeded" raw-or-fd op)))
+      (thread-sleep! (random-real))
       (lp))))
 
 (def (open-input-file/lock path (timeout #f)

--- a/src/std/os/flock.ss
+++ b/src/std/os/flock.ss
@@ -1,0 +1,94 @@
+;;; -*- Gerbil -*-
+;;; (C) vyzo at hackzen.org
+;;; OS Advisory File Locking
+
+(import :std/foreign
+        :std/os/fd
+        :std/os/fcntl
+        :std/os/fdio
+        :std/os/error
+        :std/error
+        :std/sugar
+        :gerbil/gambit/os
+        :gerbil/gambit/random
+        :gerbil/gambit/threads)
+(export flock flock/block
+        open-output-file/lock
+        LOCK_SH LOCK_EX LOCK_UN)
+
+(def (flock raw op)
+  (let ((fd (if (fd? raw)
+              (fd-e raw)
+              raw))
+        (op (fxior op LOCK_NB)))
+    (do-retry-nonblock (_flock fd op)
+      (flock raw op))))
+
+;; This blocks the current thread until the lock operation is successful.
+;; Blocking is implemented with polling -- alternative would be to use an os thread
+;; but that is too heavyweight
+(def (flock/block raw-or-fd op (timeout #f))
+  (def deadline
+    (cond
+     ((not timeout) #f)
+     ((time? timeout)
+      (time->seconds timeout))
+     ((real? timeout)
+      (+ (##current-time-point) timeout))
+     (else
+      (error "Bad argument; expected real, time or #f" timeout))))
+
+  (let lp ()
+    (unless (flock raw-or-fd op)
+      (thread-sleep! (random-real))
+      (when deadline
+        (unless (< deadline (##current-time-point))
+          (raise-timeout 'flock "Deadline for flock operation exceeded" raw-or-fd op)))
+      (lp))))
+
+;; This opens a file output port with a lock
+(def (open-output-file/lock path op (timeout #f)
+                            flags: (flags (fxior O_WRONLY O_CREAT))
+                            mode: (mode S_IRWXU))
+  (let* ((flags
+          (cond-expand
+            (linux (fxior flags O_NONBLOCK O_CLOEXEC))
+            (else flags)))
+         (fd (check-os-error (_open path flags mode)
+               (open path flags mode))))
+    (cond-expand
+      ((not linux)
+       (fd-set-nonblock/closeonexec fd)))
+    (try
+     (flock/block fd op timeout)
+     (catch (e)
+       (_close fd)
+       (raise e)))
+    (fdopen-port fd 'out path)))
+
+(begin-ffi (_flock LOCK_SH LOCK_EX LOCK_UN LOCK_NB)
+  (c-declare "#include <errno.h>")
+  (c-declare "#include <sys/file.h>")
+
+  (define-const LOCK_SH)
+  (define-const LOCK_EX)
+  (define-const LOCK_UN)
+  (define-const LOCK_NB)
+
+  (define-macro (define-with-errno symbol ffi-symbol args)
+    `(define (,symbol ,@args)
+       (declare (not interrupts-enabled))
+       (let ((r (,ffi-symbol ,@args)))
+         (if (##fx< r 0)
+           (##fx- (__errno))
+           r))))
+
+  ;; private
+  (namespace ("std/os/flock#" __flock __errno))
+
+  (define-c-lambda __errno () int
+    "___return (errno);")
+  (define-c-lambda __flock (int int) int
+    "flock")
+
+  (define-with-errno _flock __flock (fd op)))


### PR DESCRIPTION
Adds flock to the `:std/os` package, which exposes the `flock` call and a utility procedure for opening input and output files with locks.
