### PR TITLE
make amb-collect reliable

### DIFF
--- a/doc/reference/amb.md
+++ b/doc/reference/amb.md
@@ -104,6 +104,13 @@ Procedural form of `amb-find`
 Procedural form of `amb-collect`
 
 
+### amb-exhausted?
+```
+(amb-exhausted? e) -> boolean
+```
+
+Predicate that returns true if *e* is an exception raised because the amb search was exhausted.
+
 ## Example
 
 Here is the well known dwelling house puzzle:


### PR DESCRIPTION
This would sometimes fail, because the required clause is be outside the collect scope:
```
(begin-amb-random (let (x (amb 0 1 2)) (required (not (= 0 x))) (all-of x)))
```

This fixes the issue by introducing a parameter that prescribes the behaviour of `amb-fail`; when set, it is a thunk that continues at the end of the collection; otherwise it just raises.

Note that we have completely deviated from the original chicken egg that served as inspiration at this point; there, `all-off` is a scope construct (not really, but almost because it uses mutation of global variables and it's also completely undocumented) that collects from ambs within the expression context.
In the Gerbil implementation, `all-of` just appears within an amb scope to perform a collect+cut.

cc @eraserhd 