### PR TITLE
std/misc/string: str

### DIFF
--- a/doc/reference/misc.md
+++ b/doc/reference/misc.md
@@ -5589,6 +5589,63 @@ characters (`[a-zA-Z0-9_]`). Throws an error if `len` is not a fixnum.
 ```
 :::
 
+### str
+``` scheme
+(str . xs) -> string
+
+  xs := values to be converted and concatenated into a string
+```
+`str` converts all of its arguments into a single string.
+When called without an argument an empty string is returned.
+
+::: tip Examples:
+``` scheme
+> (str)
+""
+
+> (str 2.0)
+"2.0"
+
+> (str "hello" ", world")
+"hello, world"
+
+> (import :std/format :std/misc/repr)
+> (defstruct point (x y))
+> (def p (make-point 10 20))
+> (defmethod {:pr point}
+    (lambda (self port options)
+      (fprintf port "(point ~a ~a)"
+               (point-x self) (point-y self))))
+
+> (str p 'abc [1 2] 3.4E+2)
+"(point 10 20)abc[1 2]340.0"
+```
+:::
+
+### str-format
+``` scheme
+(str-format v) -> string
+
+  v := any value
+```
+`str-format` takes any value and returns a formatting string, which can be
+used by the `:std/format` family of procedures. Considers the `:pr`
+[method](https://cons.io/reference/misc.html#representable) from `:std/misc/repr`.
+
+::: tip Examples:
+``` scheme
+> (import :std/format)
+> (str-format "hello")
+"~a"  ; default format
+
+> (str-format 1.2E+2)
+"~f"  ; inexact number
+
+> (str-format (vector 1 2 3))
+"~r"  ; object which implements the :pr method of :std/misc/repr
+```
+:::
+
 ### line ending variables
 ``` scheme
 (define +cr+   "\r")

--- a/src/std/misc/string-test.ss
+++ b/src/std/misc/string-test.ss
@@ -3,11 +3,16 @@
 (import
   :std/misc/string :std/srfi/13
   :std/test :gerbil/gambit/exceptions
-  :std/pregexp)
+  :std/pregexp :std/misc/repr :std/sugar :std/format)
 
 (def (error-with-message? message)
   (lambda (e)
     (and (error-exception? e) (equal? (error-exception-message e) message))))
+
+(defstruct point (x y))
+(defmethod {:pr point}
+  (lambda (self port options)
+    (fprintf port "(point ~a ~a)" (point-x self) (point-y self))))
 
 (def string-test
   (test-suite "test :std/misc/string"
@@ -65,4 +70,18 @@
       (check-eq? (and (pregexp-match "^\\w+$" (random-string 100)) #t) #t)
       (check-equal? (random-string 0) "")
       (check-equal? (random-string -1) "")
-      (check-equal? (string-length (random-string 5)) 5))))
+      (check-equal? (string-length (random-string 5)) 5))
+    (test-case "test str"
+      (check (str)                    => "")
+      (check (str "hi")               => "hi")
+      (check (str "hello" ", world.") => "hello, world.")
+      (check (str 0.1 "!")            => "0.1!")
+      (check (str 2.0)                => "2.0")
+      (check (str 1.2E+2)             => "120.0")
+      (check (str 'abc)               => "abc")
+      (check (str '(1 2))             => "[1 2]")
+      (check (str (hash (a 10)))      => "(hash (a 10))")
+      (check (str #(1 2))             => "(vector 1 2)")
+      (check (str (values 1 2))       => "(values 1 2)")
+      (check (str (make-point 1 2))   => "(point 1 2)"))
+    ))


### PR DESCRIPTION
Handy Clojure like procedure that converts a single thing into a string or appends multiple string into one.

``` scheme
> (str 1.0)
"1.0"

> (str "foo" "bar")
"foobar"
```

I tried to get the output as human friendly as possible by e.g. converting numbers from `2.` to `2.0`.