### PR TITLE
std/text/csv: add write-csv-file

### DIFF
--- a/doc/reference/text.md
+++ b/doc/reference/text.md
@@ -257,6 +257,29 @@ Format one line of *fields* to *port* in CSV format, using the current syntax pa
 Given a list of *lines*, each of them a list of fields, and a PORT,
 format those lines as CSV according to the current syntax parameters.
 
+### write-csv-file
+``` scheme
+(write-csv-file path lines . settings) -> void
+
+  lines    := list of strings
+  path     := output path
+  settings := optional path settings
+```
+Writes `lines` to the designated `path` using `write-csv-lines`
+and the provided `settings`. Check section
+[17.7.1 Filesystem devices](http://www.iro.umontreal.ca/~gambit/doc/gambit.html#Filesystem-devices)
+of the Gambit Manual if you want to know more about the `settings` parameter.
+
+::: tip Examples:
+``` scheme
+> (write-csv-file "/tmp/foo.csv" [["hello" "world"] ["a" "b"]])
+;; hello,world\na,b
+
+> (write-csv-file "/tmp/foo.csv" [["and" "more"]] append: #t)
+;; hello,world\na,b\nand,more
+```
+:::
+
 ### call-with-creativyst-csv-syntax
 ``` scheme
 (call-with-creativyst-csv-syntax thunk) -> any

--- a/src/std/text/csv.ss
+++ b/src/std/text/csv.ss
@@ -31,7 +31,8 @@
   csv-eol csv-line-endings csv-skip-whitespace?
   csv-allow-binary?
   call-with-creativyst-csv-syntax call-with-rfc4180-csv-syntax call-with-strict-rfc4180-csv-syntax
-  read-csv-line read-csv-lines read-csv-file write-csv-line write-csv-lines)
+  read-csv-line read-csv-lines read-csv-file write-csv-line write-csv-lines write-csv-file
+  )
 
 (import
   :std/error :std/misc/list :std/misc/string :std/srfi/1 :std/srfi/13 :std/sugar)
@@ -300,6 +301,12 @@
 ;; format those lines as CSV according to the current syntax parameters.
 (def (write-csv-lines lines port)
   (for-each (cut write-csv-line <> port) lines))
+
+;; Writes list of LINES to the designated PATH using write-csv-lines
+;; and the provided settings.
+(def (write-csv-file path lines . settings)
+  (call-with-output-file (cons* path: path settings)
+    (cut write-csv-lines lines <>)))
 
 ;; Format one line of FIELDS to PORT in CSV format,
 ;; using the current syntax parameters.


### PR DESCRIPTION
A convenient procedure to improve working from the REPL with csv.