### PR TITLE
Don't use realpath, non-standard on BSD

### DIFF
--- a/src/gerbil/gxi
+++ b/src/gerbil/gxi
@@ -4,7 +4,8 @@ set -e
 GERBIL_GSI="gsi"
 
 if [ -z "$GERBIL_HOME" ]; then
-    GERBIL_HOME=$(dirname "$(dirname "$(realpath "$0")")")
+    # The path below is set by configure --prefix=...
+    GERBIL_HOME=$(cd ${0%/*}; echo "${PWD%/*}") # Won't work if a symlink; use configure --prefix then.
     export GERBIL_HOME
 fi
 

--- a/src/gerbil/gxi-build-script
+++ b/src/gerbil/gxi-build-script
@@ -4,7 +4,8 @@ set -e
 GERBIL_GSI="gsi"
 
 if [ -z "$GERBIL_HOME" ]; then
-    GERBIL_HOME=$(dirname "$(dirname "$(realpath "$0")")")
+    # The path below is set by configure --prefix=...
+    GERBIL_HOME=$(cd ${0%/*}; echo "${PWD%/*}") # Won't work if a symlink; use configure --prefix then.
     export GERBIL_HOME
 fi
 


### PR DESCRIPTION
Restore the previous GERBIL_HOME autodetection algorithm,
even though it doesn't work when gxi is a symlink:
- Realpath is part of GNU coreutils, not present on Darwin by default.
- In cases where it is a symlink (as when using Nix), Gerbil can and must
  be configured with --prefix at which point this autodetection is replaced
  by a hardwired path.
- However, compared to the previous version, since we're using ${foo%/*}
  once already, let's not use dirname to do the same thing a second time.