### PR TITLE
Clean up code duplication related to define-with-errno

### DIFF
--- a/doc/guide/ffi.md
+++ b/doc/guide/ffi.md
@@ -86,6 +86,8 @@ It also defines some common utility macros:
 - `(define-const id)` which expands to a definition that evals the constant in C.
 - `(define-const* id)` which conditionally defines the constant to a value of `#f` if it is undefined in the C preprocessor.
 - `(define-guard defn)` which conditionally expands a definition with an accompanied cond-expand feature.
+- `(define-with-errno id ffi-id args)` which expands to a definition of `(id args ...)` which calls `(ffi-id args ...)` and returns the negated errno if the reuslt is negative.
+  This is useful for wrapping C/POSIX ffi functions that report errors using `errno`.
 
 In addition, it provides a few other preprocessor macros and a definition of `ffi_free`, a function suitable as a release function for ffi types.
 

--- a/doc/guide/ffi.md
+++ b/doc/guide/ffi.md
@@ -86,7 +86,7 @@ It also defines some common utility macros:
 - `(define-const id)` which expands to a definition that evals the constant in C.
 - `(define-const* id)` which conditionally defines the constant to a value of `#f` if it is undefined in the C preprocessor.
 - `(define-guard defn)` which conditionally expands a definition with an accompanied cond-expand feature.
-- `(define-with-errno id ffi-id args)` which expands to a definition of `(id args ...)` which calls `(ffi-id args ...)` and returns the negated errno if the reuslt is negative.
+- `(define-with-errno id ffi-id args)` which expands to a definition of `(id args ...)` which calls `(ffi-id args ...)` and returns the negated errno if the result is negative.
   This is useful for wrapping C/POSIX ffi functions that report errors using `errno`.
 
 In addition, it provides a few other preprocessor macros and a definition of `ffi_free`, a function suitable as a release function for ffi types.

--- a/doc/reference/foreign.md
+++ b/doc/reference/foreign.md
@@ -26,6 +26,7 @@ The following prelude macros are available within the body:
 (define-const id)
 (define-const* id)
 (define-guard guard defn)
+(define-with-errno id ffi-id args)
 ```
 
 The following declarations are included before the body:

--- a/src/std/foreign.ss
+++ b/src/std/foreign.ss
@@ -36,10 +36,18 @@
                       "___return (___FAL);\n"
                       "#endif")))
           `(define ,symbol
-             ((c-lambda () scheme-object ,code)))))))
+             ((c-lambda () scheme-object ,code)))))
+      (define-macro (define-with-errno symbol ffi-symbol args)
+        `(define (,symbol ,@args)
+           (declare (not interrupts-enabled))
+           (let ((r (,ffi-symbol ,@args)))
+             (if (##fx< r 0)
+               (##fx- (##c-code "___RESULT = ___FIX (errno);"))
+               r))))))
 
   (def (prelude-c-decls)
     '((c-declare "#include <stdlib.h>")
+      (c-declare "#include <errno.h>")
       (c-declare "static ___SCMOBJ ffi_free (void *ptr);")
       (c-declare #<<END-C
 #ifndef ___HAVE_FFI_U8VECTOR

--- a/src/std/os/_socket.scm
+++ b/src/std/os/_socket.scm
@@ -274,15 +274,12 @@ END-C
 (c-define-type linger*
   (pointer linger (linger*) "ffi_free"))
 
-(define-c-lambda __errno () int
-  "___return (errno);")
-
 (define-macro (define-with-errno symbol ffi-symbol args)
   `(define (,symbol ,@args)
      (declare (not interrupts-enabled))
      (let ((r (,ffi-symbol ,@args)))
        (if (##fx< r 0)
-         (##fx- (__errno))
+         (##fx- (##c-code "___RESULT = ___FIX (errno);"))
          r))))
 
 (define-c-lambda __socket (int int int) int

--- a/src/std/os/epoll.ss
+++ b/src/std/os/epoll.ss
@@ -79,13 +79,13 @@
        (declare (not interrupts-enabled))
        (let ((r (,ffi-symbol ,@args)))
          (if (##fx< r 0)
-           (##fx- (__errno))
+           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
            r))))
 
   ;; private
   (namespace ("std/os/epoll#"
               epoll_event epoll_event*
-              __errno __epoll_create __epoll_ctl __epoll_wait
+              __epoll_create __epoll_ctl __epoll_wait
               _epoll_create _epoll_ctl _epoll_wait))
 
   (define-const EPOLL_CTL_ADD)
@@ -98,12 +98,9 @@
   (define-const EPOLLET)
   (define-const EPOLLONESHOT)
 
-    (c-define-type epoll_event (struct "epoll_event"))
+  (c-define-type epoll_event (struct "epoll_event"))
   (c-define-type epoll_event*
     (pointer epoll_event (epoll_event*) "ffi_free"))
-
-  (define-c-lambda __errno () int
-    "___return (errno);")
 
   (define-c-lambda __epoll_create (int) int
     "epoll_create")

--- a/src/std/os/epoll.ss
+++ b/src/std/os/epoll.ss
@@ -71,16 +71,7 @@
             epoll_evt_fd epoll_evt_fd_set
             epoll_evt_events epoll_evt_events_set)
 
-  (c-declare "#include <errno.h>")
   (c-declare "#include <sys/epoll.h>")
-
-  (define-macro (define-with-errno symbol ffi-symbol args)
-    `(define (,symbol ,@args)
-       (declare (not interrupts-enabled))
-       (let ((r (,ffi-symbol ,@args)))
-         (if (##fx< r 0)
-           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
-           r))))
 
   ;; private
   (namespace ("std/os/epoll#"

--- a/src/std/os/fcntl.ss
+++ b/src/std/os/fcntl.ss
@@ -65,21 +65,12 @@
             ;; F_RDLCK F_UNLCK F_WRLCK
             _fcntl0 _fcntl1
             )
-  (c-declare "#include <errno.h>")
   (c-declare "#include <unistd.h>")
   (c-declare "#include <sys/types.h>")
   (c-declare "#include <sys/stat.h>")
   (c-declare "#include <fcntl.h>")
 
   (namespace ("std/os/fcntl#" __fcntl0 __fcntl1))
-
-  (define-macro (define-with-errno symbol ffi-symbol args)
-    `(define (,symbol ,@args)
-       (declare (not interrupts-enabled))
-       (let ((r (,ffi-symbol ,@args)))
-         (if (##fx< r 0)
-           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
-           r))))
 
   ;; POSIX commands
   (define-const F_DUPFD)

--- a/src/std/os/fcntl.ss
+++ b/src/std/os/fcntl.ss
@@ -71,14 +71,14 @@
   (c-declare "#include <sys/stat.h>")
   (c-declare "#include <fcntl.h>")
 
-  (namespace ("std/os/fcntl#" __fcntl0 __fcntl1 __errno))
+  (namespace ("std/os/fcntl#" __fcntl0 __fcntl1))
 
   (define-macro (define-with-errno symbol ffi-symbol args)
     `(define (,symbol ,@args)
        (declare (not interrupts-enabled))
        (let ((r (,ffi-symbol ,@args)))
          (if (##fx< r 0)
-           (##fx- (__errno))
+           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
            r))))
 
   ;; POSIX commands
@@ -123,8 +123,6 @@
 
   (define-c-lambda __fcntl0 (int int) int "fcntl")
   (define-c-lambda __fcntl1 (int int int) int "fcntl")
-  (define-c-lambda __errno () int
-    "___return (errno);")
 
   (define-with-errno _fcntl0 __fcntl0 (fd cmd))
   (define-with-errno _fcntl1 __fcntl1 (fd cmd arg)))

--- a/src/std/os/fdio.ss
+++ b/src/std/os/fdio.ss
@@ -60,7 +60,6 @@
             S_IRWXO S_IROTH S_IWOTH S_IXOTH)
 
   (c-declare "#include <unistd.h>")
-  (c-declare "#include <errno.h>")
   (c-declare "#include <sys/types.h>")
   (c-declare "#include <sys/stat.h>")
   (c-declare "#include <fcntl.h>")
@@ -77,14 +76,6 @@
   (define-const S_IROTH)
   (define-const S_IWOTH)
   (define-const S_IXOTH)
-
-  (define-macro (define-with-errno symbol ffi-symbol args)
-    `(define (,symbol ,@args)
-       (declare (not interrupts-enabled))
-       (let ((r (,ffi-symbol ,@args)))
-         (if (##fx< r 0)
-           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
-           r))))
 
   ;; private
   (namespace ("std/os/fdio#" __read __write __open __close))

--- a/src/std/os/fdio.ss
+++ b/src/std/os/fdio.ss
@@ -83,14 +83,11 @@
        (declare (not interrupts-enabled))
        (let ((r (,ffi-symbol ,@args)))
          (if (##fx< r 0)
-           (##fx- (__errno))
+           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
            r))))
 
   ;; private
-  (namespace ("std/os/fdio#" __read __write __open __close __errno))
-
-  (define-c-lambda __errno () int
-    "___return (errno);")
+  (namespace ("std/os/fdio#" __read __write __open __close))
 
   (c-declare "static int ffi_fdio_read (int fd, ___SCMOBJ bytes, int start, int end);")
   (c-declare "static int ffi_fdio_write (int fd, ___SCMOBJ bytes, int start, int end);")

--- a/src/std/os/flock.ss
+++ b/src/std/os/flock.ss
@@ -96,21 +96,12 @@
     fd))
 
 (begin-ffi (_flock LOCK_SH LOCK_EX LOCK_UN LOCK_NB)
-  (c-declare "#include <errno.h>")
   (c-declare "#include <sys/file.h>")
 
   (define-const LOCK_SH)
   (define-const LOCK_EX)
   (define-const LOCK_UN)
   (define-const LOCK_NB)
-
-  (define-macro (define-with-errno symbol ffi-symbol args)
-    `(define (,symbol ,@args)
-       (declare (not interrupts-enabled))
-       (let ((r (,ffi-symbol ,@args)))
-         (if (##fx< r 0)
-           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
-           r))))
 
   ;; private
   (namespace ("std/os/flock#" __flock))

--- a/src/std/os/flock.ss
+++ b/src/std/os/flock.ss
@@ -109,14 +109,12 @@
        (declare (not interrupts-enabled))
        (let ((r (,ffi-symbol ,@args)))
          (if (##fx< r 0)
-           (##fx- (__errno))
+           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
            r))))
 
   ;; private
-  (namespace ("std/os/flock#" __flock __errno))
+  (namespace ("std/os/flock#" __flock))
 
-  (define-c-lambda __errno () int
-    "___return (errno);")
   (define-c-lambda __flock (int int) int
     "flock")
 

--- a/src/std/os/inotify.ss
+++ b/src/std/os/inotify.ss
@@ -150,11 +150,10 @@
        (declare (not interrupts-enabled))
        (let ((r (,ffi-symbol ,@args)))
          (if (##fx< r 0)
-           (##fx- (__errno))
+           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
            r))))
 
   (namespace ("std/os/inotify#"
-              __errno
                __inotify_init
                __inotify_add_watch
                __inotify_rm_watch))
@@ -183,9 +182,6 @@
   (define-const-uint32 IN_ISDIR)
   (define-const-uint32 IN_Q_OVERFLOW)
   (define-const-uint32 IN_UNMOUNT)
-
-  (define-c-lambda __errno () int
-    "___return (errno);")
 
   (define-c-lambda __inotify_init () int
     "___return (inotify_init1 (IN_NONBLOCK|IN_CLOEXEC));")

--- a/src/std/os/inotify.ss
+++ b/src/std/os/inotify.ss
@@ -137,21 +137,12 @@
             IN_Q_OVERFLOW
             IN_UNMOUNT)
   (c-declare "#include <sys/inotify.h>")
-  (c-declare "#include <errno.h>")
 
   (define-macro (define-const-uint32 symbol)
     (let* ((str (symbol->string symbol))
            (ref (string-append "___return (" str ");")))
       `(define ,symbol
          ((c-lambda () unsigned-int32 ,ref)))))
-
-  (define-macro (define-with-errno symbol ffi-symbol args)
-    `(define (,symbol ,@args)
-       (declare (not interrupts-enabled))
-       (let ((r (,ffi-symbol ,@args)))
-         (if (##fx< r 0)
-           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
-           r))))
 
   (namespace ("std/os/inotify#"
                __inotify_init

--- a/src/std/os/kqueue.ss
+++ b/src/std/os/kqueue.ss
@@ -214,7 +214,7 @@
        (declare (not interrupts-enabled))
        (let ((r (,ffi-symbol ,@args)))
          (if (##fx< r 0)
-           (##fx- (__errno))
+           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
            r))))
 
   (namespace ("std/os/kqueue#"
@@ -240,7 +240,7 @@
 
               kevent kevent* timespec timespec*
               make_timespec timespec_seconds_set timespec_nanoseconds_set
-              __errno __kqueue __kevent
+              __kqueue __kevent
               _kqueue _kevent
               make_kevents
               kevent_ident kevent_ident_set
@@ -367,9 +367,6 @@
     "___arg1->tv_sec = ___arg2; ___return ;")
   (define-c-lambda timespec_nanoseconds_set (timespec* int) void
     "___arg1->tv_nsec = ___arg2; ___return ;")
-
-  (define-c-lambda __errno () int
-    "___return (errno);")
 
   (define-c-lambda __kqueue () int
     "kqueue")

--- a/src/std/os/kqueue.ss
+++ b/src/std/os/kqueue.ss
@@ -185,7 +185,6 @@
      (define-cond-expand-feature darwin))))
 
 (begin-foreign
-  (c-declare "#include <errno.h>")
   (c-declare "#include <stdlib.h>")
   (c-declare "#include <sys/types.h>")
   (c-declare "#include <sys/event.h>")
@@ -208,14 +207,6 @@
       (begin
         (eval `(define-cond-expand-feature ,guard))
         defn)))
-
-  (define-macro (define-with-errno symbol ffi-symbol args)
-    `(define (,symbol ,@args)
-       (declare (not interrupts-enabled))
-       (let ((r (,ffi-symbol ,@args)))
-         (if (##fx< r 0)
-           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
-           r))))
 
   (namespace ("std/os/kqueue#"
               EV_ADD EV_ENABLE EV_DISABLE EV_DELETE EV_RECEIPT EV_ONESHOT

--- a/src/std/os/pipe.ss
+++ b/src/std/os/pipe.ss
@@ -46,16 +46,13 @@
        (declare (not interrupts-enabled))
        (let ((r (,ffi-symbol ,@args)))
          (if (##fx< r 0)
-           (##fx- (__errno))
+           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
            r))))
 
-  (namespace ("std/os/pipe#" __pipe __errno))
+  (namespace ("std/os/pipe#" __pipe))
 
   (c-define-type pipe*
     (pointer int (pipe*) "ffi_free"))
-
-  (define-c-lambda __errno () int
-    "___return (errno);")
 
   (define-c-lambda __pipe (pipe*) int
     "pipe")

--- a/src/std/os/pipe.ss
+++ b/src/std/os/pipe.ss
@@ -38,16 +38,7 @@
        (values ifd ofd)))))
 
 (begin-ffi (_pipe make_pipe_ptr pipe_ptr_ref)
-  (c-declare "#include <errno.h>")
   (c-declare "#include <unistd.h>")
-
-  (define-macro (define-with-errno symbol ffi-symbol args)
-    `(define (,symbol ,@args)
-       (declare (not interrupts-enabled))
-       (let ((r (,ffi-symbol ,@args)))
-         (if (##fx< r 0)
-           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
-           r))))
 
   (namespace ("std/os/pipe#" __pipe))
 

--- a/src/std/os/signal.ss
+++ b/src/std/os/signal.ss
@@ -97,15 +97,6 @@
             sigismember)
   (c-declare "#include <sys/types.h>")
   (c-declare "#include <signal.h>")
-  (c-declare "#include <errno.h>")
-
-  (define-macro (define-with-errno symbol ffi-symbol args)
-    `(define (,symbol ,@args)
-       (declare (not interrupts-enabled))
-       (let ((r (,ffi-symbol ,@args)))
-         (if (##fx< r 0)
-           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
-           r))))
 
   (namespace ("std/os/signal#"
               SIGHUP SIGINT SIGQUIT SIGILL SIGTRAP SIGABRT SIGBUS

--- a/src/std/os/signal.ss
+++ b/src/std/os/signal.ss
@@ -104,7 +104,7 @@
        (declare (not interrupts-enabled))
        (let ((r (,ffi-symbol ,@args)))
          (if (##fx< r 0)
-           (##fx- (__errno))
+           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
            r))))
 
   (namespace ("std/os/signal#"
@@ -118,11 +118,7 @@
               SIG_BLOCK SIG_UNBLOCK SIG_SETMASK
 
               __kill
-              __sigprocmask
-              __errno))
-
-  (define-c-lambda __errno () int
-    "___return (errno);")
+              __sigprocmask))
 
   (define-const SIGHUP)
   (define-const SIGINT)

--- a/src/std/os/signalfd.ss
+++ b/src/std/os/signalfd.ss
@@ -81,14 +81,11 @@
        (declare (not interrupts-enabled))
        (let ((r (,ffi-symbol ,@args)))
          (if (##fx< r 0)
-           (##fx- (__errno))
+           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
            r))))
 
   ;; private
-  (namespace ("std/os/signalfd#" __signalfd __errno))
-
-  (define-c-lambda __errno () int
-    "___return (errno);")
+  (namespace ("std/os/signalfd#" __signalfd))
 
   (define-const SFD_NONBLOCK)
   (define-const SFD_CLOEXEC)

--- a/src/std/os/signalfd.ss
+++ b/src/std/os/signalfd.ss
@@ -74,15 +74,6 @@
             _signalfd)
   (c-declare "#include <signal.h>")
   (c-declare "#include <sys/signalfd.h>")
-  (c-declare "#include <errno.h>")
-
-  (define-macro (define-with-errno symbol ffi-symbol args)
-    `(define (,symbol ,@args)
-       (declare (not interrupts-enabled))
-       (let ((r (,ffi-symbol ,@args)))
-         (if (##fx< r 0)
-           (##fx- (##c-code "___RESULT = ___FIX (errno);"))
-           r))))
 
   ;; private
   (namespace ("std/os/signalfd#" __signalfd))


### PR DESCRIPTION
- The macro is now part of the `begin-ffi` macros
- Accessing `errno` is done with inline C instead of an ffi wrapper.