### PR TITLE
Document stx-source and stx-wrap-source

### DIFF
--- a/doc/reference/core-expander.md
+++ b/doc/reference/core-expander.md
@@ -324,7 +324,7 @@ Please document me!
 Please document me!
 
 ### stx-source
-::: tip usage
+
 ```
 (stx-source stx) -> locat | #f
   stx := syntax
@@ -336,7 +336,7 @@ Returns the source location of a syntax object AST `stx`.
 The `locat` structure includes the container and filepos, accessed by `##locat-container` and `##locat-filepos`. The filepos has line and column information, accessed with `##filepos-line` and `##filepos-col`.
 
 ### stx-wrap-source
-::: tip usage
+
 ```
 (stx-wrap-source stx src) -> syntax
   stx := any

--- a/doc/reference/core-expander.md
+++ b/doc/reference/core-expander.md
@@ -326,20 +326,27 @@ Please document me!
 ### stx-source
 ::: tip usage
 ```
-(stx-source ...)
+(stx-source stx) -> locat | #f
+  stx := syntax
 ```
 :::
 
-Please document me!
+Returns the source location of a syntax object AST `stx`.
+
+The `locat` structure includes the container and filepos, accessed by `##locat-container` and `##locat-filepos`. The filepos has line and column information, accessed with `##filepos-line` and `##filepos-col`.
 
 ### stx-wrap-source
 ::: tip usage
 ```
-(stx-wrap-source ...)
+(stx-wrap-source stx src) -> syntax
+  stx := any
+  src := locat
 ```
 :::
 
-Please document me!
+Produces a new syntax object with source location `src` if `stx` is not wrapped as an AST already, otherwise returns `stx` unchanged.
+
+The `locat` structure can be constructed with `(##make-locat container filepos)`, where a filepos can be constructed with `(##make-filepos line col off)`.
 
 ### stx-car
 ::: tip usage


### PR DESCRIPTION
This documents `stx-source` and `stx-wrap-source` in Expander Runtime Utilities.

The documentation for `stx-source` also explains how to access the container, line, and column information, and the documentation for `stx-wrap-source` explains how to construct a locat from the container, line, col, and off information.