### PR TITLE
Correcting major-mode for gerbil.el, see #510

### DIFF
--- a/doc/guide/emacs.md
+++ b/doc/guide/emacs.md
@@ -29,7 +29,7 @@ You can then make `gxi` your scheme program by setting `scheme-program-name`:
 
 And you can now run Gerbil with `M-x run-scheme`.
 
-N.B. Up to v0.16 the editing mode file was gerbil.el. Starting with `v0.16-1-g36a31050`, gerbil mode has been migrated to gerbil-mode.el; see [#510](https://github.com/vyzo/gerbil/issues/510) for migrating.
+N.B. Up to v0.16 the editing mode file was gerbil.el. After `v0.16-48-g46f10016`, gerbil mode has been migrated to gerbil-mode.el; see [#510](https://github.com/vyzo/gerbil/issues/510) for migrating.
 
 ## Treadmill: An Alternative
 

--- a/doc/guide/emacs.md
+++ b/doc/guide/emacs.md
@@ -3,12 +3,12 @@
 The natural home for Gerbil development is Emacs, the ultimate parenthesis manipulation machine.
 
 ## Standard Emacs Setup
-Gerbil comes with a custom editing mode, which extends scheme-mode with font-lock and indentation for Gerbil code: [gerbil.el](https://github.com/vyzo/gerbil/blob/master/etc/gerbil.el).
+Gerbil comes with a custom editing mode, which extends scheme-mode with font-lock and indentation for Gerbil code: [gerbil-mode.el](https://github.com/vyzo/gerbil/blob/master/etc/gerbil-mode.el).
 See below for additional functionality provided by gerbil-mode.
 
 You can add it to your autoload path (eg by linking in `$HOME/.emacs.d`) and adding this to your `.emacs`:
 ```
-(autoload 'gerbil-mode "gerbil" "Gerbil editing mode." t)
+(autoload 'gerbil-mode "gerbil-mode" "Gerbil editing mode." t)
 ```
 
 You should further utilize Gambit's inferior mode, as it offers debugger integration with sources on emacs.
@@ -28,6 +28,8 @@ You can then make `gxi` your scheme program by setting `scheme-program-name`:
 ```
 
 And you can now run Gerbil with `M-x run-scheme`.
+
+N.B. Up to v0.16 the editing mode file was gerbil.el. Starting with `v0.16-1-g36a31050`, gerbil mode has been migrated to gerbil-mode.el; see [#510](https://github.com/vyzo/gerbil/issues/510) for migrating.
 
 ## Treadmill: An Alternative
 
@@ -97,7 +99,7 @@ hacking in no time. All you have to do is to set the environment variables
 `GERBIL_HOME` and `GAMBIT_HOME` and copy the code snippet below into your Emacs config.
 
 ``` elisp
-(use-package gerbil
+(use-package gerbil-mode
   :when (getenv "GERBIL_HOME")
   :ensure nil
   :defer t
@@ -111,7 +113,7 @@ hacking in no time. All you have to do is to set the environment variables
   (setf gambit (getenv "GAMBIT_HOME"))
   (setf gerbil (getenv "GERBIL_HOME"))
   (autoload 'gerbil-mode
-    (concat gerbil "/etc/gerbil.el") "Gerbil editing mode." t)
+    (concat gerbil "/etc/gerbil-mode.el") "Gerbil editing mode." t)
   :hook
   ((gerbil-mode . linum-mode)
    (inferior-scheme-mode-hook . gambit-inferior-mode))

--- a/etc/gerbil-mode.el
+++ b/etc/gerbil-mode.el
@@ -1,4 +1,4 @@
-;;; gerbil.el --- Gerbil mode -*- lexical-binding: t; -*-
+;;; gerbil-mode.el --- Gerbil mode -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (c) 2007-2019 Dimitris Vyzovitis & Contributors
 ;;
@@ -510,6 +510,7 @@
   (kill-all-local-variables)
   (use-local-map gerbil-mode-map)
   (setq mode-name "Gerbil")
+  (setq major-mode 'gerbil-mode)
   (setq scheme-program-name gerbil-program-name)
   (setq comment-start ";;")
   (scheme-mode-variables)
@@ -522,6 +523,6 @@
   (modify-coding-system-alist 'file "\\.ss\\'"  'utf-8))
 
 
-(provide 'gerbil)
+(provide 'gerbil-mode)
 
-;;; gerbil.el ends here
+;;; gerbil-mode.el ends here

--- a/src/install
+++ b/src/install
@@ -49,7 +49,7 @@
   (create-directory-if-necessary (string-append default-gerbil-home "/share/emacs"))
   (create-directory-if-necessary (string-append default-gerbil-home "/share/emacs/site-lisp"))
   (create-directory-if-necessary (string-append default-gerbil-home "/share/emacs/site-lisp/gerbil"))
-  (install "../etc/gerbil.el" (string-append default-gerbil-home "/share/emacs/site-lisp/gerbil/gerbil.el"))
+  (install "../etc/gerbil-mode.el" (string-append default-gerbil-home "/share/emacs/site-lisp/gerbil/gerbil-mode.el"))
   (create-directory-if-necessary (string-append default-gerbil-home "/share/gerbil"))
   (install "TAGS" (string-append default-gerbil-home "/share/gerbil/TAGS"))
   (patch-gxc-shebang))


### PR DESCRIPTION
### What
This PR fixes #510, there were two problems:

1. `gerbil.el` did not set the `major-mode` to `gerbil-mode`
2. `gerbil.el` provided `gerbil` but spacemacs and `use-package` expected it to provide `gerbil-mode`

### The fix
1. rename `gerbil.el` to `gerbil-mode.el`
2. add `(setq major-mode 'gerbil-mode)`
3. change `(provide 'gerbil)` to `(provide 'gerbil-mode)`

This should not be an invasive change in any way, but I have not tested it in vanilla emacs so please try it and reject if it changes the workflow. If it impacts the vanilla emacs workflow in any way then I'll just pull a mirror copy for the `spacemacs` layer and maintain it. Any comments on ways to better contribute also appreciated.

Thanks!