### PR TITLE
std/misc/list: alias delete-duplicates to unique

### DIFF
--- a/doc/reference/misc.md
+++ b/doc/reference/misc.md
@@ -2273,6 +2273,27 @@ error    ; expects proper non-dotted list-of-lists
 ```
 :::
 
+### unique
+### unique!
+``` scheme
+(unique lst [test = equal?]) -> list
+
+  lst  := proper list
+  test := test procedure which takes two arguments, defaults to equal?
+```
+Alias for `delete-duplicates` and `delete-duplicates!` ([SRFI 1](https://srfi.schemers.org/srfi-1/srfi-1.html#delete-duplicates)).
+
+::: tip Examples:
+``` scheme
+> (unique [1 2 3 2])
+(1 2 3)
+
+> (let (lst [1 2])
+    (unique [lst lst] ev?))
+((1 2))
+```
+:::
+
 ### rassoc
 ``` scheme
 (rassoc elem alist [pred = eqv?]) -> pair | #f

--- a/src/std/misc/list.ss
+++ b/src/std/misc/list.ss
@@ -3,6 +3,7 @@
 ;;;; List utilities
 
 (export
+  unique unique!
   alist?
   plist?
   plist->alist
@@ -32,8 +33,12 @@
 
 (import (only-in ../srfi/1
                  drop drop-right drop-right! take take-right take! reverse!
-                 take-while take-while! drop-while)
+                 take-while take-while! drop-while
+                 delete-duplicates delete-duplicates!)
         ../sugar)
+
+(defalias unique delete-duplicates)
+(defalias unique! delete-duplicates!)
 
 ;; This function checks if the list is a proper association-list.
 ;; ie it has the form [[key1 . val1] [key2 . val2]]


### PR DESCRIPTION
Alias for `delete-duplicates` because the default name is difficult to remember (and too long). There is an interference between the words `delete` and `remove` (I work in E-Learning).

If your interested in the topic, you can find much more information [here](https://www.supermemo.com/en/archives1990-2015/articles/20rules) (check out _'11. Combat interference'_).