### PR TITLE
Improve docs for hash-merge

### DIFF
--- a/doc/reference/core-builtin.md
+++ b/doc/reference/core-builtin.md
@@ -959,7 +959,14 @@ Copies *hash* into a new hash table
   more := list of hash tables
 ```
 
-Creates a new hash table, merging *more* hash tables into *hash*.
+Creates a new hash table, merging *more* hash tables into *hash*. Entries in *hash* take precedence over entries in *more*.
+
+```
+> (define t1 (list->hash-table '((a . 1) (b . 2) (c . 3))))
+> (define t2 (list->hash-table '((a . 4) (b . 5) (z . 6))))
+> (hash->list (hash-merge t1 t2))
+((a . 1) (z . 6) (b . 2) (c . 3))
+```
 
 ### hash-merge!
 ``` scheme
@@ -970,7 +977,14 @@ Creates a new hash table, merging *more* hash tables into *hash*.
 ```
 :::
 
-Merges *more* hash tables into *hash*.
+Merges *more* hash tables into *hash*. Entries in *hash* take precedence over entries in *more*.
+
+```
+> (define t1 (list->hash-table '((a . 1) (b . 2) (c . 3))))
+> (define t2 (list->hash-table '((a . 4) (b . 5) (z . 6))))
+> (begin (hash-merge! t1 t2) (hash->list t1))
+((a . 1) (z . 6) (b . 2) (c . 3))
+```
 
 ### hash-&gt;list
 ``` scheme

--- a/doc/reference/core-builtin.md
+++ b/doc/reference/core-builtin.md
@@ -959,7 +959,7 @@ Copies *hash* into a new hash table
   more := list of hash tables
 ```
 
-Creates a new hash table, merging *more* hash tables into *hash*. Entries in *hash* take precedence over entries in *more*.
+Creates a new hash table, merging *more* hash tables into *hash*. Entries in hash tables on the left take precedence over entries on the right.
 
 ```
 > (define t1 (list->hash-table '((a . 1) (b . 2) (c . 3))))
@@ -977,7 +977,7 @@ Creates a new hash table, merging *more* hash tables into *hash*. Entries in *ha
 ```
 :::
 
-Merges *more* hash tables into *hash*. Entries in *hash* take precedence over entries in *more*.
+Merges *more* hash tables into *hash*. Entries in hash tables on the left take precedence over entries on the right.
 
 ```
 > (define t1 (list->hash-table '((a . 1) (b . 2) (c . 3))))


### PR DESCRIPTION
Describes how entries in the first argument take precedence, adds examples.