### PR TITLE
json: optimize list parsing with inline list accumulators

### DIFF
--- a/src/std/build-deps
+++ b/src/std/build-deps
@@ -124,7 +124,6 @@
    gerbil/gambit/exact
    gerbil/gambit/ports
    std/error
-   std/srfi/1
    std/text/hex))
  (std/text/_zlib
   (ssi: "text/_zlib" (gsc: "text/_zlib" "-cc-options" "" "-ld-options" "-lz"))


### PR DESCRIPTION
Instead of cons+reverse!, just accumulate the list inline by setting the tail.

Follow up from #535.