### PR TITLE
allow exports in top context

### DIFF
--- a/src/gerbil/expander/module.ss
+++ b/src/gerbil/expander/module.ss
@@ -1017,15 +1017,23 @@ namespace: gx
     (or (module-export? e)
         (export-set? e)))
 
-  (let (rbody (core-expand-import/export stx expanded-export?
-                                         'apply-export-expander
-                                         current-export-expander-phi
-                                         expand1))
-    (if internal-expand?
-      (reverse rbody)
-      (core-quote-syntax
-       (core-cons '%#export (export! rbody))
-       (stx-source stx)))))
+  (cond
+   ((or (module-context? (current-expander-context)) internal-expand?)
+    (let (rbody (core-expand-import/export stx expanded-export?
+                                           'apply-export-expander
+                                           current-export-expander-phi
+                                           expand1))
+      (if internal-expand?
+        (reverse rbody)
+        (core-quote-syntax
+         (core-cons '%#export (export! rbody))
+         (stx-source stx)))))
+   ((top-context? (current-expander-context))
+    (core-quote-syntax
+     (core-cons '%#begin [])
+     (stx-source stx)))
+   (else
+    (raise-syntax-error #f "Illegal context" stx))))
 
 (def (core-expand-export-source hd)
   (core-expand-export% ['export-macro% hd] #t))

--- a/src/gerbil/expander/root.ss
+++ b/src/gerbil/expander/root.ss
@@ -76,7 +76,7 @@ namespace: gx
                         ,core-compile-top-import%)
     (%#module           top:     ,core-expand-module%
                         ,core-compile-top-module%)
-    (%#export           module:  ,core-expand-export%
+    (%#export           top:  ,core-expand-export%
                         ,core-compile-top-export%)
     (%#provide          module:  ,core-expand-provide%
                         ,core-compile-top-provide%)


### PR DESCRIPTION
A much requested feature.
When not in module context (or an internal expansion), it is ignored.
This allows us to have scripts that are also modules and use export.