### PR TITLE
Make polydactyl compile in the background

### DIFF
--- a/src/lang/build-deps
+++ b/src/lang/build-deps
@@ -58,10 +58,6 @@
  (scheme/r5rs-null "scheme/r5rs-null" (gerbil/core scheme/r5rs))
  (scheme/r7rs "scheme/r7rs" (gerbil/core scheme/base))
  (gerbil/polydactyl
-  (gxc:
-   "gerbil/polydactyl"
-   (foreground: #t)
-   "-e"
-   "(include \"~~lib/_gambit#.scm\")")
-  (gerbil/core gerbil/gambit/readtables)))
+  (gxc: "gerbil/polydactyl" "-e" "(include \"~~lib/_gambit#.scm\")")
+  (gerbil/core gerbil/gambit/readtables std/gambit-sharp)))
 

--- a/src/lang/build.ss
+++ b/src/lang/build.ss
@@ -2,14 +2,14 @@
 ;; -*- Gerbil -*-
 
 (import :std/build-script
-        :std/gambit-sharp)
+        :std/make)
 
 (defbuild-script
   `(;; standard scheme
     "scheme/stubs"
     "scheme/base-etc"
     "scheme/base-vectors"
-    (gxc: "scheme/base-ports" "-e" "(include \"~~lib/_gambit#.scm\")")
+    (gxc: "scheme/base-ports" ,@(include-gambit-sharp))
     "scheme/base-impl"
     "scheme/base"
     "scheme/case-lambda"
@@ -41,7 +41,7 @@
     "scheme/r5rs-null"
     "scheme/r7rs"
     ;; Gerbil variants. Polydactyl needs foreground due to using _gambit# at phi 1.
-    (gxc: "gerbil/polydactyl" (foreground: #t) "-e" "(include \"~~lib/_gambit#.scm\")")
+    (gxc: "gerbil/polydactyl" ,@(include-gambit-sharp))
     )
   libdir: (path-expand "lib" (getenv "GERBIL_HOME"))
   debug: 'src)

--- a/src/lang/gerbil/polydactyl.ss
+++ b/src/lang/gerbil/polydactyl.ss
@@ -12,7 +12,7 @@
   (export #t)
   (extern namespace: #f macro-readtable-brace-keyword-set!))
 
-(import (for-syntax _gambit))
+(import (for-syntax _gambit :std/gambit-sharp))
 
 (begin-syntax
   (def *readtable*

--- a/src/std/build-deps
+++ b/src/std/build-deps
@@ -2,6 +2,7 @@
  (std/build-config
   (gxc: "build-config" (extra-inputs: ("build-features.ss")))
   (gerbil/core))
+ (std/gambit-sharp "gambit-sharp" (gerbil/core))
  (std/interactive "interactive" (gerbil/core gerbil/gambit/misc))
  (std/pregexp "pregexp" (gerbil/core))
  (std/sort "sort" (gerbil/core))


### PR DESCRIPTION
Removes the foregrounding by virtue of importing `:std/gambit-sharp` for syntax so that it injected in the compiler.
Also updates build-deps files.