### PR TITLE
Refactor run-tests

### DIFF
--- a/src/std/actor-test.ss
+++ b/src/std/actor-test.ss
@@ -6,8 +6,7 @@
         :std/test
         :std/event
         :std/actor)
-(export actor-rpc-test
-        actor-rpc-stream-test)
+(export actor-test)
 
 (defproto hello
   call: (hello a)
@@ -253,3 +252,8 @@
 
       (stop-rpc-server! remoted)
       (stop-rpc-server! locald))))
+
+(def actor-test
+  (test-suite "test :std/actor RPC"
+    (run-test-suite! actor-rpc-test)
+    (run-test-suite! actor-rpc-stream-test)))

--- a/src/std/actor/xdr-test.ss
+++ b/src/std/actor/xdr-test.ss
@@ -8,9 +8,9 @@
         :std/actor/xdr
         :std/net/bio
         :std/iter)
-(export actor-xdr-test)
+(export xdr-test)
 
-(def actor-xdr-test
+(def xdr-test
   (test-suite "test :std/actor/xdr"
 
     (def (check-serialize obj (obj-e values))

--- a/src/std/generic-test.ss
+++ b/src/std/generic-test.ss
@@ -4,9 +4,9 @@
 
 (import :std/test
         :std/generic)
-(export generic-runtime-test generic-macro-test)
+(export generic-test)
 
-(def generic-runtime-test
+(def generic-test
   (test-suite "test :std/generic support"
     (def my-generic (make-generic 'my-generic (lambda args #f)))
     (test-case "test default dispatch"
@@ -36,11 +36,9 @@
                     (type-linearize-class A::t)]
                    (lambda (a b) ['A+ (A-x a) (A-x b)]))
     (test-case "test user type dispatch"
-      (check (generic-dispatch my-generic (make-A 1) (make-A 2)) => '(A+ 1 2)))))
+      (check (generic-dispatch my-generic (make-A 1) (make-A 2)) => '(A+ 1 2)))
 
-
-(def generic-macro-test
-  (test-suite "test :std/generic macros"
+    ;; Test cases for macro support
     (defgeneric my-add
       (lambda args #f))
 
@@ -63,7 +61,6 @@
       (check (my-add 1 2) => '(fixnum+ 1 2))
       (check (my-add 1.0 2.0) => '(number+ 1.0 2.0)))
 
-    (defstruct A (x))
     (defmethod (my-add (a A) (b A))
       ['A+ (A-x a) (A-x b)])
 

--- a/src/std/net/socket/server-test.ss
+++ b/src/std/net/socket/server-test.ss
@@ -11,9 +11,9 @@
         :std/error
         :std/sugar
         :std/test)
-(export socket-server-test)
+(export server-test)
 
-(def socket-server-test
+(def server-test
   (test-suite "test :std/net/socket"
 
     (def server-address "localhost:4242")


### PR DESCRIPTION
Make it so you only have to register a test in one place,
so no test is left behind.
Automatically match test files and test suites by name, patching a few files.

Check that no test file is forgotten. I used this zsh command to locate the
missing files (it's damning that zsh is easier for that than gerbil still):

diff -u =(grep '.-test"' run-tests.ss | cut -d\" -f2 | sort -u) =(print -l **/*-test.ss | cut -d. -f1 | sort -u)

Add missing test/utf32-test.

Add explicitly commented-out tests where a running server is required.