### PR TITLE
Some runtime optimizations

### DIFF
--- a/src/bootstrap/gerbil/core.ssxi.ss
+++ b/src/bootstrap/gerbil/core.ssxi.ss
@@ -384,7 +384,7 @@ package: gerbil
  fxarithmetic-shift
  set-box!
  memf find
- remq remv remf
+ remove remq remv remf
  hash-key?
  hash-map
  string-shrink!
@@ -447,7 +447,6 @@ package: gerbil
  (assgetq 2 3)
  (assgetv 2 3)
  (assget 2 3)
- (remove 2 3)
  (pgetq 2 3)
  (pgetv 2 3)
  (pget 2 3)

--- a/src/gerbil/prelude/core.ssxi.ss
+++ b/src/gerbil/prelude/core.ssxi.ss
@@ -384,7 +384,7 @@ package: gerbil
  fxarithmetic-shift
  set-box!
  memf find
- remq remv remf
+ remove remq remv remf
  hash-key?
  hash-map
  string-shrink!
@@ -447,7 +447,6 @@ package: gerbil
  (assgetq 2 3)
  (assgetv 2 3)
  (assget 2 3)
- (remove 2 3)
  (pgetq 2 3)
  (pgetv 2 3)
  (pget 2 3)


### PR DESCRIPTION
The procedure families `rem*`, `assget*`, and `pget*` have been specialized to inline the parametric function.
Also of note, `remove` has lost the optional argument -- use `remf` instead.