### PR TITLE
Fix :std/sugar chain macro

### DIFF
--- a/src/std/sugar-test.ss
+++ b/src/std/sugar-test.ss
@@ -48,4 +48,5 @@
              (xs (map number->string xs))
              (string-join <> ", "))
       (iota 3))
-     "2"))))
+     "2")
+    (check-equal? (chain [0 1] (map (lambda (v) (1+ v)) <>)) [1 2]))))

--- a/src/std/sugar.ss
+++ b/src/std/sugar.ss
@@ -270,7 +270,7 @@
    (~chain-aux more
 	       (~chain-aux-variable (var acc) (body1 body2 . body*))))
 
-  ((_ ((var (body1 body2 . body*) body-error ...) . more) acc)
+  ((_ ((var (body1 body2 . body*) (body-error ...) ...) . more) acc)
    (syntax-error "More than one body expression in chain-variable context"))
 
   ;; diamond


### PR DESCRIPTION
Fix an error when using a sub-expression in a chain-diamond context. The below valid code returned previously the error `More than one body expression in chain-variable context`.

``` scheme
(chain (iota 3)
  (map (lambda (v) (1+ v)) <>))
```