### PR TITLE
chain macro - add plain procedure call support

### DIFF
--- a/doc/reference/sugar.md
+++ b/doc/reference/sugar.md
@@ -167,6 +167,7 @@ Anaphoric `when`. Evaluates and binds *test* to *id*. Evaluates *body ...* if
 (chain expr (expression) ...)
 
 <expression>:
+  proc                        ; unary procedure
   (proc arg* ...)             ; must contain exactly one <> symbol
   (var (proc arg1 arg* ...))  ; var supports destructuring
 
@@ -188,9 +189,9 @@ chain will return a unary lambda.
 ::: tip Examples:
 ``` scheme
 > (chain "stressed"
-    (string->list <>)
-    (reverse <>)
-    (list->string <>)
+    string->list
+    reverse
+    list->string
     (string-append "then have some " <>))
 "then have some desserts"
 

--- a/src/std/sugar-test.ss
+++ b/src/std/sugar-test.ss
@@ -49,6 +49,23 @@
              (string-join <> ", "))
       (iota 3))
      "2")
+
+    (check-equal?
+      ;; unary procedure at the start
+      (let (map1 (cut map 1+ <>))
+        (chain [1 2]
+          map1
+          (reverse <>)))
+      [3 2])
+
+    (check-equal?
+      ;; unary procedure not at the start
+      (chain [9 19 29]
+        ([_ . rest] (map 1+ rest))
+        reverse
+        car)
+      30)
+
     (check-equal? (chain [0 1] (map (lambda (v) (1+ v)) <>)) [1 2]))
    (test-case "test is"
     (check ((is 1+ 3) 2)                => #t)

--- a/src/std/sugar.ss
+++ b/src/std/sugar.ss
@@ -230,77 +230,100 @@
 ;; prefixed with a variable (supports destructuring).
 ;;
 ;; When the first expression is a <> or ([pattern] <> expression),
-;; chain will return a unary lambda.
+;; chain will return an unary lambda.
 ;;
 ;; Example:
 ;;  (chain [1 2 3]
-;;         ([_ . rest] (map number->string rest))
-;;         (v (string-join v ", "))
-;;         (string-append <> " :)"))
+;;    ([_ . rest] (map number->string rest))
+;;    (v (string-join v ", "))
+;;    (string-append <> " :)"))
 ;; => "2, 3 :)"
 (defrules chain (<>)
   ((_ <> (fn arg arg* ...) ...)
-   (lambda (v)
-     (~chain-aux ((fn arg arg* ...) ...) v)))
+    (lambda (init)
+      (~chain-aux ((fn arg arg* ...) ...) init)))
 
   ((_ ((var . vars) <> exp) (fn arg arg* ...) ...)
-   (lambda (v)
-     (with (((var . vars) v))
-       (~chain-aux ((fn arg arg* ...) ...) exp))))
+    (lambda (init)
+      (with (((var . vars) init))
+        (~chain-aux ((fn arg arg* ...) ...) exp))))
 
-  ((_ exp (fn arg arg* ...) ...)
-   (~chain-aux ((fn arg arg* ...) ...) exp)))
+  ((_ init exp ...)
+    (~chain-wrap-fn init (exp ...))))
+
+;; ~chain-wrap-fn is an auxiliary macro to wrap unary procedures which
+;; have no parentheses around with parentheses: proc -> (proc) to
+;; distinguish them later in ~chain-aux.
+(defrules ~chain-wrap-fn ()
+  ((_ init () previous)
+    (~chain-aux previous init))
+
+  ((_ init ((proc arg arg* ...) . more))
+    (~chain-wrap-fn init more ((proc arg arg* ...))))
+
+  ((_ init ((proc arg arg* ...) . more) (previous ...))
+    (~chain-wrap-fn init more (previous ... (proc arg arg* ...))))
+
+  ((_ init (proc . more))
+    (~chain-wrap-fn init more ((proc))))
+
+  ((_ init (proc . more) (previous ...))
+    (~chain-wrap-fn init more (previous ... (proc)))))
 
 ;; ~chain-aux is an auxiliary macro which takes a list of expressions
 ;; and the initial chain value. It then loops over the expression list
 ;; and transforms one expression after the other.
 (defrules ~chain-aux (<>)
-  ((_ () acc)
-   acc)
+  ((_ () previous)
+    previous)
 
-  ((_ ((var ()) . more) acc)
-   (syntax-error "Body expression cannot be empty"))
+  ((_ ((var ()) . more) previous)
+    (syntax-error "Body expression cannot be empty"))
 
   ;; variable
-  ((_ ((var (body1 body2 . body*)) . more) acc)
-   (~chain-aux more
-	       (~chain-aux-variable (var acc) (body1 body2 . body*))))
+  ((_ ((var (body1 body2 . body*)) . more) previous)
+    (~chain-aux more
+      (~chain-aux-variable (var previous) (body1 body2 . body*))))
 
-  ((_ ((var (body1 body2 . body*) (body-error ...) ...) . more) acc)
-   (syntax-error "More than one body expression in chain-variable context"))
+  ((_ ((var (body1 body2 . body*) (body-error ...) ...) . more) previous)
+    (syntax-error "More than one body expression in chain-variable context"))
+
+  ;; unary procedure
+  ((_ ((fn) . more) previous)
+    (~chain-aux more (fn previous)))
 
   ;; diamond
-  ((_ ((fn . args) . more) acc)
-   (~chain-aux more
-	       (~chain-aux-diamond (fn . args) () acc))))
+  ((_ ((fn . args) . more) previous)
+    (~chain-aux more
+      (~chain-aux-diamond (fn . args) () previous))))
 
 ;; ~chain-aux-variable is an auxiliary macro that transforms
 ;; the passed expression into a with-expression.
 (defrules ~chain-aux-variable ()
   ((_ (() (fn . args)) body)
-   (syntax-error "The variable must be non-empty"))
+    (syntax-error "The variable must be non-empty"))
 
   ((_ (var previous) body)
-   (with ((var previous)) body)))
+    (with ((var previous)) body)))
 
 ;; ~chain-aux-diamond is an auxiliary macro that replaces the <> symbol
 ;; with the previous expressions. There must be only one <> diamond in a row
 ;; and it must be in the top-level expression.
 (defrules ~chain-aux-diamond (<>)
   ((_ () acc)
-   acc)
+    acc)
 
   ((_ () acc previous)
-   (syntax-error "No diamond operator in expression"))
+    (syntax-error "No diamond operator in expression"))
 
   ((_ (<> . more) (acc ...))
-   (syntax-error "More than one diamond operator in expression"))
+    (syntax-error "More than one diamond operator in expression"))
 
   ((_ (<> . more) (acc ...) previous)
-   (~chain-aux-diamond more (acc ... previous)))
+    (~chain-aux-diamond more (acc ... previous)))
 
   ((_ (v . more) (acc ...) . previous) ; previous is not set after <> was replaced
-   (~chain-aux-diamond more (acc ... v) . previous)))
+    (~chain-aux-diamond more (acc ... v) . previous)))
 
 ;; is converts a given value into a predicate testing for the presence of the
 ;; given value. Optionally a transforming procedure can prefix the value, which


### PR DESCRIPTION
Allow unary procedures in `chain` macro. Before this patch we had to write the following:

``` scheme
(chain [1 2]
  (reverse <>)
  ...
)
```

Now it is possible to write:
``` scheme
(chain [1 2]
  reverse
  ...
)
```