### PR TITLE
Remove newline when writing http post/put data

### DIFF
--- a/src/std/net/request.ss
+++ b/src/std/net/request.ss
@@ -246,8 +246,7 @@
             headers)
   (newline port)
   (when body
-    (write-subu8vector body 0 (u8vector-length body) port)
-    (newline port))
+    (write-subu8vector body 0 (u8vector-length body) port))
   (force-output port))
 
 (def status-line-rx


### PR DESCRIPTION
When writing post data, adding an extra newline may cause some
web servers to close the connection before sending a response
because the extra newline isn’t accounted for in the post/put data’s
content length. Removing the newline seems to fix the problem. This was
encountered posting a capabilities document to `chromedriver`’s
/session endpoint. An alternate fix is to include the new line in the
content-length calculation.