### PR TITLE
Add yaml-key-format parameter

### DIFF
--- a/doc/reference/text.md
+++ b/doc/reference/text.md
@@ -666,6 +666,34 @@ against libyaml.
 ```
 :::
 
+### yaml-key-format
+``` scheme
+(yaml-key-format) -> formatter
+(yaml-key-format new-formatter) -> old-formatter
+```
+
+A parameter that controls how string keys are stored in mappings.  YAML allows
+non-string keys in mappings (e.g. numbers, sequences, and other mappings).
+These are not affected by this parameter.
+
+No conversion is done by default.
+
+::: tip To convert map keys to symbols:
+``` scheme
+> (parameterize ((yaml-key-format string->symbol))
+   (hash-keys (car (yaml-load-string "foo: bar"))))
+(foo)
+```
+:::
+
+::: tip To convert map keys to keywords:
+``` scheme
+> (parameterize ((yaml-key-format string->keyword))
+   (hash-keys (car (yaml-load-string "foo: bar"))))
+(foo:)
+```
+:::
+
 ### yaml-load
 ``` scheme
 (yaml-load filename) -> any | error

--- a/src/std/run-tests.ss
+++ b/src/std/run-tests.ss
@@ -2,7 +2,7 @@
 ;; -*- Gerbil -*-
 
 (import :std/test
-	:std/foreign-test
+        :std/foreign-test
         "build-config"
         "generic-test"
         "coroutine-test"
@@ -26,6 +26,7 @@
         "text/json-test"
         "text/utf8-test"
         "text/utf16-test"
+        "text/yaml-test"
         "actor/xdr-test"
         "actor-test"
         "net/httpd-test"
@@ -66,6 +67,7 @@
    json-test
    utf8-test
    utf16-test
+   (if config-enable-libyaml [yaml-test] []) ...
    string-test
    list-test
    channel-test
@@ -93,8 +95,7 @@
      (linux [signalfd-test])
      (else []))
    ...
-   signal-handler-test
-   ])
+   signal-handler-test])
 
 (apply run-tests! tests)
 (test-report-summary!)

--- a/src/std/text/yaml-test.ss
+++ b/src/std/text/yaml-test.ss
@@ -1,0 +1,17 @@
+;;; -*- Gerbil -*-
+;;; (C) vyzo at hackzen.org
+;;; :std/text/yaml unit test
+
+(import :std/test
+        :std/text/yaml
+        :std/sugar)
+(export yaml-test)
+
+(def yaml-test
+  (test-suite "test :std/text/yaml"
+    (test-case "test encoding of mapping keys"
+      (check (yaml-load-string "foo: bar") => (list (hash ("foo" "bar"))))
+      (parameterize ((yaml-key-format string->symbol))
+        (check (yaml-load-string "foo: bar") => (list (hash (foo "bar")))))
+      (parameterize ((yaml-key-format string->keyword))
+        (check (yaml-load-string "foo: bar") => (list (hash (foo: "bar"))))))))

--- a/src/std/text/yaml.ss
+++ b/src/std/text/yaml.ss
@@ -8,7 +8,10 @@
         :std/pregexp
         :std/text/utf8
         :std/text/libyaml)
-(export yaml-load yaml-load-string yaml-dump)
+(export yaml-key-format yaml-load yaml-load-string yaml-dump)
+
+(def yaml-key-format
+  (make-parameter values))
 
 (def (yaml-load fname)
   (cond
@@ -139,6 +142,11 @@
           (reverse seq)
           (lp (cons next seq))))))
 
+  (def (format-map-key key)
+    (if (string? key)
+      ((yaml-key-format) key)
+      key))
+
   (def (read-mapping tag)
     (let (ht (make-hash-table))
       (let lp ()
@@ -146,7 +154,7 @@
           (if (eq? key end-token)
             ht
             (let (value (read-node))
-              (hash-put! ht key value)
+              (hash-put! ht (format-map-key key) value)
               (lp)))))))
 
   (def (parse-scalar data tag)


### PR DESCRIPTION
I decided to make its value a function for processing the string keys.  It
seems decently general, but perhaps it is overly general?  Also, I hope
the documentation is clear enough.  Let me know.