### PR TITLE
unlock ports created with lock on close-port

### DIFF
--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -150,7 +150,7 @@
     (gxc: "os/fd" ,@(include-gambit-sharp))
     (gxc: "os/fdio" ,@(include-gambit-sharp))
     (gxc: "os/fcntl" ,@(include-gambit-sharp))
-    "os/flock"
+    (gxc: "os/flock" ,@(include-gambit-sharp))
     (gxc: "os/pipe" ,@(include-gambit-sharp))
     ,(cond-expand
        (linux


### PR DESCRIPTION
This is a supplement to #358; when opening a file with an advisory lock, closing the port will also unlock the file descriptor.