### PR TITLE
Custom writers

### DIFF
--- a/src/gerbil/prelude/core.ss
+++ b/src/gerbil/prelude/core.ss
@@ -198,6 +198,8 @@ package: gerbil
     find-method
     next-method call-next-method
     struct-subtype? class-subtype?
+    ;; write-env style
+    write-style
     ;; control
     current-error-port
     make-promise promise?

--- a/src/gerbil/runtime/gx-gambc0.scm
+++ b/src/gerbil/runtime/gx-gambc0.scm
@@ -944,6 +944,19 @@
    (else
     (error "Cannot find next method" obj id))))
 
+;; custom writers
+(define (write-style we)
+  (macro-writeenv-style we))
+
+(define (write-object we obj)
+  (cond
+   ((method-ref obj ':wr)
+    => (lambda (method) (method obj we)))
+   (else
+    (##default-wr we obj))))
+
+(##wr-set! write-object)
+
 ;;; etc
 ;; use gambit type for this
 (define (raise-type-error where type obj)


### PR DESCRIPTION
This adds support for custom writers through the `:wr` method.
Many thanks to @belmarca for his investigative work.

Example:
```
(defstruct A (a b c))
(def a (make-A 1 2 3))

> a
#<A #4>

(defmethod {:wr A}
  (lambda (obj we)
    (case (write-style we)
      ((mark)
       (when (##wr-mark-begin we obj)
         (##wr we (A-a obj))
         (##wr-mark-end we obj)))
      (else
       (when (##wr-stamp we obj)
         (##wr-str we "#{A ")
         (##wr we (A-a obj))
         (##wr-str we "}"))))))

> a
#{A 1}

> (set! (A-a a) a)
> a
#0=#{A #0#}
```
