### PR TITLE
generic dispatch: unroll apply for generic methods of up to 3 arguments

### DIFF
--- a/src/std/generic/macros.ss
+++ b/src/std/generic/macros.ss
@@ -24,8 +24,11 @@
                    (procedure-id (format-id #'id "~a::apply" #'id))
                    (procedure
                     (syntax/loc stx
-                      (def (procedure-id . args)
-                        (apply generic-dispatch dispatch-table-id args))))
+                      (def* procedure-id
+                        ((arg1) (generic-dispatch1 dispatch-table-id arg1))
+                        ((arg1 arg2) (generic-dispatch2 dispatch-table-id arg1 arg2))
+                        ((arg1 arg2 arg3) (generic-dispatch3 dispatch-table-id arg1 arg2 arg3))
+                        (args (apply generic-dispatch dispatch-table-id args)))))
                    (meta
                     #'(defsyntax id
                         (make-generic-info


### PR DESCRIPTION
This unrolls the apply by specializing dispatch for generic methods of up to 3 arguments.
It results to a great speed up as there is no allocation for application any more.
The trivial `(:ref vec 1)` test, repeated 10M times, went from `1.88s` to `0.25s` in my laptop.