### PR TITLE
misc/func: pred-limit

### DIFF
--- a/doc/reference/misc.md
+++ b/doc/reference/misc.md
@@ -6194,3 +6194,20 @@ Like `compose/values`, but the values flow left-to-right.
 
 These are macro versions of the functional composition operators; they generate
 significantly more efficient code and allow the optimizer to see through the composition.
+
+### pred-limit
+``` scheme
+(pred-limit pred limit) -> procedure
+
+  pred  := predicate
+  limit := number of times pred is allowed to return a truthy value
+```
+
+`pred-limit` returns a predicate which returns a truthy value only `limit` times.
+
+::: tip Examples:
+``` scheme
+> (filter (pred-limit even? 2) [1 2 3 4 5 6])
+(2 4)
+```
+:::

--- a/src/std/misc/func-test.ss
+++ b/src/std/misc/func-test.ss
@@ -49,4 +49,7 @@
       (check ((@rcompose * 1+) 1 2) => 3)
       (check ((@rcompose * 1+ 1-) 1 2) => 2)
       (check ((@rcompose/values (cut values 1 2) *)) => 2)
-      (check ((@rcompose/values (cut values 1 2) * 1+)) => 3))))
+      (check ((@rcompose/values (cut values 1 2) * 1+)) => 3))
+    (test-case "test pred-limit"
+      (check (filter (pred-limit even? 2) (iota 6 1)) => [2 4])
+      (check (filter (pred-limit even? -1) (iota 6 1)) => []))))

--- a/src/std/misc/func.ss
+++ b/src/std/misc/func.ss
@@ -8,7 +8,8 @@
   compose1 compose compose/values
   @compose1 @compose @compose/values
   rcompose1 rcompose rcompose/values
-  @rcompose1 @rcompose @rcompose/values)
+  @rcompose1 @rcompose @rcompose/values
+  pred-limit)
 
 ;; Repeat value or call function N times and return the result as list.
 ;; (repeat 2 5)                  -> (2 2 2 2 2)  ; repeat the value 2
@@ -180,3 +181,20 @@
   ((_ f) f)
   ((recur f ... fn)
    (call-with-values (lambda () (recur f ...)) fn)))
+
+;; pred-limit returns a predicate which returns a truthy value only limit times.
+;;
+;; Example:
+;;  (filter (pred-limit even? 2) [1 2 3 4 5 6]) => (2 4)
+(def (pred-limit pred limit)
+  (def (test v)
+    (declare (fixnum))
+    (if (> limit 0)
+      (let (v (pred v))
+        (when v
+          (set! limit (1- limit)))
+        v)
+      #f))
+  ;; TODO when contracts merge
+  ;; (@contract (pred-limit pred limit) (or (not limit) (fixnum? limit)))
+  (if (> limit 0) test pred))


### PR DESCRIPTION
Quite a lot of procedures take a predicate, but don't take a limit. This helper allows to get "limit like" functionality without rewriting the original procedure to accept a limit parameter.