### PR TITLE
Gerbil.el - Lexical-binding fixes and improvements

### DIFF
--- a/etc/gerbil.el
+++ b/etc/gerbil.el
@@ -78,8 +78,7 @@
   (message (concat "Gerbil-info : SENT=" string " ...")))
 
 (defun gerbil-send-string (string)
-  (let ((string (concat string "\n"))
-        (string-len (length string)))
+  (let ((string (concat string "\n")))
     (comint-check-source string)
     (comint-send-string (scheme-proc) string)
     (gerbil-message (seq-subseq string 0 (string-match "\n" string)))))

--- a/etc/gerbil.el
+++ b/etc/gerbil.el
@@ -198,7 +198,7 @@
         (with-current-buffer buf
           (goto-char (point-max))
           (when (re-search-backward gerbil-compile-mark-rx nil t)
-            (let (limit (point))
+            (let ((limit (point)))
               (goto-char (point-max))
               (when (re-search-backward gerbil-error-locat-rx limit t)
                 (let* ((loc (gerbil-extract-locat (buffer-substring (point) (point-max))))

--- a/etc/gerbil.el
+++ b/etc/gerbil.el
@@ -206,7 +206,8 @@
                                   (concat gerbil-build-directory (car loc))
                                 (car loc))))
                   (find-file fname)
-                  (goto-line (cadr loc))
+                  (goto-char (point-min))
+                  (forward-line (1- (cadr loc)))
                   (forward-char (- (caddr loc) 1))
                   (mark-sexp)))))))
        (t

--- a/etc/gerbil.el
+++ b/etc/gerbil.el
@@ -74,10 +74,6 @@
   "Send a string to the inferior Scheme process."
   (gerbil-send-string str))
 
-(defun scheme-compile-region (start end)
-  (interactive)
-  (gerbil-compile-current-buffer))
-
 (defun gerbil-message (string)
   (message (concat "Gerbil-info : SENT=" string " ...")))
 

--- a/etc/gerbil.el
+++ b/etc/gerbil.el
@@ -1,4 +1,4 @@
-;;; gerbil.el --- Gerbil mode  -*- lexical-binding: t; -*-
+;;; gerbil.el --- Gerbil mode -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2007-2019 Dimitris Vyzovitis & Contributors
 ;;


### PR DESCRIPTION
After byte-compiling `gerbil.el` I realized that an error was triggered due to `lexical-binding`.

This pull request fixes the error, removes all the warnings and some unused code, so that it works as before 😃 