### PR TITLE
Static mux for httpd

### DIFF
--- a/doc/reference/httpd.md
+++ b/doc/reference/httpd.md
@@ -1,68 +1,59 @@
 # The Embedded HTTP Server
 
 The `:std/net/httpd` library provides an embedded HTTP/1.1 server, which you can
-use to server web applications and apis from your program.
+use to serve web applications and apis from your program.
 
 See the [tutorial](/tutorials/httpd.md) for a simple example program which uses
 the server.
 
-::: tip usage
+::: tip To use the bindings from this package:
+```scheme
 (import :std/net/httpd)
+```
 :::
 
 ## Server Interface
 
 ### current-http-server
-
-::: tip usage
-```
+```scheme
 (current-http-server [server])
 ```
-:::
 
 Parameter denoting the current http server.
 
 ### start-http-server!
-
-::: tip usage
-```
+```scheme
 (start-http-server! [mux: mux = (make-default-http-mux)]
                     [backlog: backlog = 10]
                     [sockopts: sockopts = [SO_REUSEADDR]]
-                    address ...)
+                    address ...) -> <server>
+
   mux := request multiplexer
   backlog := server socket listen backlog
   sockpts := server socket options.
   address ... := addresses to listen
-=> <server>
 ```
-:::
 
 Start a new http server serving in the specified addresses and multiplexing
 requests using the specified multiplexer.
 
 ### stop-http-server!
-
-::: tip usage
-```
+```scheme
 (stop-http-server! <server>)
 ```
-:::
 
 Stops the http server and all associated threads.
 
 
 ### http-register-handler
-
-::: tip usage
-```
+```scheme
 (http-register-handler httpd path handler [host = #f])
+
   httpd   := server; the http server
   path    := string; the path to associate with the handler
   handler := procedure; the request handler
   host    := string; the host to associate with the handler
 ```
-:::
 
 Registers a new http request handler, for multiplexers that support dynamic
 request handlers.
@@ -87,30 +78,62 @@ may define this method as void if they don't support dynamic handler
 registration.
 
 ### make-default-http-mux
+```scheme
+(make-default-http-mux [default = #f]) -> <mux>
 
-::: tip usage
-```
-(make-default-http-mux [default = #f])
   default := handler; the default page handler
-=> <mux>
 ```
-:::
 
 Creates a default request multiplexer, which maps exact paths to
 handlers for all hosts. The default handler is returned if no handler
 has been registered for the path.
 
-### recursive-http-mux
+### make-recursive-http-mux
+```scheme
+(make-recursive-http-mux [default = #f]) -> <mux>
 
-::: tip usage
+  default := handler; the default page handler
 ```
-(make-recursive-http-mux [default = #f])
-```
-:::
 
 Creates a request multiplexer that maps paths and their subpaths to
 handlers for all hosts. The default handler is returned if no handler
 has been registered for the path or a prefix.
+
+### make-static-http-mux
+```scheme
+(make-static-http-mux table [default = #f]) -> <mux>
+
+  table   := hash table, mapping paths (strings) to handlers
+  default := the default page handler
+```
+
+Creates a static request multiplexer initialized from a hash table of handlers.
+The multiplexer does not support dynamic handler registration with `put-handler!`.
+The advantage over the default mux is that there is no mutex associated with the
+handler table, resulting in faster (concurrent) handler lookup.
+
+### make-recursive-static-http-mux
+```scheme
+(make-recursive-static-http-mux table [default = #f]) -> <mux>
+
+  table   := hash table, mapping paths (strings) to handlers
+  default := the default page handler
+```
+
+Creates a static request multiplexer initialized from a hash table of handlers.
+Like `make-recursive-http-mux`, the multiplexer maps paths and their subpaths to
+handlers for all hosts.
+
+### make-custom-http-mux
+```scheme
+(make-custom-http-mux getf [setf = void]) -> <mux>
+
+  getf := procedure that resolves the handler
+  setf := procedure that adds a new handler
+```
+
+Creates a request multiplexer that dispatches to user procedures for handler
+resolution and registration.
 
 ## Request Handler Interface
 
@@ -118,207 +141,147 @@ The request handler is a procedure accepting two arguments, a request
 and a response.
 
 ### http-request?
-
-::: tip usage
+```scheme
+(http-request? obj) -> boolean
 ```
-(http-request? obj)
-=> boolean
-```
-:::
 
 Returns true for http request objects.
 
 ### http-request-method
-
-::: tip usage
+```scheme
+(http-request-method <request>) -> symbol
 ```
-(http-request-method <request>)
-=> symbol
-```
-:::
 
 Returns the request method.
 
 ### http-request-url
-
-::: tip usage
+```scheme
+(http-request-url <request>) -> string
 ```
-(http-request-url <request>)
-=> string
-```
-:::
 
 Returns the request URL.
 
 ### http-request-path
-
-::: tip usage
+```scheme
+(http-request-path <request>) -> string
 ```
-(http-request-path <request>)
-=> string
-```
-:::
 
 Returns the request path.
 
 ### http-request-params
-
-::: tip usage
+```scheme
+(http-request-params <request>) -> string or #f
 ```
-(http-request-params <request>)
-=> string or #f
-```
-:::
 
 Returns the request parameters.
 
 ### http-request-proto
-
-::: tip usage
+```scheme
+(http-request-proto <request>) -> string
 ```
-(http-request-proto <request>)
-=> string
-```
-:::
 
 Returns the request protocol.
 
 ### http-request-client
-
-::: tip usage
+```scheme
+(http-request-client <request>) -> address
 ```
-(http-request-client <request>)
-=> <address>
-```
-:::
 
 Returns the IP address of the request client.
 
 ### http-request-headers
-
-::: tip usage
+```scheme
+(http-request-headers <request>) -> alist
 ```
-(http-request-headers <request>)
-=> alist
-```
-:::
 
 Returns the request headers, as an associative list of string to string;
 the headers are title-cased.
 
 ### http-request-body
-
-::: tip usage
+```scheme
+(http-request-body <request>) -> u8vector or #f
 ```
-(http-request-body <request>)
-=> u8vector or #f
-```
-:::
 
 Reads and returns the request body.
 
 ### http-request-timeout-set!
-
-::: tip usage
+```scheme
+(http-request-timeout-set! <request> <timeout>) -> unspecified
 ```
-(http-request-timeout-set! <request> <timeout>)
-```
-:::
 
 Sets the request timeout (in seconds).
 
 ### http-response?
-
-::: tip usage
+```scheme
+(http-response? obj) -> boolean
 ```
-(http-response? obj)
-=> boolean
-```
-:::
 
 Returns true for http response objects.
 
 ### http-response-write
+```scheme
+(http-response-write res status headers body) -> unspecified
 
-::: tip usage
-```
-(http-response-write res status headers body)
   res := the http response object
   status := fixnum; the response status code
   headers := alist; the response headers
   body := string, u8vector or #f; the response body
 ```
-:::
 
 Writes a complete response.
 
 ### http-response-begin
+```scheme
+(http-response-begin res status headers) -> unspecified
 
-::: tip usage
-```
-(http-response-begin res status headers)
   res := the http response object
   status := fixnum; the response status code
   headers := alist; the response headers
 ```
-:::
 
-Begins a chunk response.
+Begins a chunked response.
 
 ### http-response-chunk
+```scheme
+(http-response-chunk res chunk [start = 0] [end = #f]) -> unspecified
 
-::: tip usage
-```
-(http-response-chunk res chunk [start = 0] [end = #f])
   res := the http response object
   chunk := string or u8vector; the response chunk
   start := fixnum; the start index in the chunk
   end := fixnum or #f; the end index in the chunk
 ```
-:::
 
 Writes the next chunk in a chunked response.
 
 ### http-response-end
-
-::: tip usage
+```scheme
+(http-response-end <response>) -> unspecified
 ```
-(http-response-end <response>)
-```
-:::
 
 Ends a chunked response.
 
 ### http-response-file
+```scheme
+(http-response-file res headers path) -> unspecified
 
-::: tip usage
-```
-(http-response-file res headers path)
   res := the http response object
   headers := alist; the response headers
   path := string; the path to the file to serve as the response
 ```
-:::
 
 Writes a file as a response.
 
 ### http-response-force-output
-
-::: tip usage
+```scheme
+(http-response-force-output <response>) -> unspecified
 ```
-(http-response-force-output <response>)
-```
-:::
 
 Flushes the response buffer.
 
 ### http-response-timeout-set!
-
-::: tip usage
+```scheme
+(http-response-timeout-set! <response> <timeout>) -> unspecified
 ```
-(http-response-timeout-set! <response> <timeout>)
-```
-:::
 
 Sets the response timeout.
 
@@ -326,72 +289,51 @@ Sets the response timeout.
 ## Server Configuration Options
 
 ### set-httpd-request-timeout!
-
-::: tip usage
+```scheme
+(set-httpd-request-timeout! <timeout>) -> unspecified
 ```
-(set-httpd-request-timeout! <timeout>)
-```
-:::
 
 Sets the http request timeout; default is 60s.
 
 ### set-httpd-response-timeout!
-
-::: tip usage
+```scheme
+(set-httpd-response-timeout! <timeout>) -> unspecified
 ```
-(set-httpd-response-timeout! <timeout>)
-```
-:::
 
 Sets the http response timeout; default is 120s.
 
 ### set-httpd-max-request-headers!
-
-::: tip usage
+```scheme
+(set-httpd-max-request-headers! <fixnum>) -> unspecified
 ```
-(set-httpd-max-request-headers! <fixnum>)
-```
-:::
 
 Sets the maximum number of headers to accept in a request; default is 256.
 
 ### set-httpd-max-token-length!
-
-::: tip usage
-```
-(set-httpd-max-token-length! <fixnum>)
+```scheme
+(set-httpd-max-token-length! <fixnum>) -> unspecified
 
 ```
-:::
 
 Sets the maximum header token length; default is 1024
 
 ### set-httpd-max-request-body-length!
-
-::: tip usage
 ```
-(set-httpd-max-request-body-length! <fixnum>)
+(set-httpd-max-request-body-length! <fixnum>) -> unspecified
 ```
-:::
 
 Sets the maximum request body length; default is 1MB.
 
 ### set-httpd-input-buffer-size!
-
-::: tip usage
+```scheme
+(set-httpd-input-buffer-size! <fixnum>) -> unspecified
 ```
-(set-httpd-input-buffer-size! <fixnum>)
-```
-:::
 
 Sets the request input buffer size; default is 4KB.
 
 ### set-httpd-output-buffer-size!
-
-::: tip usage
+```scheme
+(set-httpd-output-buffer-size! <fixnum>) -> unspecified
 ```
-(set-httpd-output-buffer-size! <fixnum>)
-```
-:::
 
 Sets the response output buffer size; default is 4KB.

--- a/src/std/net/httpd.ss
+++ b/src/std/net/httpd.ss
@@ -11,6 +11,9 @@
         current-http-server
         make-default-http-mux
         make-recursive-http-mux
+        make-static-http-mux
+        make-recursive-static-http-mux
+        make-custom-http-mux
         http-register-handler
         http-request?
         http-request-method http-request-url http-request-path http-request-params

--- a/src/std/net/httpd/mux.ss
+++ b/src/std/net/httpd/mux.ss
@@ -13,7 +13,7 @@
 
 ;; default mux implementation -- paths are resolved with an exact match
 (defstruct default-http-mux (t default)
-  constructor: :init!)
+  constructor: :init! unchecked: #t)
 
 (defmethod {:init! default-http-mux}
   (lambda (self (default #f))
@@ -21,12 +21,12 @@
 
 (defmethod {put-handler! default-http-mux}
   (lambda (self host path handler)
-    (sync-hash-put! (default-http-mux-t self) path handler)))
+    (sync-hash-put! (&default-http-mux-t self) path handler)))
 
 (defmethod {get-handler default-http-mux}
   (lambda (self host path)
-    (sync-hash-ref (default-http-mux-t self) path
-                   (default-http-mux-default self))))
+    (sync-hash-ref (&default-http-mux-t self) path
+                   (&default-http-mux-default self))))
 
 ;; recursive mux -- resolves paths up to their parent
 (defstruct (recursive-http-mux default-http-mux) ())
@@ -40,15 +40,48 @@
       (lambda (ht)
         (let lp ((path path))
           (cond
-           ((hash-get ht path) => values)
+           ((hash-get ht path))
            ((string-rindex path #\/)
             => (lambda (ix) (lp (substring path 0 ix))))
            (else
             (default-http-mux-default self))))))))
 
+;; static mux -- paths are resolved in a static hash table, which elides the need for a mutex
+(defstruct static-http-mux (t default)
+  constructor: :init! unchecked: #t)
+
+(defmethod {:init! static-http-mux}
+  (lambda (self tab (default #f))
+    (struct-instance-init! self tab default)))
+
+(defmethod {put-handler! static-http-mux}
+  (lambda (self host path handler)
+    (error "mux does not support dynamic handler registration")))
+
+(defmethod {get-handler static-http-mux}
+  (lambda (self host path)
+    (hash-ref (&static-http-mux-t self) path
+              (&static-http-mux-default self))))
+
+;; recursive static mux -- resolves paths up to their parent
+(defstruct (recursive-static-http-mux static-http-mux) ())
+
+(defmethod {:init! recursive-static-http-mux}
+  static-http-mux:::init!)
+
+(defmethod {get-handler recursive-static-http-mux}
+  (lambda (self host path)
+    (let (ht (&static-http-mux-t self))
+      (let lp ((path path))
+        (cond
+         ((hash-get ht path))
+         ((string-rindex path #\/)
+          => (lambda (ix) (lp (substring path 0 ix))))
+         (else (&static-http-mux-default self)))))))
+
 ;; custom mux -- it dispatches all resolutions/registrations to user supplied functions
 (defstruct custom-http-mux (get put)
-  constructor: :init! final: #t)
+  constructor: :init! final: #t unchecked: #t)
 
 (defmethod {:init! custom-http-mux}
   (lambda (self get (put void))
@@ -56,8 +89,8 @@
 
 (defmethod {get-handler custom-http-mux}
   (lambda (self host path)
-    ((custom-http-mux-get self) host path)))
+    ((&custom-http-mux-get self) host path)))
 
-(defmethod {put-handler custom-http-mux}
+(defmethod {put-handler! custom-http-mux}
   (lambda (self host path handler)
-    ((custom-http-mux-put self) host path handler)))
+    ((&custom-http-mux-put self) host path handler)))

--- a/src/std/net/httpd/server.ss
+++ b/src/std/net/httpd/server.ss
@@ -73,8 +73,11 @@
 
   (def (loop)
     (<- ((!httpd.register host path handler k)
-         (put-handler! host path handler)
-         (!!value (void) k)
+         (try
+          (put-handler! host path handler)
+          (!!value (void) k)
+          (catch (e)
+            (!!error e k)))
          (loop))
         ((!httpd.shutdown)
          (void))

--- a/src/std/net/httpd/server.ss
+++ b/src/std/net/httpd/server.ss
@@ -54,13 +54,15 @@
 
 ;;; implementation
 (def (http-server socks sas mux)
-  (using mux get-handler put-handler!)
+  (with-methods mux get-handler put-handler!)
 
   (def acceptors
-    (map (lambda (sock sa)
-           (spawn/name 'http-server-accept
-                       http-server-accept get-handler sock (socket-address-family sa)))
-         socks sas))
+    (parameterize ((current-http-server (current-thread)))
+      (map
+        (lambda (sock sa)
+          (spawn/name 'http-server-accept
+                      http-server-accept (cut get-handler mux <> <>) sock (socket-address-family sa)))
+           socks sas)))
 
   (def (shutdown!)
     (for-each ssocket-close socks))
@@ -74,7 +76,7 @@
   (def (loop)
     (<- ((!httpd.register host path handler k)
          (try
-          (put-handler! host path handler)
+          (put-handler! mux host path handler)
           (!!value (void) k)
           (catch (e)
             (!!error e k)))


### PR DESCRIPTION
- Adds a `static-http-mux` to the available httpd multiplexers; this one takes a static hash table and uses no mutex; it doesn't allow dynamic handler registration.
- Updates the httpd documentation to the new standard
- Updates the httpd perf benchmark program in `src/misc/http-perf` to use the static mux, which sends it over 35K requests/s in my laptop (up from about 34.3K).