### PR TITLE
Hook Gambit's ##wr to allow for custom printers.

### DIFF
--- a/src/gerbil/boot/gxi-init.scm
+++ b/src/gerbil/boot/gxi-init.scm
@@ -9,6 +9,8 @@
   (_gx#load-gxi)
   ;; hook ##begin -- gambit wraps it around -e and scripts
   (gx#eval-syntax '(define-alias ##begin begin))
+  ;; hook gambit's ##wr to use gerbil objects' :wr method
+  (##wr-set! _gx#wr)
   ;; hook gxi-script line to run as script
   (set! ##language-specs
     (append ##language-specs

--- a/src/gerbil/runtime/gx-gambc0.scm
+++ b/src/gerbil/runtime/gx-gambc0.scm
@@ -118,6 +118,18 @@
    ##repl))
 
 
+;; Replace Gambit's ##wr with our own to allow for custom printers.
+;; See Gambit's lib/_io.scm.
+(define (_gx#wr we obj)
+  (let ((wr (find-method (object-type obj) ':wr)))
+    (if wr
+      (case (macro-writeenv-style we)
+        ((mark) #f)
+        (else
+         (wr obj we)))
+      (##default-wr we obj))))
+
+
 ;;; MOP
 ;;
 ;; Gerbil rtd:

--- a/src/gerbil/runtime/gx-gambc0.scm
+++ b/src/gerbil/runtime/gx-gambc0.scm
@@ -121,13 +121,15 @@
 ;; Replace Gambit's ##wr with our own to allow for custom printers.
 ;; See Gambit's lib/_io.scm.
 (define (_gx#wr we obj)
-  (let ((wr (find-method (object-type obj) ':wr)))
-    (if wr
-      (case (macro-writeenv-style we)
-        ((mark) #f)
-        (else
-         (wr obj we)))
-      (##default-wr we obj))))
+  (if (object? obj)
+    (let ((wr (find-method (object-type obj) ':wr)))
+      (if wr
+        (case (macro-writeenv-style we)
+          ((mark) #f)
+          (else
+           (wr obj we)))
+        (##default-wr we obj)))
+    (##default-wr we obj)))
 
 
 ;;; MOP


### PR DESCRIPTION
This commit adds the `_gx#wr` hook to gerbil in order to allow for custom object printers in the REPL.

Ex:

```
(defstruct ugly-struct (a b c))
(defstruct wonderful-struct (a b c))
(defmethod {:wr wonderful-struct}
  (lambda (self we)
    (with ((wonderful-struct a b c) self)
      (##wr-str we "🦄<")
      (##wr-str we " 🌈🌈🌈 ")
      (##wr-str we (string-append
                    "a: " (number->string a)
                    " b: " (number->string a)
                    " c: " (number->string a)))
      (##wr-str we " 🌈🌈🌈 ")
      (##wr-str we ">🦄"))))

(def us (ugly-struct 1 2 3))
(def ws (wonderful-struct 1 2 3))

;; > us
;; #<ugly-struct #2>
;; > ws
;; 🦄< 🌈🌈🌈 a: 1 b: 1 c: 1 🌈🌈🌈 >🦄
```