### PR TITLE
std/misc/func: pred-and & pred-or

### DIFF
--- a/doc/reference/misc.md
+++ b/doc/reference/misc.md
@@ -6598,6 +6598,42 @@ of a matching sequence. The list elements are compared using `equal?`.
 ```
 :::
 
+### pred-and
+``` scheme
+(pred-and pred) -> procedure
+
+  pred  := predicate
+```
+`pred-and` returns `#t` when every `pred` invocation returned a truethy value.
+
+::: tip Examples:
+``` scheme
+> (let (fn (pred-and number?))
+    (fn 10)
+    (fn 20))
+#t
+```
+:::
+
+### pred-or
+``` scheme
+(pred-or pred) -> procedure
+
+  pred  := predicate
+```
+
+`pred-or` returns `#t` when any `pred` invocation returned a truethy value.
+
+::: tip Examples:
+``` scheme
+> (let (fn (pred-or number?))
+    (fn 'a)
+    (fn 20)
+    (fn "b"))
+#t
+```
+:::
+
 ## Extended Real Number Line
 The (affine) extended real number line, where real numbers are enriched
 with positive and negative infinity, compactifying their order.

--- a/src/std/misc/func-test.ss
+++ b/src/std/misc/func-test.ss
@@ -62,4 +62,10 @@
         (check (fn 1)  => #f)
         (check (fn 2)  => #f))
       (check (filter (pred-sequence [1 2]) [1 2 'a 1 2]) => '(2 2))
-      (check (filter (pred-sequence [2] 1) [1 2 1 2]) => '(2)))))
+      (check (filter (pred-sequence [2] 1) [1 2 1 2]) => '(2)))
+    (test-case "test pred-and"
+     (check (let (fn (pred-and number?)) (fn 10) (fn 20)) => #t)
+     (check (let (fn (pred-and number?)) (fn 'a) (fn 10)) => #f))
+    (test-case "test pred-or"
+     (check (let (fn (pred-or number?)) (fn 'a) (fn 20)) => #t)
+     (check (let (fn (pred-or number?)) (fn 'a) (fn 'b)) => #f))))

--- a/src/std/misc/func.ss
+++ b/src/std/misc/func.ss
@@ -9,7 +9,7 @@
   @compose1 @compose @compose/values
   rcompose1 rcompose rcompose/values
   @rcompose1 @rcompose @rcompose/values
-  pred-limit pred-sequence)
+  pred-limit pred-sequence pred-and pred-or)
 
 ;; Repeat value or call function N times and return the result as list.
 ;; (repeat 2 5)                  -> (2 2 2 2 2)  ; repeat the value 2
@@ -227,3 +227,19 @@
   (if (pair? list)
     (lambda (v) (if (zero? limit) #f (check v)))
     (lambda (_) #f)))
+
+;; pred-and returns true when every pred invocation returned a truethy value.
+(def (pred-and pred)
+  (def res #t)
+  (lambda (v)
+    (if res
+      (begin (set! res (pred v)) res)
+      #f)))
+
+;; pred-or returns true when any pred invocation returned a truethy value.
+(def (pred-or pred)
+  (def res #f)
+  (lambda (v)
+    (if res
+      #t
+      (begin (set! res (pred v)) res))))


### PR DESCRIPTION
`pred-and` allows to check if a `pred` holds on multiple circumstances without constructing a filtered list of to-be-checked items beforehand.