### PR TITLE
don't use call-with-values in sort

### DIFF
--- a/src/std/sort/lmsort.scm
+++ b/src/std/sort/lmsort.scm
@@ -13,8 +13,8 @@
      (let ((var exp)) (mlet (rest ...) body ...)))
 
     ((mlet ((vars exp) rest ...) body ...)
-     (call-with-values (lambda () exp)
-       (lambda vars (mlet (rest ...) body ...))))
+     (let-values ((vars exp))
+       (mlet (rest ...) body ...)))
 
     ((mlet () body ...) (begin body ...))))
 

--- a/src/std/sort/sort-support.scm
+++ b/src/std/sort/sort-support.scm
@@ -25,7 +25,7 @@
 (define-syntax receive
   (syntax-rules ()
     ((receive vars mv-exp body ...)
-     (call-with-values (lambda () mv-exp) (lambda vars body ...)))))
+     (let-values ((vars mv-exp)) body ...))))
 
 ;;; (let-vector-start+end (start end) proc vector arg-list
 ;;;   body ...)


### PR DESCRIPTION
Helper macros were using it instead of let-values, which showed up in profile samples.