### PR TITLE
Force UTF8 in source files

### DIFF
--- a/src/gerbil/compiler/driver.ss
+++ b/src/gerbil/compiler/driver.ss
@@ -19,8 +19,16 @@ namespace: gxc
 (def (compile-timestamp)
   (inexact->exact (floor (time->seconds (current-time)))))
 
+(def scheme-file-settings '(permissions: #o644 char-encoding: UTF-8 eol-encoding: lf))
+
+(def (with-output-to-scheme-file path fun)
+  (with-output-to-file [path: path . scheme-file-settings] fun))
+
 (def (gerbil-gsc)
   (getenv "GERBIL_GSC" "gsc"))
+
+(def gsc-runtime-args
+  ["-:f8,-8,t8"]) ;; force Gambit to use UTF-8
 
 (def (compile-file srcpath (opts []))
   (unless (string? srcpath)
@@ -89,8 +97,8 @@ namespace: gxc
 
   (def (compile-stub output-scm output-bin)
     (let* ((init-stub  (path-expand "lib/gx-init-exe.scm" (getenv "GERBIL_HOME")))
-           (gsc-args ["-exe" "-o" output-bin output-scm]))
-      (with-output-to-file output-scm (cut generate-stub init-stub))
+           (gsc-args [gsc-runtime-args ... "-exe" "-o" output-bin output-scm]))
+      (with-output-to-scheme-file output-scm (cut generate-stub init-stub))
       (when (current-compile-invoke-gsc)
         (verbose "invoke gsc " (cons 'gsc gsc-args))
         (let* ((proc (open-process [path: (gerbil-gsc) arguments: gsc-args
@@ -198,10 +206,10 @@ namespace: gxc
                             ["-e" "(define-cond-expand-feature|enable-smp|)"
                              "-e" include-gx-gambc-macros]
                             ["-e" include-gx-gambc-macros]))
-           (gsc-args ["-exe" "-o" output-bin
+           (gsc-args [gsc-runtime-args ... "-exe" "-o" output-bin
                       (gsc-debug-options) ... gsc-opts ... gsc-gx-macros ...
                       output-scm]))
-      (with-output-to-file output-scm
+      (with-output-to-scheme-file output-scm
         (cut generate-stub [gx-gambc0 gx-gambc-init deps ... bin-scm]))
       (when (current-compile-invoke-gsc)
         (verbose "invoke gsc " (cons 'gsc gsc-args))
@@ -390,8 +398,7 @@ namespace: gxc
        ((current-compile-static)
         ;; just touch empty runtime code file in static
         (let (path (compile-static-output-file ctx))
-          (with-output-to-file [path: path permissions: #o644]
-            void))))
+          (with-output-to-scheme-file path void))))
 
       (generate-loader-code ctx code rt)))
 
@@ -458,7 +465,7 @@ namespace: gxc
              (else #f)))
            (rt (hash-get (current-compile-runtime-sections) ctx)))
       (verbose "compile " path)
-      (with-output-to-file [path: path permissions: #o644]
+      (with-output-to-scheme-file path
         (lambda ()
           (displayln "prelude:" " " prelude)
           (when pkg (displayln "package:" " " pkg))
@@ -494,7 +501,7 @@ namespace: gxc
            (else #f))))
 
     (verbose "compile " path)
-    (with-output-to-file [path: path permissions: #o644]
+    (with-output-to-scheme-file path
       (lambda ()
         (displayln "prelude: :gerbil/compiler/ssxi")
         (when pkg (displayln "package: " pkg))
@@ -524,7 +531,7 @@ namespace: gxc
 ;;; utilities
 (def (compile-scm-file path code (phi? #f))
   (verbose "compile " path)
-  (with-output-to-file [path: path permissions: #o644]
+  (with-output-to-scheme-file path
     (lambda ()
       (pretty-print
        `(declare
@@ -569,7 +576,7 @@ namespace: gxc
             => (lambda (opts) [opts ... path]))
            (else [path])))
          (gsc-args
-          [(gsc-debug-options phi?) ... gsc-args ...])
+          [gsc-runtime-args ... (gsc-debug-options phi?) ... gsc-args ...])
          (_ (verbose "invoke gsc " (cons 'gsc gsc-args)))
          (proc (open-process [path: (gerbil-gsc) arguments: gsc-args
                                     stdout-redirection: #f]))

--- a/src/gerbil/expander/module.ss
+++ b/src/gerbil/expander/module.ss
@@ -42,6 +42,11 @@ namespace: gx
 (def current-module-reader-args
   (make-parameter #f))
 
+(def source-file-settings '(char-encoding: UTF-8 eol-encoding: lf))
+
+(def (call-with-input-source-file path fun)
+  (call-with-input-file [path: path . source-file-settings] fun))
+
 (defmethod {:init! module-context}
   (lambda (self id super ns path)
     (struct-instance-init! self id (make-hash-table-eq) super #f #f
@@ -346,7 +351,7 @@ namespace: gx
       (read-lang inp)
       (raise-syntax-error #f "Illegal module syntax" path)))
 
-  (call-with-input-file path read-e))
+  (call-with-input-source-file path read-e))
 
 (def (core-read-module-package path pre ns)
   (def (string-e e)
@@ -493,7 +498,7 @@ namespace: gx
       (let* ((gerbil.pkg (path-expand "gerbil.pkg" dir))
              (plist
               (if (or exists? (file-exists? gerbil.pkg))
-                (let (e (call-with-input-file gerbil.pkg read))
+                (let (e (call-with-input-source-file gerbil.pkg read))
                   (cond
                    ((eof-object? e) [])
                    ((list? e) e)


### PR DESCRIPTION
Force use of UTF-8 for Gerbil and Gambit source files, overriding any settings from either the end-user's ambient environment, or Gambit's default runtime options.