### PR TITLE
net/request: Add auth: parameter supporting basic auth

### DIFF
--- a/doc/reference/requests.md
+++ b/doc/reference/requests.md
@@ -18,13 +18,14 @@ implementation Gerbil is using  must be configured with `--enable-openssl` flag.
 ### http-get
 
 ``` scheme
-(http-get url [redirect: #t] [headers: #f] [cookies: #f] [params: #f]) -> request | error
+(http-get url [redirect: #t] [headers: #f] [cookies: #f] [params: #f] [auth: #f]) -> request | error
 
   url      := a string to tell which URL the HTTP client should connect to
   redirect := boolean telling if client should follow HTTP redirects
   headers  := alist of extra HTTP headers to set in request
   cookies  := alist of cookie name/value pairs to set in request
   params   := alist of query param name/value pairs set in request
+  auth     := a list with a keyword head, like [basic: user password]
 ```
 
 The `http-get` procedure executes HTTP GET request to given *url* and returns an
@@ -65,13 +66,14 @@ key/value pairs to add as HTTP query params to the request.
 ### http-head
 
 ``` scheme
-(http-head url [redirect: #t] [headers: #f] [cookies: #f] [params: #f]) -> request | error
+(http-head url [redirect: #t] [headers: #f] [cookies: #f] [params: #f] [auth: #f]) -> request | error
 
   url      := a string to tell which URL the HTTP client should connect to
   redirect := boolean telling if client should follow HTTP redirects
   headers  := alist of extra HTTP headers to set in request
   cookies  := alist of cookie name/value pairs to set in request
   params   := alist of query param name/value pairs set in request
+  auth     := a list with a keyword head, like [basic: user password]
 ```
 
 Like the `http-get` procedure but instead executes HTTP HEAD method on given
@@ -79,13 +81,14 @@ Like the `http-get` procedure but instead executes HTTP HEAD method on given
 
 ### http-post
 ``` scheme
-(http-post url [headers: #f] [cookies: #f] [params: #f] [data #f]) -> request | error
+(http-post url [headers: #f] [cookies: #f] [params: #f] [data: #f] [auth: #f]) -> request | error
 
   url     := a string to tell which URL the HTTP client should connect to
   headers := alist of extra HTTP headers to set in request
   cookies := alist of cookie name/value pairs to set in request
   params  := alist of query param name/value pairs set in request
   data    := request data given as octet vector or string
+  auth    := a list with a keyword head, like [basic: user password]
 ```
 
 Like the `http-get` procedure but instead executes HTTP POST method on given
@@ -93,37 +96,40 @@ Like the `http-get` procedure but instead executes HTTP POST method on given
 
 ### http-put
 ``` scheme
-(http-put url [headers: #f] [cookies: #f] [params: #f] [data: #f]) -> request | error
+(http-put url [headers: #f] [cookies: #f] [params: #f] [data: #f] [auth: #f]) -> request | error
 
   url     := a string to tell which URL the HTTP client should connect to
   headers := alist of extra HTTP headers to set in request
   cookies := alist of cookie name/value pairs to set in request
   params  := alist of query param name/value pairs set in request
   data    := request data given as octet vector or string
+  auth    := a list with a keyword head, like [basic: user password]
 ```
 
 Like the `http-post` procedure but instead executes HTTP PUT method on `url`.
 
 ### http-delete
 ``` scheme
-(http-delete url [headers: #f] [cookies: #f] [params: #f]) -> request | error
+(http-delete url [headers: #f] [cookies: #f] [params: #f] [auth: #f]) -> request | error
 
   url     := a string to tell which URL the HTTP client should connect to
   headers := alist of extra HTTP headers to set in request
   cookies := alist of cookie name/value pairs to set in request
   params  := alist of query param name/value pairs set in request
+  auth    := a list with a keyword head, like [basic: user password]
 ```
 
 Like `http-get` procedure but instead executes HTTP DELETE method on `url`.
 
 ### http-options
 ``` scheme
-(http-options url [headers: #f] [cookies: #f] [params: #f]) -> request | error
+(http-options url [headers: #f] [cookies: #f] [params: #f] [auth: #f]) -> request | error
 
   url     := a string to tell which URL the HTTP client should connect to
   headers := alist of extra HTTP headers to set in request
   cookies := alist of cookie name/value pairs to set in request
   params  := alist of query param name/value pairs set in request
+  auth    := a list with a keyword head, like [basic: user password]
 ```
 
 Like `http-get` procedure but instead executes HTTP OPTIONS method on the `url`.

--- a/src/std/net/request.ss
+++ b/src/std/net/request.ss
@@ -339,8 +339,8 @@
             (utf8->string (list->u8vector (reverse r))))
            (else
             (lp (cons* next cr r))))))
-        (else
-         (lp (cons next r)))))))
+       (else
+        (lp (cons next r)))))))
 
 (def (request-close req)
   (alet (port (request-port req))

--- a/src/std/net/request.ss
+++ b/src/std/net/request.ss
@@ -3,15 +3,15 @@
 ;;; HTTP requests for humans; py requests-like http client interface
 
 (import :gerbil/gambit/ports
-        :std/sugar
-        :std/format
-        :std/pregexp
         :std/error
+        :std/format
         :std/net/uri
+        :std/pregexp
+        :std/srfi/13
+        :std/sugar
         :std/text/json
-        :std/text/zlib
         :std/text/utf8
-        :std/srfi/13)
+        :std/text/zlib)
 (export
   http-get http-head http-post http-put http-delete http-options
   request? request-url request-status request-status-text


### PR DESCRIPTION
This was largely modelled after Python's requests, which I assume is the intent here.  Python's differs in that the user must construct an authorization subclass, e.g. HTTPBasicAuth(user,pass), and pass that for `auth`; the style here seems more lisp-y and less OOP-y.

This does **NOT** yet support user and password in the URL.  I'll take a look at that soon.