### PR TITLE
std/sugar - chain macro

### DIFF
--- a/doc/reference/sugar.md
+++ b/doc/reference/sugar.md
@@ -149,3 +149,53 @@ are resolved with the following rules:
 ```
 
 Anaphoric `when`. Evaluates and binds *test* to *id*. Evaluates *body ...* if *test* is not `#f`.
+
+## chain
+``` scheme
+(chain expr (expression) ...)
+
+<expression>:
+  (proc arg* ...)             ; must contain exactly one <> symbol
+  (var (proc arg1 arg* ...))  ; var supports destructuring
+
+(chain <> (expression) ...)
+=> (lambda (var) (chain var (expression) ...))
+
+(chain (pattern <> expr) (expression) ...)
+=>  (lambda (var) (with ((pattern var)) (chain expr (expression) ...)))
+```
+
+`chain` rewrites passed expressions by passing the previous expression
+into the position of the `<>` diamond symbol. In case a previous expression
+should be used in a sub-expression, or multiple times, the expression can be
+prefixed with a variable (supports destructuring).
+
+When the first expression is a `<>` or `([pattern] <> expr)`,
+chain will return a unary lambda.
+
+::: tip Examples:
+``` scheme
+> (chain "stressed"
+         (string->list <>)
+         (reverse <>)
+         (list->string <>)
+         (string-append "then have some " <>))
+"then have some desserts"
+
+
+(chain (random-integer 10)
+       (num (if (> num 5) num 0)))
+7
+
+
+> (def foobar
+    (chain <>
+      ([_ . rest] (map number->string rest))
+      (string-join <> ", ")
+      (string-append <> " :)")))
+
+
+> (foobar [0 1 2])
+"1, 2 :)"
+```
+:::

--- a/src/std/run-tests.ss
+++ b/src/std/run-tests.ss
@@ -7,6 +7,7 @@
         "generic-test"
         "coroutine-test"
         "iter-test"
+        "sugar-test"
         "amb-test"
         "event-test"
         "misc/string-test"
@@ -58,6 +59,7 @@
    generic-macro-test
    coroutine-test
    iter-test
+   sugar-test
    amb-test
    event-test
    csv-test

--- a/src/std/sugar-test.ss
+++ b/src/std/sugar-test.ss
@@ -1,0 +1,51 @@
+(export sugar-test)
+
+(import :std/test
+        :std/sugar)
+
+(def sugar-test
+  (test-suite "test :std/sugar"
+   (test-case "chain"
+    (check-equal?
+     ;; expression as input
+     (chain (iota 3)
+            ([_ . rest] (map 1+ rest))
+            (xs (map number->string xs))
+            (string-join <> ", "))
+     "2, 3")
+
+    (check-equal?
+     ;; variable as input
+     (let (lst (iota 3))
+       (chain lst
+              ([_ . rest] (map 1+ rest))
+              (xs (map number->string xs))
+              (string-join <> ", ")))
+     "2, 3")
+
+    (check-equal?
+     ;; chain lambda
+     ((chain <>
+             ([_ . rest] (map 1+ rest))
+             (xs (map number->string xs))
+             (string-join <> ", "))
+      (iota 3))
+     "2, 3")
+
+    (check-equal?
+     ;; destructuring lambda with pattern variable as input
+     ((chain ([a . _] <> a)
+             ([_ . rest] (map 1+ rest))
+             (xs (map number->string xs))
+             (string-join <> ", "))
+      (list (iota 3) (iota 2)))
+     "2, 3")
+
+    (check-equal?
+     ;; destructuring lambda with expression
+     ((chain ([a b _] <> (list a b))
+             ([_ . rest] (map 1+ rest))
+             (xs (map number->string xs))
+             (string-join <> ", "))
+      (iota 3))
+     "2"))))


### PR DESCRIPTION
Chain is a macro that reduces left-shifting by adding some syntactic sugar.

I spend a good amount of time thinking about the syntax and the scope of the macro. For example I rejected the idea of a multi-line row body because it would make the macro unreadable. The `with` and `let` variant is there to handle cases where a diamond operator can't be used, e.g. because the variable should be in a nested expression or is intended to be used multiple times.

Example 1:
``` scheme
(import :std/srfi/13)

(chain (string-reverse "hello world")
       (string-titlecase <>)
       (string-reverse <>))

=> "hellO worlD"
```

Example 2:
``` scheme
(def lst [1 2 3])

(chain lst
       ([_ . rest] (map number->string rest))  ; with
       (v (string-join v ", "))                ; let
       (string-append <> " :)"))

=> "2, 3 :)"
```

Example 3:
``` scheme
(def smiley-numbers
  (chain ([_ . rest] <> rest)       ; lambda with destructuring
	 (map number->string <>)
	 (string-join <> ", ")
	 (string-append <> " :)")))

(smiley-numbers (iota 10))

=> "1, 2, 3, 4, 5, 6, 7, 8, 9 :)"
```