### PR TITLE
Add random-string to misc/string

### DIFF
--- a/doc/reference/misc.md
+++ b/doc/reference/misc.md
@@ -5099,6 +5099,26 @@ Returns true when the string *s* consists only of whitespace characters.
 ```
 :::
 
+### random-string
+``` scheme
+(random-string [len = 10]) -> string | error
+
+  len := optional, length of the output string
+```
+
+`random-string` returns a string consisting of regex word-boundary
+characters (`[a-zA-Z0-9_]`). Throws an error if `len` is not a fixnum.
+
+::: tip Examples:
+``` scheme
+> (random-string)
+"5CfMyYd2Ob"
+
+> (random-string 0)
+""
+```
+:::
+
 ### line ending variables
 ``` scheme
 (define +cr+   "\r")

--- a/src/std/misc/string-test.ss
+++ b/src/std/misc/string-test.ss
@@ -1,7 +1,9 @@
 (export string-test)
 
 (import
-  :std/misc/string :std/srfi/13 :std/test :gerbil/gambit/exceptions)
+  :std/misc/string :std/srfi/13
+  :std/test :gerbil/gambit/exceptions
+  :std/pregexp)
 
 (def (error-with-message? message)
   (lambda (e)
@@ -58,4 +60,9 @@
       (check-equal? (string-whitespace? " ") #t)
       (check-equal? (string-whitespace? " \n") #t)
       (check-equal? (string-whitespace? " \n\t\r\f\v") #t)
-      (check-equal? (string-whitespace? " a") #f))))
+      (check-equal? (string-whitespace? " a") #f))
+    (test-case "random-string"
+      (check-eq? (and (pregexp-match "^\\w+$" (random-string 100)) #t) #t)
+      (check-equal? (random-string 0) "")
+      (check-equal? (random-string -1) "")
+      (check-equal? (string-length (random-string 5)) 5))))

--- a/src/std/misc/string.ss
+++ b/src/std/misc/string.ss
@@ -10,10 +10,12 @@
   string-trim-eol
   string-subst
   string-whitespace?
+  random-string
   +cr+ +lf+ +crlf+)
 
 (import
   (only-in :gerbil/gambit/ports write-substring write-string)
+  (only-in :gerbil/gambit/random random-integer)
   :std/srfi/13)
 
 ;; If the string starts with given prefix, return the end of the string after the prefix.
@@ -185,3 +187,31 @@
 ;;  (string-whitespace? " \n\r \t") => #t
 (def (string-whitespace? s)
   (string-every char-whitespace? s))
+
+
+(def (random-word-char)
+  (declare (not safe) (fixnum))
+  (def n (random-integer 63))
+  (integer->char
+   (+ n (cond
+	 ((< n 10) 48) ; 0-9
+	 ((< n 36) 55) ; A-Z
+	 ((< n 62) 61) ; a-z
+	 (else 33))))) ; _
+
+
+;; random-string returns a string consisting of regex word-boundary
+;; characters [a-zA-Z0-9_]. Throws an error if len is not a fixnum.
+;;
+;; Example:
+;;  (random-string) => "5CfMyYd2Ob"
+(def (random-string (len 10))
+  (declare (not safe) (fixnum))
+  (unless (fixnum? len) (error "len must be a fixnum"))
+  (if (> len 0)
+    (let (str (make-string len))
+      (do ((i 0 (1+ i)))
+	  ((= i len))
+	(string-set! str i (random-word-char)))
+      str)
+    ""))


### PR DESCRIPTION
The reason why I limited the characters to regex word boundary is because they can easily be typed on any keyboard and are file system friendly. Also there are no "evil characters" that might do something unexpected in a file path when a string generated by the procedure is used in a bash script.

I'll add the documentation when we have an agreement on the scope of `random-string`.
