### PR TITLE
Implement eval-when-compile

### DIFF
--- a/doc/reference/core-prelude.md
+++ b/doc/reference/core-prelude.md
@@ -894,6 +894,15 @@ Examples:
 = (import :std/sugar :std/srfi/1 :std/srfi/113 :std/srfi/133)
 ```
 
+### Special Evaluation Forms
+
+#### eval-when-compile
+```
+(eval-when-compile expr)
+```
+
+Evaluates `expr` when expanding in compiler context.
+
 ## Runtime Symbol Bindings
 
 The runtime bindings exported by the prelude are all externs collected in nested modules,
@@ -2091,3 +2100,5 @@ Symbols related to thread programming; spawn and with-lock primitives.
     + [prefix-in prefix-out](#prefix-in-prefix-out)
     + [struct-out](#struct-out)
     + [group-in](#group-in)
+  * [Special Evaluation Forms](#special-evaluation-forms)
+    + [eval-when-compile](#eval-when-compile)

--- a/src/bootstrap/gerbil/expander/core.ssi
+++ b/src/bootstrap/gerbil/expander/core.ssi
@@ -35,6 +35,9 @@ namespace: gx
          (%#define-runtime
           current-expander-allow-rebind?
           gx#current-expander-allow-rebind?)
+          (%#define-runtime
+          current-expander-compiling?
+          gx#current-expander-compiling?)
          (%#define-runtime expander-context::t gx#expander-context::t)
          (%#define-runtime expander-context? gx#expander-context?)
          (%#define-runtime make-expander-context gx#make-expander-context)

--- a/src/bootstrap/gerbil/expander/core__0.scm
+++ b/src/bootstrap/gerbil/expander/core__0.scm
@@ -15,6 +15,7 @@
   (define gx#current-expander-module-library-package-cache
     (make-parameter '#f))
   (define gx#current-expander-allow-rebind? (make-parameter '#f))
+  (define gx#current-expander-compiling? (make-parameter '#f))
   (define gx#expander-context::t
     (make-struct-type
      'gx#expander-context::t

--- a/src/gerbil/compiler/driver.ss
+++ b/src/gerbil/compiler/driver.ss
@@ -63,7 +63,8 @@ namespace: gxc
                    (current-compile-debug debug)
                    (current-compile-generate-ssxi gen-ssxi)
                    (current-compile-static static)
-                   (current-compile-timestamp (compile-timestamp)))
+                   (current-compile-timestamp (compile-timestamp))
+                   (current-expander-compiling? #t))
       (verbose "compile " srcpath)
       (compile-top-module (import-module srcpath)))))
 
@@ -89,7 +90,8 @@ namespace: gxc
                    (current-compile-gsc-options gsc-options)
                    (current-compile-keep-scm keep-scm?)
                    (current-compile-verbose verbosity)
-                   (current-compile-timestamp (compile-timestamp)))
+                   (current-compile-timestamp (compile-timestamp))
+                   (current-expander-compiling? #t))
       (verbose "compile exe " srcpath)
       (compile-e (import-module srcpath) opts))))
 

--- a/src/gerbil/expander/core.ss
+++ b/src/gerbil/expander/core.ss
@@ -40,6 +40,9 @@ namespace: gx
 (def current-expander-allow-rebind?
   (make-parameter #f))
 
+(def current-expander-compiling?
+  (make-parameter #f))
+
 ;; expander context
 (defstruct expander-context (id table)
   id: gx#expander-context::t

--- a/src/gerbil/prelude/core.ss
+++ b/src/gerbil/prelude/core.ss
@@ -6,8 +6,8 @@ package: gerbil
 
 (export #t
         (import: <runtime> <sugar> <MOP> <match> <more-sugar>
-                 <module-sugar>)
-        (phi: +1 (import: <runtime> <sugar> <MOP> <match> <more-sugar>
+                 <module-sugar> <special>)
+        (phi: +1 (import: <runtime> <sugar> <MOP> <match> <more-sugar> <special>
                           <expander-runtime> <syntax-case> <syntax-sugar>
                           <more-syntax-sugar>)))
 
@@ -319,6 +319,7 @@ package: gerbil
     current-expander-marks
     current-expander-path
     current-expander-phi
+    current-expander-compiling?
     current-module-reader-path
     current-module-reader-args
     local-context? top-context? module-context? prelude-context?
@@ -3280,3 +3281,16 @@ package: gerbil
   )
 
 (import <module-sugar>)
+
+(module <special>
+  (export #t)
+
+  (defsyntax (eval-when-compile stx)
+    (syntax-case stx ()
+      ((_ expr)
+       (begin
+         (when (current-expander-compiling?)
+           (eval-syntax #'expr))
+         #'(void))))))
+
+(import <special>)

--- a/src/lang/build-deps
+++ b/src/lang/build-deps
@@ -58,10 +58,6 @@
  (scheme/r5rs-null "scheme/r5rs-null" (gerbil/core scheme/r5rs))
  (scheme/r7rs "scheme/r7rs" (gerbil/core scheme/base))
  (gerbil/polydactyl
-  (gxc:
-   "gerbil/polydactyl"
-   (foreground: #t)
-   "-e"
-   "(include \"~~lib/_gambit#.scm\")")
-  (gerbil/core gerbil/gambit/readtables)))
+  (gxc: "gerbil/polydactyl" "-e" "(include \"~~lib/_gambit#.scm\")")
+  (gerbil/core gerbil/gambit/readtables std/gambit-sharp)))
 

--- a/src/lang/build.ss
+++ b/src/lang/build.ss
@@ -2,14 +2,14 @@
 ;; -*- Gerbil -*-
 
 (import :std/build-script
-        :std/gambit-sharp)
+        :std/make)
 
 (defbuild-script
   `(;; standard scheme
     "scheme/stubs"
     "scheme/base-etc"
     "scheme/base-vectors"
-    (gxc: "scheme/base-ports" "-e" "(include \"~~lib/_gambit#.scm\")")
+    (gxc: "scheme/base-ports" ,@(include-gambit-sharp))
     "scheme/base-impl"
     "scheme/base"
     "scheme/case-lambda"
@@ -41,7 +41,7 @@
     "scheme/r5rs-null"
     "scheme/r7rs"
     ;; Gerbil variants. Polydactyl needs foreground due to using _gambit# at phi 1.
-    (gxc: "gerbil/polydactyl" (foreground: #t) "-e" "(include \"~~lib/_gambit#.scm\")")
+    (gxc: "gerbil/polydactyl" ,@(include-gambit-sharp))
     )
   libdir: (path-expand "lib" (getenv "GERBIL_HOME"))
   debug: 'src)

--- a/src/lang/gerbil/polydactyl.ss
+++ b/src/lang/gerbil/polydactyl.ss
@@ -13,7 +13,7 @@
   (extern namespace: #f macro-readtable-brace-keyword-set!))
 
 (import (for-syntax _gambit))
-(eval-when-compile (import :std/gambit-sharp))
+(eval-when-compile (import (for-syntax :std/gambit-sharp)))
 
 (begin-syntax
   (def *readtable*

--- a/src/lang/gerbil/polydactyl.ss
+++ b/src/lang/gerbil/polydactyl.ss
@@ -13,6 +13,7 @@
   (extern namespace: #f macro-readtable-brace-keyword-set!))
 
 (import (for-syntax _gambit))
+(eval-when-compile (import :std/gambit-sharp))
 
 (begin-syntax
   (def *readtable*

--- a/src/std/build-deps
+++ b/src/std/build-deps
@@ -2,6 +2,7 @@
  (std/build-config
   (gxc: "build-config" (extra-inputs: ("build-features.ss")))
   (gerbil/core))
+ (std/gambit-sharp "gambit-sharp" (gerbil/core))
  (std/interactive "interactive" (gerbil/core gerbil/gambit/misc))
  (std/pregexp "pregexp" (gerbil/core))
  (std/sort "sort" (gerbil/core))

--- a/src/std/make.ss
+++ b/src/std/make.ss
@@ -252,7 +252,8 @@ TODO:
   (defvalues (positionals keywords) (separate-keyword-arguments args #t))
   (def buildspec (match positionals ([x] x) (_ (error "invalid arguments" make positionals))))
   (def settings (apply make-settings keywords))
-  (parameterize ((current-directory (settings-srcdir settings)))
+  (parameterize ((current-directory (settings-srcdir settings))
+                 (current-expander-compiling? #t))
     (with-fresh-cache (%make buildspec settings))))
 
 (def (%make buildspec settings)


### PR DESCRIPTION
Adds a new special form, `eval-when-compile` that can be used to do evaluation in the compiler context.
This is implemented using a new parameter in the expander, `current-expander-compiling?`, which is set by the compiler driver and `make`.

This allows us to compile `:gerbil/polydactyl` in the background without having to incur any load time penalty from loading `:std/gambit-sharp`.