### PR TITLE
core: rename 'remove' to 'remove1'

### DIFF
--- a/doc/reference/core-builtin.md
+++ b/doc/reference/core-builtin.md
@@ -1256,15 +1256,15 @@ Returns the first element in *lst* that satisfies *pred*.
 Generalization of *member*; returns the first pair in *lst* whose *car*
 satisfies *pred*.
 
-### remove
+### remove1
 ``` scheme
-(remove el lst [=? = equal?]) -> list
+(remove1 el lst) -> list
 
   el  := any
   lst := list
 ```
 
-Returns *lst* removing the first element *x* that satisfies `(=? el x)`.
+Returns *lst* removing the first element *x* that satisfies `(equal? el x)`.
 
 ### remv
 ``` scheme
@@ -1274,7 +1274,7 @@ Returns *lst* removing the first element *x* that satisfies `(=? el x)`.
   lst := list
 ```
 
-Apply `remove` using `eqv?` as the comparator.
+Apply `remove1` using `eqv?` as the comparator.
 
 ### remq
 ``` scheme
@@ -1284,7 +1284,7 @@ Apply `remove` using `eqv?` as the comparator.
   lst := list
 ```
 
-Apply `remove` using `eq?` as the comparator.
+Apply `remove1` using `eq?` as the comparator.
 
 ### remf
 ``` scheme
@@ -1294,7 +1294,7 @@ Apply `remove` using `eq?` as the comparator.
   lst  := list
 ```
 
-Like `remove`, but removes the first element `x` that satisfies `(pred x)`
+Like `remove1`, but removes the first element `x` that satisfies `(pred x)`
 
 ## Numerics
 

--- a/doc/reference/core-prelude.md
+++ b/doc/reference/core-prelude.md
@@ -1016,7 +1016,7 @@ Defines the following symbols as externs:
     make-list cons*
     foldl foldr andmap ormap filter filter-map iota last last-pair
     memf assgetq find
-    remove remq remv remf
+    remove1 remq remv remf
     pgetq pgetv pget
     subvector subvector->list subvector-fill!
     vector-map vector-copy vector-append

--- a/src/bootstrap/gerbil/core.ssi
+++ b/src/bootstrap/gerbil/core.ssi
@@ -303,7 +303,7 @@ namespace: gerbil/core
                     (find find)
                     (list-set list-set)
                     (list-set! list-set!)
-                    (remove remove)
+                    (remove1 remove1)
                     (remq remq)
                     (remv remv)
                     (remf remf)

--- a/src/gerbil/prelude/core.ss
+++ b/src/gerbil/prelude/core.ss
@@ -123,7 +123,7 @@ package: gerbil
     foldl foldr andmap ormap filter filter-map iota last last-pair
     memf assgetq assgetv assget find
     list-set list-set!
-    remove remq remv remf
+    remove1 remq remv remf
     pgetq pgetv pget
     subvector subvector->list subvector-fill!
     vector-copy!

--- a/src/gerbil/prelude/core.ssxi.ss
+++ b/src/gerbil/prelude/core.ssxi.ss
@@ -384,7 +384,7 @@ package: gerbil
  fxarithmetic-shift
  set-box!
  memf find
- remove remq remv remf
+ remove1 remq remv remf
  hash-key?
  hash-map
  string-shrink!

--- a/src/gerbil/runtime/gx-gambc0.scm
+++ b/src/gerbil/runtime/gx-gambc0.scm
@@ -1385,7 +1385,7 @@
        (if (proc hd) rest (lp tl)))
       (else #f))))
 
-(define-macro (define-remove remove cmp)
+(define-macro (define-remove1 remove cmp)
   `(define (,remove el lst)
     (let lp ((rest lst) (r '()))
       (core-match rest
@@ -1395,9 +1395,9 @@
            (lp rest (cons hd r))))
         (else lst)))))
 
-(define-remove remove equal?)
-(define-remove remv eqv?)
-(define-remove remq eq?)
+(define-remove1 remove1 equal?)
+(define-remove1 remv eqv?)
+(define-remove1 remq eq?)
 
 (define (remf proc lst)
   (let lp ((rest lst) (r '()))

--- a/src/std/actor/rpc/server.ss
+++ b/src/std/actor/rpc/server.ss
@@ -222,7 +222,7 @@
         ((!rpc.unmonitor remote)
          (let (address (remote-address remote))
            (alet (thread (hash-get conns address))
-             (hash-update! monitors thread (cut remove [src . remote] <>) []))))
+             (hash-update! monitors thread (cut remove1 [src . remote] <>) []))))
         ((!rpc.shutdown)
          (raise 'shutdown))
         (else

--- a/src/std/net/wamp.ss
+++ b/src/std/net/wamp.ss
@@ -242,7 +242,7 @@
 
   (def (remove-actor-subscription! topic thread)
     (alet (topics (hash-get actor-subscriptions thread))
-      (let (topics (remove topic topics))
+      (let (topics (remove1 topic topics))
         (if (null? topics)
           (hash-remove! actor-subscriptions thread)
           (hash-put! actor-subscriptions thread topics)))


### PR DESCRIPTION
The current core [remove](https://cons.io/reference/core-builtin.html#remove) procedure behaves more like srfi-1 [delete](https://srfi.schemers.org/srfi-1/srfi-1.html#delete) with the exception that it only eliminates **one item** from the list and doesn't take a test argument. Therefor the behavior of the current `remove` changes when srfi-1 is imported. This PR renames the procedure to clean-up this pitfall and introduces thereby a breaking change.