### PR TITLE
add define-c-struct macro for ffi with c structs

### DIFF
--- a/doc/reference/foreign.md
+++ b/doc/reference/foreign.md
@@ -27,6 +27,7 @@ The following prelude macros are available within the body:
 (define-const* id)
 (define-guard guard defn)
 (define-with-errno id ffi-id args)
+(define-c-struct struct-name members release-function)
 ```
 
 The following declarations are included before the body:
@@ -36,6 +37,10 @@ The following declarations are included before the body:
 #define U8_LEN(u8vector) ...
 static ___SCMOBJ ffi_free (void *ptr);
 ```
+
+In case you are using define-c-struct without a release function and have a string member,
+then a `<struct-name>_ffi_free` function is included, which apart from freeing the ptr also
+cleans up any string member.
 
 The following definitions are included after the body:
 

--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -3,6 +3,8 @@
   `((gxc: "build-config" dep: ("build-features.ss"))
     "interactive"
     "foreign"
+    ;; tests for :std/foreign
+    "foreign-test"
     "format"
     "pregexp"
     "sort"

--- a/src/std/foreign-test.ss
+++ b/src/std/foreign-test.ss
@@ -1,0 +1,135 @@
+(import :std/foreign
+        :std/test)
+
+(export foreign-test)
+
+(begin-ffi (f
+            (struct abc a b)
+            (struct foo a1 d2 str)
+            (struct bar i j)
+            g)
+  (c-declare "
+struct abc {
+    char* a;
+    char* b;
+    char* c;
+};
+struct d { int e;};
+
+struct foo {
+    struct abc* a1;
+    struct abc* d2;
+    char* str;
+};
+
+struct bar {
+int i;
+int j;
+};
+")
+
+
+  (c-define-type d (struct "d"))
+  (define-c-lambda f () int "___return(2);")
+  (define-c-lambda g () int "___return(2);")
+  (define-c-struct abc ((a . char-string)
+                        (b . char-string)))
+
+  (define-c-struct foo ((a1 . abc*)
+                        (d2 . abc*)
+                        (str . char-string)))
+  (define-c-struct bar ((i . int)
+                        (j . int))))
+
+(define foreign-test
+  (test-suite "test :std/foreign"
+
+              (def test-str1 "hello")
+              (def test-str2 "world")
+
+              (define (make-abc a b)
+                (let (o (malloc-abc))
+                  (abc-a-set! o a)
+                  (abc-b-set! o b)
+                  o))
+
+              (test-case "c struct"
+                         (def obj (malloc-abc))
+
+                         (abc-a-set! obj test-str1)
+                         (abc-b-set! obj test-str2)
+
+                         (check (abc-a obj) => test-str1)
+                         (check (abc-b obj) => test-str2)
+
+                         (check (abc-ptr? obj) => #t))
+
+              (test-case "c struct array"
+
+                         (def obj-array (malloc-abc-array 2))
+
+                         (def obj1 (malloc-abc))
+                         (abc-a-set! obj1 test-str1)
+
+                         (def obj2 (malloc-abc))
+                         (abc-a-set! obj2 test-str2)
+
+                         (abc-array-set! obj-array 0 obj1)
+                         (abc-array-set! obj-array 1 obj2)
+
+                         (check (abc-a (abc-array-ref obj-array 0)) => test-str1)
+                         (check (abc-a (abc-array-ref obj-array 1)) => test-str2))
+
+              (test-case "c int struct array"
+                         (define y (malloc-bar))
+                         (bar-i-set! y 123)
+                         (bar-j-set! y 456)
+
+                         (define y2 (malloc-bar))
+                         (bar-i-set! y2 320)
+                         (bar-j-set! y2 328)
+
+                         (define k (malloc-bar-array 2))
+                         (bar-array-set! k 0 y)
+                         (bar-array-set! k 1 y2)
+
+                         (check (bar-i (bar-array-ref k 1)) => 320))
+
+              (test-case "modifying c strings"
+                         (def obj1 (malloc-abc))
+
+                         (def t3 (string-append test-str1 test-str2))
+                         (def t4 (string-append test-str1 " test"))
+
+                         (abc-a-set! obj1 test-str1)
+                         (abc-b-set! obj1 test-str2)
+                         (abc-a-set! obj1 t3)
+                         (abc-b-set! obj1 t4)
+
+                         (check (abc-a obj1) => t3)
+                         (check (abc-b obj1) => t4))
+
+              (test-case "nested structs"
+                         (def foo-arr (malloc-foo-array 2))
+
+                         (def obj1 (make-abc test-str1 test-str2))
+                         (def obj2 (make-abc test-str2 test-str1))
+
+                         (def t5 "here we go")
+                         (def t6 "but not")
+
+                         (def foo1 (malloc-foo))
+                         (foo-a1-set! foo1 obj1)
+                         (foo-d2-set! foo1 obj2)
+                         (foo-str-set! foo1 t5)
+
+                         (def foo2 (malloc-foo))
+                         (foo-a1-set! foo2 obj2)
+                         (foo-d2-set! foo2 obj1)
+                         (foo-str-set! foo2 t6)
+
+                         (foo-array-set! foo-arr 0 foo1)
+                         (foo-array-set! foo-arr 1 foo2)
+
+                         (check (foo-str (foo-array-ref foo-arr 0)) => t5)
+                         (check (foo-str (foo-array-ref foo-arr 1)) => t6))))

--- a/src/std/foreign.ss
+++ b/src/std/foreign.ss
@@ -1,6 +1,7 @@
 ;;; -*- Gerbil -*-
 ;;; © vyzo
 ;;; FFI macros
+(import (for-syntax :std/stxutil))
 
 (export begin-ffi)
 
@@ -43,10 +44,172 @@
            (let ((r (,ffi-symbol ,@args)))
              (if (##fx< r 0)
                (##fx- (##c-code "___RESULT = ___FIX (errno);"))
-               r))))))
+               r))))
+      ;; Definitions:
+      ;; struct => is the name of the struct
+      ;; members => is a pair of member name and type
+      ;; release-function => this is the cleanup function called by the gc.
+      ;;    If no cleanup function is provided, a c function is created <struct-name>_ffi_free
+      ;;    this function frees the struct pointer as well as any string members if
+      ;;    they were set.
+      ;;
+      ;; Usage:
+      ;; for a c struct X with members a of type t1 and b of type t2
+      ;; (define-c-struct X) =>
+      ;;
+      ;; -- Types created
+      ;; - X for struct
+      ;; - X* for the pointer to the struct. this is the struct to which the configurable
+      ;;      release function is provided
+      ;; - X-shallow-ptr* similar to X*, default release function ffi_free is associated
+      ;;      (only created if char-string is one of the members)
+      ;; - X-borrowed-ptr* similat to X* but no release function
+      ;;
+      ;; -- Lambdas created
+      ;; - X-ptr? predicate for the struct types (uses foreign-tags)
+      ;; - malloc-X calls malloc for the struct and returns a pointer to it
+      ;; - ptr->X get the value of X from its pointer
+      ;; - (malloc-X-array N) calls malloc for N * sizeof X and returns a pointer to it, the
+      ;;      returned pointer is of type X-shallow-ptr* if strings are present o/w X*
+      ;; - (X-array-ref ptr i) returns a pointer with offset i starting at ptr, the returned
+      ;;      pointer is of type X-borrowed-ptr*
+      ;; - (X-array-set! ptr i val-ptr) sets the value of the pointer at offset i from ptr to
+      ;;      be val-ptr
+      ;;
+      ;;
+      ;; (define-c-struct X ((a . t1) (b . t2))) =>
+      ;; In addition to the types and lambdas defined above, following additional lambdas are provided:
+      ;;
+      ;; - X-a-set!, X-b-set! setter for member variables.
+      ;;   Special compatibility for string types is provided,
+      ;;   if a string is passed as the value, then we strdup the string and set that to the
+      ;;   argument. If the struct member is already pointing to another string, then that
+      ;;   string is freed and the member will now point to a new string.
+      ;;   The cleanup of such strings are handled by the generated <struct>_ffi_free, if
+      ;;   a custom release function is provided, care should be taken while freeing.
+      ;;
+      ;;- X-a X-b accessor functions for struct members
+      (define-macro (define-c-struct struct #!optional (members '()) release-function)
+        (let* ((struct-str (symbol->string struct))
+               (struct-ptr (string->symbol (string-append struct-str "*")))
+               (shallow-ptr (string->symbol (string-append struct-str "-shallow-ptr*")))
+               (borrowed-ptr (string->symbol (string-append struct-str "-borrowed-ptr*")))
+               (string-types '(char-string nonull-char-string UTF-8-string
+                                           nonnull-UTF-8-string UTF-16-string
+                                           nonnull-UTF16-string))
+               (string-compat-required? (let loop ((m members))
+                                          (cond
+                                           ((null? m) #f)
+                                           ((member (cdr (car m)) string-types) #t)
+                                           (else (loop (cdr m))))))
+               (string-setter-body (lambda (member-name)
+                                     (let ((m (string-append "___arg1->" member-name)))
+                                       (string-append
+                                        "if(" m " == NULL)" "\n"
+                                        m "= strdup(___arg2);" "\n"
+                                        "else if (strcmp(" m ", ___arg2) != 0) {" "\n"
+                                        "free(" m ");" "\n"
+                                        m "= strdup(___arg2);" "\n"
+                                        "}" "\n"
+                                        "___return;" "\n"))))
+               (default-free-body (and string-compat-required?
+                                       (string-append
+                                        "___SCMOBJ " struct-str "_ffi_free (void *ptr) {" "\n"
+                                        "struct " struct-str " *obj = (struct " struct-str "*) ptr;" "\n"
+                                        (apply string-append
+                                          (map (lambda (m)
+                                                 (case (cdr m)
+                                                   ((char-string)
+                                                    (let ((mem-name (symbol->string (car m))))
+                                                      (string-append "if(obj->" mem-name ") " 
+                                                                     "free(obj->" mem-name ");" "\n")))
+                                                                           (else "")))
+                                               members))
+                                        "free(obj);" "\n"
+                                        "return ___FIX (___NO_ERR);" "\n"
+                                        "}"
+                                        )))
+               (release-function (or release-function
+                                     (if string-compat-required?
+                                       (string-append struct-str "_ffi_free")
+                                       "ffi_free")))
+               (string-compat-types (if string-compat-required?
+                                      `((c-declare ,default-free-body)
+                                        (c-define-type ,shallow-ptr
+                                              (pointer ,struct (,struct-ptr) "ffi_free"))))))
+          `(begin
+             ,@(append `((c-define-type ,struct (struct ,struct-str))
+                         (c-define-type ,struct-ptr
+                                        (pointer ,struct (,struct-ptr) ,release-function))
+                         (c-define-type ,borrowed-ptr (pointer ,struct (,struct-ptr))))
+                       string-compat-types)
+
+
+                  (define ,(string->symbol (string-append struct-str "-ptr?"))
+                    (lambda (obj)
+                      (and (foreign? obj)
+                         (equal? (foreign-tags obj) (quote (,struct-ptr))))))
+
+                  ;; getter and setters
+                  ,@(apply append
+                     (map (lambda (m)
+                            (let* ((member-name (symbol->string (car m)))
+                                   (member-type (cdr m))
+                                   (getter-name (string-append struct-str "-" member-name))
+                                   (setter-body (cond
+                                                 ((member member-type string-types)
+                                                  (string-setter-body member-name))
+                                                 (else
+                                                  (string-append
+                                                   "___arg1->" member-name " = ___arg2;" "\n"
+                                                   "___return;" "\n")))))
+                              `((define ,(string->symbol getter-name)
+                                  (c-lambda (,struct-ptr) ,member-type
+                                       ,(string-append
+                                         "___return(___arg1->" member-name ");")))
+
+                                (define ,(string->symbol (string-append getter-name "-set!"))
+                                  (c-lambda (,struct-ptr ,member-type) void
+                                            ,setter-body)))))
+                          members))
+
+                  ;; malloc
+                  (define ,(string->symbol (string-append "malloc-" struct-str))
+                    (c-lambda () ,struct-ptr
+                         ,(string-append
+                           "struct " struct-str "* var = malloc(sizeof(struct " struct-str "));" "\n"
+                           "memset(var, 0, sizeof(struct " struct-str "));"
+                          "if (var == NULL)" "\n"
+                          "    ___return (NULL);" "\n"
+                          "___return(var);")))
+
+                  (define ,(string->symbol (string-append "ptr->" struct-str))
+                    (c-lambda (,struct-ptr) ,struct
+                         "___return(*___arg1);"))
+
+                  ;; malloc array
+                  (define ,(string->symbol (string-append "malloc-" struct-str "-array"))
+                    (c-lambda (unsigned-int32) ,(if string-compat-required? shallow-ptr struct-ptr)
+                         ,(string-append
+                           "struct " struct-str " *arr_var=malloc(___arg1*sizeof(struct " struct-str "));" "\n"
+                           "memset(arr_var, 0, ___arg1*sizeof(struct " struct-str "));" "\n"
+                           "if (arr_var == NULL)" "\n"
+                           "    ___return (NULL);" "\n"
+                           "___return(arr_var);")))
+
+                  ;; ref array
+                  (define ,(string->symbol (string-append struct-str "-array-ref"))
+                    (c-lambda (,struct-ptr unsigned-int32) ,borrowed-ptr
+                         "___return (___arg1 + ___arg2);"))
+
+                  ;; set! array
+                  (define ,(string->symbol (string-append struct-str "-array-set!"))
+                    (c-lambda (,struct-ptr unsigned-int32 ,struct-ptr) void
+                         "*(___arg1 + ___arg2) = *___arg3; ___return;")))))))
 
   (def (prelude-c-decls)
     '((c-declare "#include <stdlib.h>")
+      (c-declare "#include <string.h>")
       (c-declare "#include <errno.h>")
       (c-declare "static ___SCMOBJ ffi_free (void *ptr);")
       (c-declare #<<END-C
@@ -73,22 +236,47 @@ END-C
 )
       ))
 
+  (def (make-struct-ids name fields)
+    (append (list (format-id name "malloc-~a" name)
+                  (format-id name "malloc-~a-array" name)
+                  (format-id name "~a-array-ref" name)
+                  (format-id name "~a-array-set!" name)
+                  (format-id name "ptr->~a" name)
+                  (format-id name "~a-ptr?" name))
+            (apply append
+             (map (lambda (field) (list (format-id name "~a-~a" name field)
+                                   (format-id name "~a-~a-set!" name field)))
+                  fields))))
+
   (syntax-case stx ()
-    ((_ (id ...) body ...)
-     (identifier-list? #'(id ...))
-     (if (module-context? (current-expander-context))
-       (let (ns (or (module-context-ns (current-expander-context))
-                    (expander-context-id (current-expander-context))))
-         (with-syntax (((nsdef ...) (namespace-def ns #'(id ...)))
-                       ((macros ...) (prelude-macros))
-                       ((c-decls ...) (prelude-c-decls))
-                       ((c-defs ...) (prelude-c-defs)))
-           #'(begin
-               (extern id ...)
-               (begin-foreign
-                 macros ...
-                 c-decls ...
-                 nsdef ...
-                 body ...
-                 c-defs ...))))
-       (raise-syntax-error #f "Illegal expansion context; not in module context" stx)))))
+    ((_ (exts ...) body ...)
+     (with-syntax (((id ...)
+                    (let lp ((rest #'(exts ...))
+                             (ids []))
+                      (syntax-case rest (struct)
+                        ((id . rest)
+                         (identifier? #'id)
+                         (lp #'rest (cons #'id ids)))
+
+                        (((struct name fields ...) . rest)
+                         (lp (syntax rest)
+                             (foldl cons ids (make-struct-ids #'name
+                                                              #'(fields ...)))))
+
+                        (() ids)))))
+       (if (module-context? (current-expander-context))
+         (let (ns (or (module-context-ns (current-expander-context))
+                      (expander-context-id (current-expander-context))))
+           (with-syntax (((nsdef ...) (namespace-def ns #'(id ...)))
+                         ((macros ...) (prelude-macros))
+                         ((c-decls ...) (prelude-c-decls))
+                         ((c-defs ...) (prelude-c-defs)))
+             #'(begin
+                 (extern id ...)
+                 (begin-foreign
+                   macros ...
+                   c-decls ...
+                   nsdef ...
+                   body ...
+                   c-defs ...))))
+         (raise-syntax-error #f "Illegal expansion context; not in module context" stx))))))

--- a/src/std/foreign.ss
+++ b/src/std/foreign.ss
@@ -52,43 +52,6 @@
       ;;    If no cleanup function is provided, a c function is created <struct-name>_ffi_free
       ;;    this function frees the struct pointer as well as any string members if
       ;;    they were set.
-      ;;
-      ;; Usage:
-      ;; for a c struct X with members a of type t1 and b of type t2
-      ;; (define-c-struct X) =>
-      ;;
-      ;; -- Types created
-      ;; - X for struct
-      ;; - X* for the pointer to the struct. this is the struct to which the configurable
-      ;;      release function is provided
-      ;; - X-shallow-ptr* similar to X*, default release function ffi_free is associated
-      ;;      (only created if char-string is one of the members)
-      ;; - X-borrowed-ptr* similat to X* but no release function
-      ;;
-      ;; -- Lambdas created
-      ;; - X-ptr? predicate for the struct types (uses foreign-tags)
-      ;; - malloc-X calls malloc for the struct and returns a pointer to it
-      ;; - ptr->X get the value of X from its pointer
-      ;; - (malloc-X-array N) calls malloc for N * sizeof X and returns a pointer to it, the
-      ;;      returned pointer is of type X-shallow-ptr* if strings are present o/w X*
-      ;; - (X-array-ref ptr i) returns a pointer with offset i starting at ptr, the returned
-      ;;      pointer is of type X-borrowed-ptr*
-      ;; - (X-array-set! ptr i val-ptr) sets the value of the pointer at offset i from ptr to
-      ;;      be val-ptr
-      ;;
-      ;;
-      ;; (define-c-struct X ((a . t1) (b . t2))) =>
-      ;; In addition to the types and lambdas defined above, following additional lambdas are provided:
-      ;;
-      ;; - X-a-set!, X-b-set! setter for member variables.
-      ;;   Special compatibility for string types is provided,
-      ;;   if a string is passed as the value, then we strdup the string and set that to the
-      ;;   argument. If the struct member is already pointing to another string, then that
-      ;;   string is freed and the member will now point to a new string.
-      ;;   The cleanup of such strings are handled by the generated <struct>_ffi_free, if
-      ;;   a custom release function is provided, care should be taken while freeing.
-      ;;
-      ;;- X-a X-b accessor functions for struct members
       (define-macro (define-c-struct struct #!optional (members '()) release-function)
         (let* ((struct-str (symbol->string struct))
                (struct-ptr (string->symbol (string-append struct-str "*")))

--- a/src/std/run-tests.ss
+++ b/src/std/run-tests.ss
@@ -2,6 +2,7 @@
 ;; -*- Gerbil -*-
 
 (import :std/test
+	:std/foreign-test
         "build-config"
         "generic-test"
         "coroutine-test"
@@ -81,6 +82,7 @@
    httpd-test
    sasl-test
    protobuf-test
+   foreign-test
    (if config-enable-sqlite [sqlite-test] []) ...
    (if config-enable-lmdb [lmdb-test] []) ...
    (if config-enable-leveldb [leveldb-test] []) ...


### PR DESCRIPTION
this generates commonly used methods that are used to work with
the c structs
* malloc, setters, getters for struct
* malloc-array, array-ref and array-set! for working with arrays

A compatibility layer is also provided for scheme string types
which is allocated and freed by the generated methods