### PR TITLE
Make amb search strategy parametric, default to deterministic

### DIFF
--- a/doc/reference/amb.md
+++ b/doc/reference/amb.md
@@ -16,12 +16,24 @@ AMB is the ambiguous special form for non-deterministic computation.
 Evaluates body in a fresh amb scope; you should always wrap the beginning of ambiguous computation
 in a `begin-amb` form to avoid side-effects leaking between amb executions.
 
+### begin-amb-random
+```
+(begin-amb-random body ...)
+```
+
+Like `begin-amb`, but the search strategy for generating amb values is randomized.
+
 ### amb
 ```
 (amb expr ...)
 ```
 
 The ambiguous operator; may evaluate and return the value of any expression operand.
+
+The order with which the values are generated depends on the search strategy.
+After `v0.16-56-g6fb422de` by default it is deterministic, unless the computation is within
+a `begin-amb-random` scope, in which case it is randomized.
+Prior to `v0.16-56-g6fb422de` the search strategy was always randomized.
 
 ### amb-find
 ```

--- a/src/std/amb.ss
+++ b/src/std/amb.ss
@@ -7,7 +7,7 @@
         :std/sugar
         :std/error
         :std/misc/shuffle)
-(export begin-amb amb amb-find one-of amb-collect all-of amb-assert required
+(export begin-amb begin-amb-random amb amb-find one-of amb-collect all-of amb-assert required
         amb-do amb-do-find amb-do-collect)
 
 (defstruct (amb-completion <error>) ())
@@ -24,10 +24,20 @@
 (def amb-results
   (make-parameter []))
 
+(def amb-strategy
+  (make-parameter identity))
+
 (defrules begin-amb ()
   ((_ e es ...)
    (parameterize ((amb-fail amb-exhausted)
                   (amb-results []))
+     e es ...)))
+
+(defrules begin-amb-random ()
+  ((_ e es ...)
+   (parameterize ((amb-fail amb-exhausted)
+                  (amb-results [])
+                  (amb-strategy shuffle))
      e es ...)))
 
 (defrules amb ()
@@ -59,7 +69,7 @@
 (def (amb-do thunks)
   (let (fail (amb-fail))
     (let/cc return
-      (let loop ((rest (shuffle thunks)))
+      (let loop ((rest ((amb-strategy) thunks)))
         (match rest
           ([thunk . rest]
            (amb-fail (lambda () (loop rest)))


### PR DESCRIPTION
Adds a new `begin-amb-random` construct for explicitly requesting randomized search strategy, which is now by default deterministic.
Previously it was always randomized.

cc @eraserhd 