### PR TITLE
avoid internal expansion in @expand and @expand1

### DIFF
--- a/doc/guide/shell.md
+++ b/doc/guide/shell.md
@@ -23,7 +23,15 @@ Starts a repl using the syntactic context of a given module, which is first eval
 (@expand1 form)
 ```
 
-These two macros perform macro expansion, pretty print the result, and return the quoted expanded syntax for inspection. The difference lies in the function used to perform the expansion. `@expand` uses core-expand* which expands until the outer form is a core macro. `@expand1` uses core-expand1 which performs a single step expansion.
+These two macros perform macro expansion, pretty print the result, and return the expanded syntax for inspection. The difference lies in the function used to perform the expansion. `@expand` uses core-expand* which expands until the outer form is a core macro. `@expand1` uses core-expand1 which performs a single step expansion.
+
+
+```
+(macro-expand quoted-form)
+(macro-expand1 quoted-form)
+```
+
+Procedural forms of `@expand` and `@expand1`.
 
 ## Customizing the Interactive Shell
 

--- a/src/std/interactive.ss
+++ b/src/std/interactive.ss
@@ -2,7 +2,7 @@
 ;;; © vyzo
 ;;; interactive development utilities
 
-(import (for-syntax (only-in :gerbil/gambit/misc pretty-print)))
+(import (only-in :gerbil/gambit/misc pretty-print))
 (export #t (for-syntax #t))
 
 ;; Module reloading
@@ -46,19 +46,21 @@
 
 ;; Macro expansion
 ;; These two macros expand a form, pretty print the expansion, and
-;; return a quoted syntax of the expansion for debugging purposes.
+;; return the result of the expansion for debugging purposes.
 ;; @expand uses core-expand* while @expand1 performs a single step
 ;; expansion with core-expand1
-(defsyntax (@expand stx)
-  (syntax-case stx ()
-    ((_ expr)
-     (with-syntax ((expr* (gx#core-expand* #'expr)))
-       (pretty-print (syntax->datum #'expr*))
-       #'(quote-syntax expr*)))))
+(defrules @expand ()
+  ((_ expr) (macro-expand 'expr)))
 
-(defsyntax (@expand1 stx)
-  (syntax-case stx ()
-    ((_ expr)
-     (with-syntax ((expr* (gx#core-expand1 #'expr)))
-       (pretty-print (syntax->datum #'expr*))
-       #'(quote-syntax expr*)))))
+(defrules @expand1 ()
+  ((_ expr) (macro-expand1 'expr)))
+
+(def (macro-expand expr)
+  (let (expr* (gx#core-expand* expr))
+    (pretty-print (gx#syntax->datum expr*))
+    expr*))
+
+(def (macro-expand1 expr)
+  (let (expr* (gx#core-expand1 expr))
+    (pretty-print (gx#syntax->datum expr*))
+    expr*))

--- a/src/std/interactive.ss
+++ b/src/std/interactive.ss
@@ -55,12 +55,10 @@
 (defrules @expand1 ()
   ((_ expr) (macro-expand1 'expr)))
 
-(def (macro-expand expr)
-  (let (expr* (gx#core-expand* expr))
+(def (macro-expand expr (expand-e gx#core-expand*))
+  (let (expr* (expand-e expr))
     (pretty-print (gx#syntax->datum expr*))
     expr*))
 
 (def (macro-expand1 expr)
-  (let (expr* (gx#core-expand1 expr))
-    (pretty-print (gx#syntax->datum expr*))
-    expr*))
+  (macro-expand expr gx#core-expand1))


### PR DESCRIPTION
Introduces procedural forms for macro expansion, `macro-expand` and `macro-expand1`, and expands `@expand` and `@expand1` to use them.

This avoids internal expansion, which has interesting side-effects -- eg it breaks for macros that use `syntax-local-introduce`.