### PR TITLE
pred-after-sequence

### DIFF
--- a/doc/reference/misc.md
+++ b/doc/reference/misc.md
@@ -6499,6 +6499,29 @@ if `limit` is not false.
 ```
 :::
 
+### pred-after-sequence
+``` scheme
+(pred-after-sequence lst [limit = #f]) -> procedure
+
+  lst   := proper or circular list
+  limit := optional, return #t only limit times
+```
+
+`pred-after-sequence` returns a predicate which returns `#t` after a
+matching sequence. `#t` is returned `limit` times, if `limit` is not `#f`.
+
+::: tip Examples:
+``` scheme
+> (find (pred-after-sequence [1 2]) [0 1 2 'a 'b])
+a
+
+> (let (fn (pred-after-sequence [1]))
+    (fn 0)  ; #f
+    (fn 1)  ; #f
+    (fn 2)) ; #t
+```
+:::
+
 ## Extended Real Number Line
 The (affine) extended real number line, where real numbers are enriched
 with positive and negative infinity, compactifying their order.

--- a/src/std/misc/func-test.ss
+++ b/src/std/misc/func-test.ss
@@ -53,4 +53,14 @@
     (test-case "test pred-limit"
       (check (filter (pred-limit even? 2) (iota 6 1))  => [2 4])
       (check (filter (pred-limit even? 0) (iota 6 1))  => [])
-      (check (filter (pred-limit even? #f) (iota 6 1)) => [2 4 6]))))
+      (check (filter (pred-limit even? #f) (iota 6 1)) => [2 4 6]))
+    (test-case "test pred-after-sequence"
+      (let (fn (pred-after-sequence [1 2]))
+        (check (fn 1)  => #f)
+        (check (fn 2)  => #f)
+        (check (fn 'a) => #t))
+      (let (fn (pred-after-sequence []))
+        (check (fn 1)  => #f)
+        (check (fn 2)  => #f))
+      (check (filter (pred-after-sequence [1 2]) [1 2 'a 1 2 'b]) => '(a b))
+      (check (filter (pred-after-sequence [2] 1) [1 2 'a 1 2 'b]) => '(a)))))

--- a/src/std/misc/func.ss
+++ b/src/std/misc/func.ss
@@ -9,7 +9,7 @@
   @compose1 @compose @compose/values
   rcompose1 rcompose rcompose/values
   @rcompose1 @rcompose @rcompose/values
-  pred-limit)
+  pred-limit pred-after-sequence)
 
 ;; Repeat value or call function N times and return the result as list.
 ;; (repeat 2 5)                  -> (2 2 2 2 2)  ; repeat the value 2
@@ -202,3 +202,31 @@
   (if limit
     (if (> limit 0) test (lambda (_) #f))
     pred))
+
+;; pred-after-sequence returns a predicate which returns #t after a
+;; matching sequence. True is returned limit times, if limit is not #f.
+;;
+;; Example:
+;;  (filter (pred-after-sequence [1 2]) [1 2 'a 1 2 'b]) => (a b)
+(def (pred-after-sequence list (limit #f))
+  (declare (not safe) (fixnum))
+  ;; TODO when contracts merge
+  ;; (@contract (pred-sequence list limit) (or (not limit) (fixnum? limit)))
+  (unless (fixnum? limit) (set! limit -1))
+  (def is-after #f)
+  (def seq list)
+  (def (check v)
+    (when (and (or (equal? (car seq) v)
+                   (begin (set! seq list) #f)) ; reset
+               (set! seq (cdr seq))
+               (null? seq))
+      (set! is-after #t) ; return #t on next call
+      (set! seq list)    ; reset
+      (when (> limit 0) (set! limit (1- limit)))))
+  (if (pair? list)
+    (lambda (v)
+      (match* (is-after limit)
+        ((#t _) (set! is-after #f) #t)   ; success
+        ((_ 0)                     #f)   ; limit reached
+        (else   (check v)          #f))) ; always false
+    (lambda (_) #f)))


### PR DESCRIPTION
Since some time I'm tinkering about new `pred` procedures and how to combine them to extend e.g. `srfi` procedures.

- `pred-after-sequence` is there to find a "thing" after a "patter"