### PR TITLE
Some more generic tuning

### DIFF
--- a/src/std/generic/dispatch.ss
+++ b/src/std/generic/dispatch.ss
@@ -6,7 +6,7 @@
 (export type-of linear-type-of type-linearize-class
         make-generic generic? generic-id generic-dispatch
         generic-bind! generic-dispatch generic-dispatch-next
-        generic-dispatch1 generic-dispatch2 generic-dispatch3)
+        generic-dispatch1 generic-dispatch2 generic-dispatch3 generic-dispatch4)
 
 (declare (not safe))
 
@@ -321,6 +321,7 @@
 (defdispatch* generic-dispatch1 generic-dispatch-method1 generic-dispatch-cache-lookup1 1 arg1)
 (defdispatch* generic-dispatch2 generic-dispatch-method2 generic-dispatch-cache-lookup2 2 arg1 arg2)
 (defdispatch* generic-dispatch3 generic-dispatch-method3 generic-dispatch-cache-lookup3 3 arg1 arg2 arg3)
+(defdispatch* generic-dispatch4 generic-dispatch-method4 generic-dispatch-cache-lookup4 4 arg1 arg2 arg3 arg4)
 
 (def (generic-dispatch-find-method methods args)
   (let (arg-types (map linear-type-of args))
@@ -418,19 +419,18 @@
          (obj (##vector-ref cache ix)))
     (cache-hash-ref obj tid)))
 
-(def (cache-hash2 cache mix shift arg1 arg2)
-  (declare (not interrupts-enabled))
-  (let* ((tid (type-of arg1))
-         (hash (cache-hash-e mix shift tid))
-         (obj (cache-hash1 cache hash (fx1+ shift) arg2)))
-    (cache-hash-ref obj tid)))
+(defrules defcache-hash* ()
+  ((_ cache-hash cache-hash-next arg1 arg ...)
+   (def (cache-hash cache mix shift arg1 arg ...)
+     (declare (not interrupts-enabled))
+     (let* ((tid (type-of arg1))
+            (hash (cache-hash-e mix shift tid))
+            (obj (cache-hash-next cache hash (fx1+ shift) arg ...)))
+       (cache-hash-ref obj tid)))))
 
-(def (cache-hash3 cache mix shift arg1 arg2 arg3)
-  (declare (not interrupts-enabled))
-  (let* ((tid (type-of arg1))
-         (hash (cache-hash-e mix shift tid))
-         (obj (cache-hash2 cache hash (fx1+ shift) arg2 arg3)))
-    (cache-hash-ref obj tid)))
+(defcache-hash* cache-hash2 cache-hash1 arg1 arg2)
+(defcache-hash* cache-hash3 cache-hash2 arg1 arg2 arg3)
+(defcache-hash* cache-hash4 cache-hash3 arg1 arg2 arg3 arg4)
 
 (defrules deflookup* ()
   ((_ lookup-e hash-e arg ...)
@@ -442,6 +442,7 @@
 (deflookup* generic-dispatch-cache-lookup1 cache-hash1 arg1)
 (deflookup* generic-dispatch-cache-lookup2 cache-hash2 arg1 arg2)
 (deflookup* generic-dispatch-cache-lookup3 cache-hash3 arg1 arg2 arg3)
+(deflookup* generic-dispatch-cache-lookup4 cache-hash4 arg1 arg2 arg3 arg4)
 
 ;; cache the result of method dispatch
 (def (generic-dispatch-cache! gtab args method)

--- a/src/std/generic/dispatch.ss
+++ b/src/std/generic/dispatch.ss
@@ -410,6 +410,7 @@
      (else #f))))
 
 (def (cache-hash1 cache mix shift arg)
+  (declare (not interrupts-enabled))
   (let* ((tid (type-of arg))
          (hash (cache-hash-e mix shift tid))
          (len (##vector-length cache))
@@ -418,12 +419,14 @@
     (cache-hash-ref obj tid)))
 
 (def (cache-hash2 cache mix shift arg1 arg2)
+  (declare (not interrupts-enabled))
   (let* ((tid (type-of arg1))
          (hash (cache-hash-e mix shift tid))
          (obj (cache-hash1 cache hash (fx1+ shift) arg2)))
     (cache-hash-ref obj tid)))
 
 (def (cache-hash3 cache mix shift arg1 arg2 arg3)
+  (declare (not interrupts-enabled))
   (let* ((tid (type-of arg1))
          (hash (cache-hash-e mix shift tid))
          (obj (cache-hash2 cache hash (fx1+ shift) arg2 arg3)))

--- a/src/std/generic/macros.ss
+++ b/src/std/generic/macros.ss
@@ -28,6 +28,7 @@
                         ((arg1) (generic-dispatch1 dispatch-table-id arg1))
                         ((arg1 arg2) (generic-dispatch2 dispatch-table-id arg1 arg2))
                         ((arg1 arg2 arg3) (generic-dispatch3 dispatch-table-id arg1 arg2 arg3))
+                        ((arg1 arg2 arg3 arg4) (generic-dispatch4 dispatch-table-id arg1 arg2 arg3 arg4))
                         (args (apply generic-dispatch dispatch-table-id args)))))
                    (meta
                     #'(defsyntax id


### PR DESCRIPTION
- disables interrupts in unrolled hash look ups.
- defines unrolled method specializations for 4 arguments.