### PR TITLE
srfi-159: fix incorrect "col" calculation with ANSI escape codes

### DIFF
--- a/src/std/srfi/159/color.scm
+++ b/src/std/srfi/159/color.scm
@@ -18,7 +18,7 @@
     (else "0")))
 
 (define (ansi-escape color)
-  (each (integer->char 27) "[" (color->ansi color) "m"))
+  (string-append (string (integer->char 27)) "[" (color->ansi color) "m"))
 
 (define (colored new-color . args)
   (fn (color)


### PR DESCRIPTION
`ansi-escape` function outputs the escape code in smaller pieces,
however `as-unicode` can only recognize ANSI escape code in one
piece. Because of this when you get `col` property from a string with
ANSI escape code it gives incorrect column number.

For reference, see ashinn/chibi-scheme#591. This should fix #429.