### PR TITLE
Add ~r format specifier for repr

### DIFF
--- a/doc/reference/format.md
+++ b/doc/reference/format.md
@@ -25,6 +25,7 @@ Formats the arguments to a string using the supplied format specifier.
 - lower-case synonyms for all format specifiers (~a and ~A are equivalent)
 - ~u/~U for unicode hex char print (for #\uXXXX)
 - ~f/~F means "float" and does non-exp fp (C-style %f more or less)
+- ~r/~R means "repr" and works with `:std/misc/repr` and the `:pr` method
 - ~w{spec} does generic fixed width
 - not implemented: ~& ~H wtfs
 :::

--- a/src/std/format.ss
+++ b/src/std/format.ss
@@ -12,7 +12,9 @@
   (only-in :gerbil/gambit/misc
            pretty-print)
   (only-in :gerbil/gambit/bits
-           integer-length))
+           integer-length)
+  (only-in :std/misc/repr
+           print-representation))
 
 (def (format fmt . args)
   (unless (string? fmt)
@@ -41,6 +43,7 @@
 ;;   lower-case synonyms for all format specifiers
 ;;   ~u/~U for unicode hex char print (for #\uXXXX)
 ;;   ~f/~F means "float" and does non-exp fp (C-style %f more or less)
+;;   ~r/~R means "repr" and works with `:std/misc/repr` and the `:pr` method
 ;;   ~w{spec} does generic fixed width
 ;; not implemented: ~& ~H wtfs
 ;; TODO: ~g/~e for C-style %g/%e
@@ -150,6 +153,9 @@
 
 (defdispatch-e (#\y #\Y)
   pretty-print)
+
+(defdispatch-e (#\r #\R)
+  print-representation)
 
 (defdispatch-q (#\% #\n)
   (newline))

--- a/src/std/misc/repr.ss
+++ b/src/std/misc/repr.ss
@@ -9,7 +9,7 @@
 
 (import
   :gerbil/gambit/hash :gerbil/gambit/ports
-  :std/format :std/misc/list :std/misc/rtd :std/sort)
+  :std/misc/list :std/misc/rtd :std/sort)
 
 ;; Default options for printing an evaluable representation. Keep it empty for now.
 ;; Note: we don't actually use options yet, but
@@ -124,7 +124,9 @@
            (and (type-descriptor? t) (assgetq transparent: (type-descriptor-plist t)))))
     (display-separated
      (cdr (if (struct-type? (object-type x)) (struct->list x) (class->list x))) port
-     prefix: (format "(~a " (type-name (object-type x))) suffix: ")" display-element: p))
+     prefix: (string-append "(" (symbol->string (type-name (object-type x))) " ")
+     suffix: ")"
+     display-element: p))
 
    (else
     (print-unrepresentable-object x port options))))


### PR DESCRIPTION
This PR adds `~r` and `~R` as format specifiers that use `:std/misc/repr`'s `print-representation` function which can use the `:pr` method.