### PR TITLE
std/misc/list: take-until take-until! drop-until

### DIFF
--- a/doc/reference/misc.md
+++ b/doc/reference/misc.md
@@ -2456,6 +2456,42 @@ unary procedure `stop`. If limit is set, split the list only limit times.
 ```
 :::
 
+### take-until
+### take-until!
+``` scheme
+(take-until pred lst) -> list
+
+  pred := predicate
+  lst  := proper or circular list
+```
+
+`take-until` returns a list with all elements before `pred` returns `#t`.
+`take-until!` is the linear-update variant of `take-until`.
+
+::: tip Examples:
+``` scheme
+> (take-until number? ['a "hi" 1 'c])
+(a "hi")
+```
+:::
+
+### drop-until
+``` scheme
+(drop-until pred lst) -> list
+
+  pred := predicate
+  lst  := proper or circular list
+```
+
+`drop-until` returns a list with all elements from the point on `pred` returns `#t`.
+
+::: tip Examples:
+``` scheme
+> (drop-until number? ['a [] "hi" 1 'c])
+(1 c)
+```
+:::
+
 ### group
 ``` scheme
 (group lst [test = equal?]) -> list

--- a/src/std/misc/list.ss
+++ b/src/std/misc/list.ss
@@ -22,6 +22,7 @@
   slice! slice-right!
   butlast
   split
+  take-until take-until! drop-until
   group
   every-consecutive?
   psetq psetv pset psetq! psetv! pset! pgetq-set! pgetv-set! pget-set!
@@ -29,7 +30,9 @@
   separate-keyword-arguments
   )
 
-(import (only-in ../srfi/1 drop drop-right drop-right! take take-right take! reverse!)
+(import (only-in ../srfi/1
+                 drop drop-right drop-right! take take-right take! reverse!
+                 take-while take-while! drop-while)
         ../sugar)
 
 ;; This function checks if the list is a proper association-list.
@@ -292,6 +295,19 @@
                        (loop xs (cons v buf) n)))
       ((#t rest)     (if (zero? limit) lst
                        (if (pair? rest) [rest] []))))))
+
+;; take-until returns a list with all elements before pred returns #t.
+;;
+;; Example:
+;;  (take-until number? ['a [] "hi" 1 'c]) => (a () "hi")
+(def (take-until  pred list) (take-while  (? (not pred)) list))
+(def (take-until! pred list) (take-while! (? (not pred)) list))
+
+;; drop-until returns a list with all elements from the point on pred returns #t.
+;;
+;; Example:
+;;  (drop-until number? ['a [] "hi" 1 'c]) => (1 c)
+(def (drop-until pred list) (drop-while (? (not pred)) list))
 
 ;; group consecutive elements of the list lst into a list-of-lists.
 ;;


### PR DESCRIPTION
Convenience functions which help code to be more literal.
We could live without them, but I think its nice to have them.

``` scheme
(drop-until string? [1 'a "b" #\c])
```
vs
``` scheme
(drop-while (? (not string?)) [1 'a "b" #\c])
```
