### PR TITLE
:std/misc/func expand pred-limit to accept #f as limit parameter too

### DIFF
--- a/doc/reference/misc.md
+++ b/doc/reference/misc.md
@@ -6203,11 +6203,25 @@ significantly more efficient code and allow the optimizer to see through the com
   limit := number of times pred is allowed to return a truthy value
 ```
 
-`pred-limit` returns a predicate which returns a truthy value only `limit` times.
+`pred-limit` returns a predicate which returns a truthy value only `limit` times,
+if `limit` is not false.
+
 
 ::: tip Examples:
 ``` scheme
-> (filter (pred-limit even? 2) [1 2 3 4 5 6])
+> (filter (pred-limit even? 1) [1 2 3 4 5 6])
+(2)
+
+(def (myfilter pred list (limit #f))
+  (filter (pred-limit pred limit) list))
+
+> (myfilter even? [1 2 3 4 5 6])
+(2 4 6)
+
+> (myfilter even? [1 2 3 4 5 6] 2)
 (2 4)
+
+> (myfilter even? [1 2 3 4 5 6] 0)
+()
 ```
 :::

--- a/src/std/misc/func-test.ss
+++ b/src/std/misc/func-test.ss
@@ -51,5 +51,6 @@
       (check ((@rcompose/values (cut values 1 2) *)) => 2)
       (check ((@rcompose/values (cut values 1 2) * 1+)) => 3))
     (test-case "test pred-limit"
-      (check (filter (pred-limit even? 2) (iota 6 1)) => [2 4])
-      (check (filter (pred-limit even? 0) (iota 6 1)) => []))))
+      (check (filter (pred-limit even? 2) (iota 6 1))  => [2 4])
+      (check (filter (pred-limit even? 0) (iota 6 1))  => [])
+      (check (filter (pred-limit even? #f) (iota 6 1)) => [2 4 6]))))

--- a/src/std/misc/func.ss
+++ b/src/std/misc/func.ss
@@ -182,10 +182,12 @@
   ((recur f ... fn)
    (call-with-values (lambda () (recur f ...)) fn)))
 
-;; pred-limit returns a predicate which returns a truthy value only limit times.
+;; pred-limit returns a predicate which returns a truthy value only
+;; limit times, if limit is not false.
 ;;
 ;; Example:
-;;  (filter (pred-limit even? 2) [1 2 3 4 5 6]) => (2 4)
+;;  (filter (pred-limit even? 2)  [1 2 3 4 5 6]) => (2 4)
+;;  (filter (pred-limit even? #f) [1 2 3 4 5 6]) => (2 4 6)
 (def (pred-limit pred limit)
   (def (test v)
     (declare (fixnum))
@@ -196,5 +198,7 @@
         v)
       #f))
   ;; TODO when contracts merge
-  ;; (@contract (pred-limit pred limit) (fixnum? limit))
-  (if (> limit 0) test (lambda (_) #f)))
+  ;; (@contract (pred-limit pred limit) (or (not limit) (fixnum? limit)))
+  (if limit
+    (if (> limit 0) test (lambda (_) #f))
+    pred))


### PR DESCRIPTION
As accepting `#f` as `limit` allows to easier extend existing procedures, I came to the conclusion that it would better fit the use-case of `pred-limit` to accept not only `fixnum` values as `limit`.

```scheme
(def (myfilter pred list (limit #f))
  (filter (pred-limit pred limit) list))

> (myfilter even? [1 2 3 4 5 6] 2)
(2 4)
```