### PR TITLE
Create target directories in make

### DIFF
--- a/src/gerbil/runtime/gx-gambc0.scm
+++ b/src/gerbil/runtime/gx-gambc0.scm
@@ -1663,16 +1663,16 @@
      (else
       (create-directory path))))
 
-  (let lp ((start 0))
-    (cond
-     ((string-index dir #\/ start)
-      => (lambda (x)
-           (when (##fx> x 0)
-             (create1 (substring dir 0 x)))
-           (lp (##fx+ x 1))))
-     (else
-      (create1 dir)
-      (path-normalize dir)))))
+  (unless (file-exists? dir)
+    (let lp ((start 0))
+      (cond
+       ((string-index dir #\/ start)
+        => (lambda (x)
+             (when (##fx> x 0)
+               (create1 (substring dir 0 x)))
+             (lp (##fx+ x 1))))
+       (else
+        (create1 dir))))))
 
 ;; kwt: #f or a vector as a perfect hash-table for expected keywords
 (define (keyword-dispatch kwt K . all-args)

--- a/src/std/make.ss
+++ b/src/std/make.ss
@@ -55,6 +55,10 @@
          (buildset (if depgraph
                      (expand-build-deps buildset buildspec depgraph)
                      buildset)))
+    (create-directory* bindir)
+    (create-directory* libdir)
+    (when static
+      (create-directory* (path-expand "static" libdir)))
     (for-each (cut build <> settings) buildset)))
 
 (def (message . rest)


### PR DESCRIPTION
Also optimizes `create-directory*` to check for existence of the target before traversing the hierarchy.