### PR TITLE
Introducing a new macro for foreign opaque objects

### DIFF
--- a/doc/guide/ffi.md
+++ b/doc/guide/ffi.md
@@ -253,4 +253,182 @@ Gerbil v0.16-133-gfdfdcb5d on Gambit v4.9.3-1232-gbba388b8
 #t
 ```
 
+## A foreign opaque object interface
 
+Opaque objects are objects which its contents are not available to the user, or is irrelevant, or even changes depending on the system implementation. A good example of an opaque object is C stream type FILE, all access to its data is made by means of methods like fprintf, fgets, fputs, etc. It is reasonable to consider that its constructor is `fopen` (or others that creates a new stream) and its destructor is `fclose`.
+
+To introduce that interface, let's consider the definition of a type `Widget` as follows:
+
+```
+$ cat widget.h
+#ifndef _widget_h
+#define _widget_h
+
+#include <stdint.h>
+
+#define OPAQUE_DATA_SIZE 32
+
+struct _Widget {
+  uint8_t * opaque_data[OPAQUE_DATA_SIZE];
+};
+
+typedef struct _Widget Widget;
+
+Widget * widget_new(int data);
+int widget_count(void);
+void widget_destroy(Widget * data);
+
+#endif
+```
+
+And widget.c:
+
+```
+$ cat widget.c
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "widget.h"
+
+static int count = 0;
+
+Widget* widget_new(int data) {
+  Widget * self = malloc(sizeof(Widget));
+  ((int *) self->opaque_data)[0] = data;
+  count++;
+  return self;
+}
+
+int widget_count(void) {
+  return count;
+}
+
+void widget_destroy(Widget * self) {
+  printf("Widget_destroy(): garbage collected\n");
+  count--;
+  free(self);
+}
+```
+
+To wrap this definition and make the destructor be called by garbage collector, a simple wrapper, is defined bellow, using `define-foo` macro:
+
+```
+$ cat widget-wrap.ss 
+package: ffi-example
+
+(import :std/foreign)
+
+(export #t)
+
+(begin-ffi (obj-new obj-count)
+  (c-declare "#include <stdlib.h>")
+  (c-declare "#include \"widget.h\"")
+  (define-foo Widget "widget_destroy")
+  (define-c-lambda widget-new (int) Widget* "widget_new")
+  (define-c-lambda widget-count () int "widget_count"))
+```
+
+Let's compile all:
+
+```
+$ gcc -Wall -c widget.c
+$ gxc -ld-options `pwd`/widget.o -cc-options -I`pwd` widget-wrap.ss
+```
+
+And a simple test to that:
+
+```
+$ cat widget-release-test.ss 
+(import :std/iter
+        :ffi-example/widget-wrap)
+
+;; gcc -Wall -c widget.c
+;; gxc foreign2.ss
+;; gxc -ld-options `pwd`/widget.o -cc-options -I`pwd` widget-wrap.ss
+;; gxi widget-release-test.ss
+
+(def o (widget-new 1))
+
+(displayln (widget-count))
+(for ((i (in-range 0 10)))
+  (let ((o (widget-new i)))
+    (displayln (widget-count))))
+```
+
+Calling it from interpreter:
+
+```
+$ gxi widget-release-test.ss 
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+Widget_destroy(): garbage collected
+Widget_destroy(): garbage collected
+Widget_destroy(): garbage collected
+Widget_destroy(): garbage collected
+Widget_destroy(): garbage collected
+Widget_destroy(): garbage collected
+Widget_destroy(): garbage collected
+Widget_destroy(): garbage collected
+Widget_destroy(): garbage collected
+Widget_destroy(): garbage collected
+Widget_destroy(): garbage collected
+```
+
+It is a quite simple implementation of a foreign opaque object (our FOO) but can be very useful, because destructors sometimes must release other system resources than their own object allocated memory.
+
+Considering C stream FILE, where its destructor must release OS resources like file descriptors, IO buffers, etc. So, as a simple example, let' consider the following wrapper code:
+
+```
+ cat FILE-wrap.ss 
+package: ffi-example
+
+(import :std/foreign)
+
+(export #t)
+
+(begin-ffi (FILE FILE* fopen fputs fclose)
+  (c-declare "#include <stdlib.h>")
+  (c-declare "#include <stdio.h>")
+  (define-foo FILE "fclose")
+  (define stdout ((c-lambda () FILE* "___return(stdout);")))
+  (define-c-lambda fopen (char-string char-string) FILE* "fopen")
+  (define-c-lambda fputs (char-string FILE*) int "fputs"))
+```
+
+The dummy example:
+
+```
+$ cat FILE-example.ss 
+(import :ffi-example/FILE-wrap)
+
+(fputs "Hello world!\n" stdout)
+
+(let ((f (fopen "FILE-test.txt" "w")))
+  (fputs "Hello FOO\n" f))
+
+;; at this point f can be closed at by Garbage Collector will...
+```
+
+Compiling and executing:
+
+```
+$ gxc FILE-wrap.ss 
+$ gxi FILE-example.ss 
+Hello world!
+```
+
+Finally:
+
+```
+$ cat FILE-test.txt 
+Hello FOO
+```

--- a/doc/guide/ffi.md
+++ b/doc/guide/ffi.md
@@ -182,12 +182,16 @@ Consider there are a simple module written in C defining two functions, f1 and f
 
 ```
 $ cat ffi-pi.h
+#ifndef _ffi_pi_h
+#define _ffi_pi_h
 double f1(void); 
 double f2(double x);
+#endif
 
 $ cat ffi-pi.c
 #include <stdlib.h>
 #include <math.h>
+#include "ffi-pi.h"
 
 double f1(void) {
   return M_PI;

--- a/src/std/build-deps
+++ b/src/std/build-deps
@@ -125,6 +125,11 @@
    gerbil/gambit/ports
    std/error
    std/text/hex))
+ (std/text/libyaml
+  (ssi:
+   "text/libyaml"
+   (gsc: "text/libyaml" "-cc-options" "" "-ld-options" "-lyaml"))
+  (gerbil/core))
  (std/text/_zlib
   (ssi: "text/_zlib" (gsc: "text/_zlib" "-cc-options" "" "-ld-options" "-lz"))
   (gerbil/core))
@@ -159,6 +164,19 @@
  (std/net/bio/buffer
   "net/bio/buffer"
   (gerbil/core std/error std/net/bio/input std/net/bio/output std/srfi/1))
+ (std/xml/_libxml
+  (ssi:
+   "xml/_libxml"
+   (gsc:
+    "xml/_libxml"
+    "-cc-options"
+    "-I/usr/include/libxml2"
+    "-ld-options"
+    "-lxml2"
+    "-e"
+    "(include \"~~lib/_gambit#.scm\")"))
+  (gerbil/core))
+ (std/xml/libxml "xml/libxml" (gerbil/core std/xml/_libxml))
  (std/xml/sxpath "xml/sxpath" (gerbil/core))
  (std/xml/sxml "xml/sxml" (gerbil/core))
  (std/xml/sxml-to-xml
@@ -502,6 +520,16 @@
    std/parser/lexer
    std/parser/rlang
    std/parser/stream))
+ (std/text/yaml
+  "text/yaml"
+  (gerbil/core
+   std/error
+   std/iter
+   std/misc/list-builder
+   std/pregexp
+   std/sugar
+   std/text/libyaml
+   std/text/utf8))
  (std/net/address
   "net/address"
   (gerbil/core gerbil/gambit/os std/format std/pregexp std/text/hex))
@@ -1174,5 +1202,25 @@
   (gerbil/core))
  (std/db/sqlite
   "db/sqlite"
-  (gerbil/core std/db/_sqlite std/db/dbi std/format std/iter)))
+  (gerbil/core std/db/_sqlite std/db/dbi std/format std/iter))
+ (std/db/_lmdb
+  (ssi: "db/_lmdb" (gsc: "db/_lmdb" "-cc-options" "" "-ld-options" "-llmdb"))
+  (gerbil/core))
+ (std/db/lmdb
+  "db/lmdb"
+  (gerbil/core gerbil/gambit/threads std/db/_lmdb std/error std/text/utf8))
+ (std/db/_leveldb
+  (ssi:
+   "db/_leveldb"
+   (gsc: "db/_leveldb" "-cc-options" "" "-ld-options" "-lleveldb"))
+  (gerbil/core))
+ (std/db/leveldb
+  "db/leveldb"
+  (gerbil/core
+   gerbil/gambit/misc
+   gerbil/gambit/threads
+   std/db/_leveldb
+   std/error
+   std/iter
+   std/text/utf8)))
 

--- a/src/std/build-deps
+++ b/src/std/build-deps
@@ -653,6 +653,7 @@
  (std/xml "xml"
           (gerbil/core
            std/build-config
+           std/xml/libxml
            std/xml/print
            std/xml/ssax
            std/xml/sxml

--- a/src/std/build-deps
+++ b/src/std/build-deps
@@ -125,11 +125,6 @@
    gerbil/gambit/ports
    std/error
    std/text/hex))
- (std/text/libyaml
-  (ssi:
-   "text/libyaml"
-   (gsc: "text/libyaml" "-cc-options" "" "-ld-options" "-lyaml"))
-  (gerbil/core))
  (std/text/_zlib
   (ssi: "text/_zlib" (gsc: "text/_zlib" "-cc-options" "" "-ld-options" "-lz"))
   (gerbil/core))
@@ -164,19 +159,6 @@
  (std/net/bio/buffer
   "net/bio/buffer"
   (gerbil/core std/error std/net/bio/input std/net/bio/output std/srfi/1))
- (std/xml/_libxml
-  (ssi:
-   "xml/_libxml"
-   (gsc:
-    "xml/_libxml"
-    "-cc-options"
-    "-I/usr/include/libxml2"
-    "-ld-options"
-    "-lxml2"
-    "-e"
-    "(include \"~~lib/_gambit#.scm\")"))
-  (gerbil/core))
- (std/xml/libxml "xml/libxml" (gerbil/core std/xml/_libxml))
  (std/xml/sxpath "xml/sxpath" (gerbil/core))
  (std/xml/sxml "xml/sxml" (gerbil/core))
  (std/xml/sxml-to-xml
@@ -520,16 +502,6 @@
    std/parser/lexer
    std/parser/rlang
    std/parser/stream))
- (std/text/yaml
-  "text/yaml"
-  (gerbil/core
-   std/error
-   std/iter
-   std/misc/list-builder
-   std/pregexp
-   std/sugar
-   std/text/libyaml
-   std/text/utf8))
  (std/net/address
   "net/address"
   (gerbil/core gerbil/gambit/os std/format std/pregexp std/text/hex))
@@ -653,7 +625,6 @@
  (std/xml "xml"
           (gerbil/core
            std/build-config
-           std/xml/libxml
            std/xml/print
            std/xml/ssax
            std/xml/sxml
@@ -1203,25 +1174,5 @@
   (gerbil/core))
  (std/db/sqlite
   "db/sqlite"
-  (gerbil/core std/db/_sqlite std/db/dbi std/format std/iter))
- (std/db/_lmdb
-  (ssi: "db/_lmdb" (gsc: "db/_lmdb" "-cc-options" "" "-ld-options" "-llmdb"))
-  (gerbil/core))
- (std/db/lmdb
-  "db/lmdb"
-  (gerbil/core gerbil/gambit/threads std/db/_lmdb std/error std/text/utf8))
- (std/db/_leveldb
-  (ssi:
-   "db/_leveldb"
-   (gsc: "db/_leveldb" "-cc-options" "" "-ld-options" "-lleveldb"))
-  (gerbil/core))
- (std/db/leveldb
-  "db/leveldb"
-  (gerbil/core
-   gerbil/gambit/misc
-   gerbil/gambit/threads
-   std/db/_leveldb
-   std/error
-   std/iter
-   std/text/utf8)))
+  (gerbil/core std/db/_sqlite std/db/dbi std/format std/iter)))
 

--- a/src/std/foreign.ss
+++ b/src/std/foreign.ss
@@ -60,13 +60,11 @@
                (string-types '(char-string nonull-char-string UTF-8-string
                                            nonnull-UTF-8-string UTF-16-string
                                            nonnull-UTF16-string))
-               (string-compat-required? (if release-function
-                                          #f
-                                          (let loop ((m members))
-                                            (cond
-                                             ((null? m) #f)
-                                             ((member (cdr (car m)) string-types) #t)
-                                             (else (loop (cdr m)))))))
+               (string-compat-required? (let loop ((m members))
+                                          (cond
+                                           ((null? m) #f)
+                                           ((member (cdr (car m)) string-types) #t)
+                                           (else (loop (cdr m))))))
                (string-setter-body (lambda (member-name)
                                      (let ((m (string-append "___arg1->" member-name)))
                                        (string-append
@@ -77,30 +75,28 @@
                                         m "= strdup(___arg2);" "\n"
                                         "}" "\n"
                                         "___return;" "\n"))))
-               (default-free-body (and (or release-function string-compat-required?)
+               (default-free-body (and string-compat-required?
                                        (string-append
                                         "___SCMOBJ " struct-str "_ffi_free (void *ptr) {" "\n"
                                         "struct " struct-str " *obj = (struct " struct-str "*) ptr;" "\n"
-                                        (if release-function
-                                          (string-append release-function "(obj);" "\n")
-                                          (string-append
-                                           (apply string-append
-                                             (map (lambda (m)
-                                                    (cond 
-                                                     ((memq (cdr m) string-types)
-                                                      (let ((mem-name (symbol->string (car m))))
-                                                        (string-append "if(obj->" mem-name ") " 
-                                                                       "free(obj->" mem-name ");" "\n")))
-                                                     (else "")))
-                                                  members))
-                                           "free(obj);" "\n"))
+                                        (apply string-append
+                                          (map (lambda (m)
+                                                 (cond 
+                                                  ((memq (cdr m) string-types)
+                                                   (let ((mem-name (symbol->string (car m))))
+                                                     (string-append "if(obj->" mem-name ") " 
+                                                                    "free(obj->" mem-name ");" "\n")))
+                                                  (else "")))
+                                               members))
+                                        "free(obj);" "\n"
                                         "return ___FIX (___NO_ERR);" "\n"
                                         "}"
                                         )))
-               (release-function (if (or release-function string-compat-required?)
-                                   (string-append struct-str "_ffi_free")
-                                   "ffi_free"))
-               (string-compat-types (if (or release-function string-compat-required?)
+               (release-function (or release-function
+                                     (if string-compat-required?
+                                       (string-append struct-str "_ffi_free")
+                                       "ffi_free")))
+               (string-compat-types (if string-compat-required?
                                       `((c-declare ,default-free-body)
                                         (c-define-type ,shallow-ptr
 						       (pointer ,struct (,struct-ptr) "ffi_free")))


### PR DESCRIPTION
Many libraries implements objects in C that are opaque, which are accessed only by functions (methods). What is proposed by this PR is a simple implementation that only assign the object destructor to be called by GC. It can be useful in many situations as for example in FFI for GTK. The documentation in ffi.md shows some examples that makes it useful.