### PR TITLE
Check for out-of-date build-deps

### DIFF
--- a/doc/reference/core-builtin.md
+++ b/doc/reference/core-builtin.md
@@ -1710,7 +1710,7 @@ Displays the arguments *args*.
   a, b := string
 ```
 
-Returns true if file *a* is newer than *b*. Both files must exist.
+Returns true if file *a* is newer than *b* by modification-time. Both files must exist.
 
 ### create-directory*
 ``` scheme

--- a/src/std/build-script.ss
+++ b/src/std/build-script.ss
@@ -61,7 +61,10 @@
                                      prefix: @prefix
                                      @build-spec)))
                             ([]
-                             (unless (file-exists? "build-deps")
+                             (unless (and (file-exists? "build-deps")
+                                          (file-newer? "build-deps" +this-source-file+)
+                                          (andmap (lambda (f) (file-newer? "build-deps" f))
+                                                  (buildspec-depfiles @build-spec)))
                                (displayln "... make deps")
                                (main "deps"))
                              (displayln "... compile")


### PR DESCRIPTION
This PR fixes #428 by changing `defbuild-script` to check that the `build-deps` file is up-to-date before using it to compile the project.

In addition to checking `(file-exists? "build-deps")`, it also checks `(file-newer? "build-deps" _)` for the build-script and each source file with deps relevant for making a depgraph.

I have tested this on my machine with the example in #428 and seen that it resolves the issue.