### PR TITLE
doc: bump minimum version of Gambit to v4.9.3

### DIFF
--- a/doc/guide/README.md
+++ b/doc/guide/README.md
@@ -11,8 +11,8 @@ $ git clone https://github.com/vyzo/gerbil.git
 
 ## Dependencies
 
-The latest Gerbil release (v0.16) requires Gambit v4.9.0;
-the latest Gambit is recommended nonetheless (v4.9.3).
+The latest Gerbil release (v0.16) requires the latest Gambit release, v4.9.3.
+Older versions of Gambit, starting with v4.9.1 may also work, but we haven't tested.
 
 The core system has no dependencies outside Gambit, but the standard
 library has several mostly optional dependencies. The only hard dependency


### PR DESCRIPTION
It turns out that v4.9.0 doesn't build any more, because of some bug in the thread system (errors with deadlock detected in the build).

This bumps the minimum Gambit version to v4.9.3, since this is what we have been testing with.