### PR TITLE
More file descriptor io support

### DIFF
--- a/src/std/net/bio/file.ss
+++ b/src/std/net/bio/file.ss
@@ -29,7 +29,7 @@
   (cond
    ((&file-input-buffer-fd buf)
     => (lambda (fd)
-         (close-port fd)
+         (close fd)
          (set! (&file-input-buffer-fd buf) #f)
          (set! (&input-buffer-fill buf) (lambda _ 0))
          (set! (&input-buffer-read buf) (lambda _ 0))))))
@@ -63,7 +63,8 @@
                     count)
                   (##fx+ count rd)))
               (begin
-                (##wait-for-io! (fd-io-in fd) #t)
+                (when (fd? fd)
+                  (##wait-for-io! (fd-io-in fd) #t))
                 (lp rhi want count)))))))))
 
 (def (file-input-read bytes start end buf)
@@ -74,7 +75,8 @@
         (let (r (fdread fd bytes start end))
           (cond
            ((not r)
-            (##wait-for-io! (fd-io-in fd) #t)
+            (when (fd? fd)
+              (##wait-for-io! (fd-io-in fd) #t))
             (lp count start))
            ((##fxzero? r)
             count)
@@ -101,7 +103,7 @@
   (cond
    ((&file-output-buffer-fd buf)
     => (lambda (fd)
-         (close-port fd)
+         (close fd)
          (set! (&file-output-buffer-fd buf) #f)
          (set! (&output-buffer-drain buf) (lambda _ (error "device is closed" fd)))
          (set! (&output-buffer-write buf) (lambda _ (error "device is closed" fd)))))))
@@ -118,6 +120,7 @@
           (if r
             (lp (##fx+ count r) (##fx+ start r))
             (begin
-              (##wait-for-io! (fd-io-out fd) #t)
+              (when (fd? fd)
+                (##wait-for-io! (fd-io-out fd) #t))
               (lp count start))))
         count))))

--- a/src/std/os/fdio.ss
+++ b/src/std/os/fdio.ss
@@ -5,7 +5,8 @@
 (import :std/foreign
         :std/os/fd
         :std/os/fcntl
-        :std/os/error)
+        :std/os/error
+        :gerbil/gambit/ports)
 (export #t)
 
 (def (fdread raw bytes (start 0) (end (u8vector-length bytes)))
@@ -34,6 +35,12 @@
             (raw (fdopen fd (file-direction flags) 'file)))
        (fd-set-nonblock/closeonexec raw)
        raw))))
+
+(def (close raw)
+  (if (fd? raw)
+    (close-port raw)
+    (do-retry-nonblock (_close raw)
+      (close raw))))
 
 (def (file-direction flags)
   (cond


### PR DESCRIPTION
- expose a proper `close` in `:std/os/fdio`
- allow raw file descriptors in file bio buffers
