### PR TITLE
Build system improvements

### DIFF
--- a/src/gerbil/runtime/gx-gambc.scm
+++ b/src/gerbil/runtime/gx-gambc.scm
@@ -128,14 +128,31 @@
   (apply cons-expander-load-path paths))
 
 (define (cons-library-load-path . paths)
-  (let* ((current (&current-module-libpath))
-         (paths (map path-normalize paths)))
+  (let ((current (&current-module-libpath))
+        (paths (map path-normalize paths)))
     (&current-module-libpath (append paths current))))
 
 (define (cons-expander-load-path . paths)
-  (let* ((current (gx#current-expander-module-library-path))
-         (paths (map path-normalize paths)))
+  (let ((current (gx#current-expander-module-library-path))
+        (paths (map path-normalize paths)))
     (gx#current-expander-module-library-path (append paths current))))
+
+(define (with-cons-load-path thunk . paths)
+  (apply with-cons-library-load-path
+    (lambda () (apply with-cons-expander-load-path thunk paths))
+    paths))
+
+(define (with-cons-library-load-path thunk . paths)
+  (let ((current (&current-module-libpath))
+        (paths (map path-normalize paths)))
+    (parameterize ((&current-module-libpath (append paths current)))
+      (thunk))))
+
+(define (with-cons-expander-load-path thunk . paths)
+  (let ((current (gx#current-expander-module-library-path))
+        (paths (map path-normalize paths)))
+    (parameterize ((gx#current-expander-module-library-path (append paths current)))
+      (thunk))))
 
 ;; stuffs
 (define (_gx#expand-source src)

--- a/src/std/build-script.ss
+++ b/src/std/build-script.ss
@@ -46,9 +46,11 @@
                             (["spec"]
                              (pretty-print build-spec))
                             (["deps"]
-                             (cons-load-path @srcdir)
-                             (let (build-deps (make-depgraph/spec @build-spec))
-                               (call-with-output-file "build-deps" (cut write build-deps <>))))
+                             (with-cons-load-path
+                              (lambda ()
+                                (let (build-deps (make-depgraph/spec @build-spec))
+                                  (call-with-output-file "build-deps" (cut write build-deps <>))))
+                              @srcdir))
                             (["compile"]
                              (let (depgraph (call-with-input-file "build-deps" read))
                                (make srcdir: @srcdir

--- a/src/std/make.ss
+++ b/src/std/make.ss
@@ -37,8 +37,9 @@
        prefix: (prefix #f)
        force:  (force? #f)
        optimize: (optimize #f)
-       debug:  (debug? #f)
+       debug:  (debug #f)
        static: (static #f)
+       static-debug: (static-debug #f)
        verbose: (verbose #f)
        depgraph: (depgraph #f))
   (let* ((gerbil-path (getenv "GERBIL_PATH" "~/.gerbil"))
@@ -47,8 +48,9 @@
          (bindir (or bindir (path-expand "bin" gerbil-path)))
          (settings  [srcdir: srcdir libdir: libdir bindir: bindir
                      prefix: prefix force: force?
-                     optimize: optimize debug: debug?
-                     static: static verbose: verbose])
+                     optimize: optimize debug: debug
+                     static: static static-debug: static-debug
+                     verbose: verbose])
          (buildset (if (not force?)
                      (filter (cut build? <> settings depgraph) buildspec)
                      buildspec))
@@ -505,7 +507,7 @@
     [invoke-gsc: #t
      output-file: binpath
      verbose: (pgetq verbose: settings)
-     debug: (pgetq debug: settings)
+     debug: (pgetq static-debug: settings)
      (if gsc-opts [gsc-options: gsc-opts] []) ...])
   (gxc-compile mod gsc-opts [static: #t settings ...] #f)
   (message "... compile static exe " mod " -> " (path-strip-directory binpath))


### PR DESCRIPTION
- Adds a seperate static-debug: option to `make`, so that default `defbuild-script` options do not bloat binary size and compilation time.
- Adds a `with-cons-load-path` primitive to `gx-gambc`, so that dependencies can be generated without affecting the load path of compilation.
- Uses `with-cons-load-path` in dependency generation in `defbuild-script`.

cc @ober 