### PR TITLE
move assert to its own module

### DIFF
--- a/doc/.vuepress/config.js
+++ b/doc/.vuepress/config.js
@@ -29,7 +29,7 @@ module.exports = {
         {
           collapsable: false,
           title: 'Gerbil Reference',
-          children:  ['', 'core-prelude', 'core-builtin', 'core-expander', 'stdlib', 'sugar', 'errors', 'getopt', 'format', 'logger', 'sort', 'regexp', 'generic', 'ref', 'iterators', 'coroutine', 'events', 'actor', 'requests', 'httpd', 'web', 'db', 'kvstore', 'sockets', 'net', 'protobuf', 'os', 'crypto', 'text', 'xml', 'parser', 'misc', 'lazy', 'amb', 'stxparam', 'stxutil', 'foreign', 'srfi', 'test', 'debug', 'make']
+            children:  ['', 'core-prelude', 'core-builtin', 'core-expander', 'stdlib', 'sugar', 'assert', 'errors', 'getopt', 'format', 'logger', 'sort', 'regexp', 'generic', 'ref', 'iterators', 'coroutine', 'events', 'actor', 'requests', 'httpd', 'web', 'db', 'kvstore', 'sockets', 'net', 'protobuf', 'os', 'crypto', 'text', 'xml', 'parser', 'misc', 'lazy', 'amb', 'stxparam', 'stxutil', 'foreign', 'srfi', 'test', 'debug', 'make']
         }
       ]
     },

--- a/doc/reference/assert.md
+++ b/doc/reference/assert.md
@@ -1,0 +1,32 @@
+# Assertions
+
+The `:std/assert` module provides the `assert!` macro which can be used to certify certain
+conditions in a program and fail with a useful error message if the condition is not satisfied.
+
+::: tip To use the bindings from this module:
+```scheme
+(import :std/assert)
+```
+:::
+
+## assert!
+```scheme
+(assert! condition-expr [message-expr extra-expr ...])
+```
+
+Raises an error when the `condition-expr` evaluates to false.
+If the `message-expr` and `extra-expr`s are provided, their
+values will be included in the error message.
+
+## Example
+
+```scheme
+> (assert! #f)
+*** ERROR -- Assertion failed (console)@9.10: #f
+
+> (assert! (< 42 0) "that's an impossibility")
+*** ERROR -- Assertion failed that's an impossibility: (< 42 0)
+  42 => 42
+  0 => 0
+
+```

--- a/doc/reference/sugar.md
+++ b/doc/reference/sugar.md
@@ -111,15 +111,6 @@ Evaluates body in a loop while the test expression evaluates to true.
 
 Evaluates body in a loop until the test expression evaluates to true.
 
-## assert!
-```scheme
-(assert! condition-expr [message-expr extra-expr ...])
-```
-
-Raises an error when the `condition-expr` evaluates to false.
-If the `message-expr` and `extra-expr`s are provided, their
-values will be included in the error message.
-
 ## hash
 ```scheme
 (hash (key val) ...)

--- a/src/std/assert-test.ss
+++ b/src/std/assert-test.ss
@@ -1,0 +1,18 @@
+(export assert-test)
+(import :std/test
+        :std/assert
+        :std/pregexp)
+
+(def assert-test
+  (test-suite "test :std/assert"
+    (test-case "test assert! failure message"
+      (def e 'needle)
+      (def l ['stack 'of 'hay])
+      (check-exception (assert! (member e l))
+                       (lambda (e)
+                         (pregexp-match
+                          (string-append
+                           "Assertion failed \"assert-test.ss\"@\\d+\\.33: \\(member e l\\)\n"
+                           "  e => 'needle\n"
+                           "  l => \\['stack 'of 'hay\\]\n")
+                          (error-message e)))))))

--- a/src/std/assert.ss
+++ b/src/std/assert.ss
@@ -1,0 +1,54 @@
+;;; -*- Gerbil -*-
+;;; © vyzo and contributors
+;;; assert macro, originally written by vyzo and enhanced by alex knauth
+
+(import
+  (for-syntax (only-in :gerbil/expander core-bound-identifier?))
+  :std/format)
+(export assert!)
+
+(begin-syntax
+  ;; original idea from Jack Firth, Sam Phillips, and Alex Knauth for Rackunit:
+  ;; https://github.com/racket/rackunit/issues/149#issuecomment-919208710
+  ;; special-identifier? : Any -> Bool
+  (def (special-identifier? stx)
+    (and (identifier? stx)
+         (or (core-bound-identifier? stx)
+             (and (syntax-local-value stx false) #t))))
+
+  ;; split-sub-exprs : Stx -> [Stx [[Id Stx] ...]]
+  (def (split-sub-exprs stx)
+    (syntax-case stx ()
+      ((f a ...)
+       (not (special-identifier? #'f))
+       (with-syntax (((x ...) (gentemps #'(a ...))))
+         [(syntax/loc stx (f x ...)) #'((x a) ...)]))
+      (_ [stx []])))
+
+  ;; srcloc-string : Stx -> String
+  (def (srcloc-string stx)
+    (def loc (stx-source stx))
+    (cond (loc (call-with-output-string "" (cut ##display-locat loc #t <>)))
+          (else "?"))))
+
+(defsyntax assert!
+  (lambda (stx)
+    (syntax-case stx ()
+      ((_ condition)
+       (with-syntax (((c ((x e) ...)) (split-sub-exprs #'condition))
+                     (message (srcloc-string #'condition)))
+         #'(let ((x e) ...)
+             (assert!/where-helper c 'message 'condition [(cons 'e x) ...]))))
+      ((_ condition message)
+       (with-syntax (((c ((x e) ...)) (split-sub-exprs #'condition)))
+         #'(let ((x e) ...)
+             (assert!/where-helper c message 'condition [(cons 'e x) ...]))))
+      ((_ condition message expr ...)
+       #'(assert!/where-helper condition message 'condition [(cons 'expr expr) ...])))))
+
+(def (assert!/where-helper condition message condition-expr extras)
+  (unless condition
+   (let ()
+    (def hd (format "Assertion failed ~a: ~s" message condition-expr))
+    (def str (apply string-append hd (map (match <> ((cons k v) (format "\n  ~s => ~r" k v))) extras)))
+    (error str))))

--- a/src/std/assert.ss
+++ b/src/std/assert.ss
@@ -4,8 +4,8 @@
 
 (import
   :std/sugar
-  (for-syntax (only-in :gerbil/expander core-bound-identifier?))
-  :std/format)
+  :std/format
+  (for-syntax (only-in :gerbil/expander core-bound-identifier?)))
 (export assert!)
 
 (begin-syntax

--- a/src/std/assert.ss
+++ b/src/std/assert.ss
@@ -3,6 +3,7 @@
 ;;; assert macro, originally written by vyzo and enhanced by alex knauth
 
 (import
+  :std/sugar
   (for-syntax (only-in :gerbil/expander core-bound-identifier?))
   :std/format)
 (export assert!)
@@ -46,9 +47,11 @@
       ((_ condition message expr ...)
        #'(assert!/where-helper condition message 'condition [(cons 'expr expr) ...])))))
 
-(def (assert!/where-helper condition message condition-expr extras)
+(defrule (assert!/where-helper condition message condition-expr extras)
   (unless condition
-   (let ()
-    (def hd (format "Assertion failed ~a: ~s" message condition-expr))
-    (def str (apply string-append hd (map (match <> ((cons k v) (format "\n  ~s => ~r" k v))) extras)))
-    (error str))))
+    (assert!/fail message condition-expr extras)))
+
+(def (assert!/fail message condition-expr extras)
+  (def hd (format "Assertion failed ~a: ~s" message condition-expr))
+  (def str (apply string-append hd (map (match <> ((cons k v) (format "\n  ~s => ~r" k v))) extras)))
+  (error str))

--- a/src/std/build-deps
+++ b/src/std/build-deps
@@ -195,7 +195,7 @@
    gerbil/gambit/misc
    gerbil/gambit/ports
    std/misc/repr))
- (std/assert "assert" (gerbil/core gerbil/expander std/format))
+ (std/assert "assert" (gerbil/core gerbil/expander std/format std/sugar))
  (std/getopt "getopt" (gerbil/core std/error std/format))
  (std/logger
   "logger"

--- a/src/std/build-deps
+++ b/src/std/build-deps
@@ -169,14 +169,6 @@
  (std/misc/list-builder "misc/list-builder" (gerbil/core))
  (std/misc/alist "misc/alist" (gerbil/core std/sugar))
  (std/misc/plist "misc/plist" (gerbil/core std/sugar))
- (std/misc/list
-  "misc/list"
-  (gerbil/core
-   std/misc/alist
-   std/misc/list-builder
-   std/misc/plist
-   std/srfi/1
-   std/sugar))
  (std/misc/rtd "misc/rtd" (gerbil/core))
  (std/misc/shuffle "misc/shuffle" (gerbil/core gerbil/gambit/random))
  (std/event
@@ -195,12 +187,7 @@
            std/sugar))
  (std/misc/repr
   "misc/repr"
-  (gerbil/core
-   gerbil/gambit/hash
-   gerbil/gambit/ports
-   std/misc/list
-   std/misc/rtd
-   std/sort))
+  (gerbil/core gerbil/gambit/hash gerbil/gambit/ports std/misc/rtd std/sort))
  (std/format
   "format"
   (gerbil/core
@@ -208,6 +195,7 @@
    gerbil/gambit/misc
    gerbil/gambit/ports
    std/misc/repr))
+ (std/assert "assert" (gerbil/core gerbil/expander std/format))
  (std/getopt "getopt" (gerbil/core std/error std/format))
  (std/logger
   "logger"
@@ -218,12 +206,8 @@
    std/format
    std/srfi/19
    std/sugar))
- (std/test
-  "test"
-  (gerbil/core gerbil/gambit std/error std/format std/misc/list std/sugar))
  (std/stxutil "stxutil" (gerbil/core std/format))
  (std/foreign "foreign" (gerbil/core std/stxutil))
- (std/foreign-test "foreign-test" (gerbil/core std/foreign std/test))
  (std/generic/macros
   "generic/macros"
   (gerbil/core std/generic/dispatch std/stxutil))
@@ -691,6 +675,19 @@
    std/text/base64
    std/text/hex
    std/text/utf8))
+ (std/misc/list
+  "misc/list"
+  (gerbil/core
+   std/assert
+   std/misc/alist
+   std/misc/list-builder
+   std/misc/plist
+   std/srfi/1
+   std/sugar))
+ (std/test
+  "test"
+  (gerbil/core gerbil/gambit std/error std/format std/misc/list std/sugar))
+ (std/foreign-test "foreign-test" (gerbil/core std/foreign std/test))
  (std/misc/uuid
   "misc/uuid"
   (gerbil/core
@@ -725,6 +722,7 @@
   (gerbil/core
    gerbil/gambit/exceptions
    gerbil/gambit/threads
+   std/assert
    std/error
    std/misc/pqueue
    std/sugar))
@@ -751,6 +749,7 @@
  (std/text/csv
   "text/csv"
   (gerbil/core
+   std/assert
    std/error
    std/misc/list
    std/misc/string
@@ -845,6 +844,7 @@
    gerbil/gambit/os
    gerbil/gambit/ports
    gerbil/gambit/threads
+   std/assert
    std/misc/concurrent-plan
    std/misc/hash
    std/misc/list
@@ -1185,6 +1185,7 @@
    std/db/postgresql-driver
    std/iter
    std/misc/channel
+   std/misc/list
    std/srfi/19))
  (std/db/_sqlite
   (ssi:

--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -11,6 +11,7 @@
     "pregexp"
     "sort"
     "sugar"
+    "assert"
     "make"
     "build-script"
     "error"

--- a/src/std/make.ss
+++ b/src/std/make.ss
@@ -21,7 +21,8 @@
         ./misc/symbol
         ./misc/concurrent-plan
         ./sort
-        ./sugar)
+        ./sugar
+        ./assert)
 
 (extern namespace: #f with-cons-load-path load-path)
 

--- a/src/std/misc/concurrent-plan.ss
+++ b/src/std/misc/concurrent-plan.ss
@@ -3,6 +3,7 @@
 (import :gerbil/gambit/threads
         :gerbil/gambit/exceptions
         ../sugar
+        ../assert
         ../error
         ./pqueue)
 

--- a/src/std/misc/list.ss
+++ b/src/std/misc/list.ss
@@ -35,7 +35,8 @@
                  drop drop-right drop-right! take take-right take! reverse!
                  take-while take-while! drop-while
                  delete-duplicates delete-duplicates!)
-        ../sugar)
+        ../sugar
+        ../assert)
 
 (defalias unique delete-duplicates)
 (defalias unique! delete-duplicates!)

--- a/src/std/run-tests.ss
+++ b/src/std/run-tests.ss
@@ -68,6 +68,7 @@
    "protobuf/protobuf-test"
    "srfi/1-test"
    "sugar-test"
+   "assert-test"
    "text/csv-test"
    "text/hex-test"
    "text/json-test"

--- a/src/std/sugar-test.ss
+++ b/src/std/sugar-test.ss
@@ -59,16 +59,4 @@
     (check ((is 'a test: eq?) 'a)       => #t)
     (check ((is 2.0) 2.0)               => #t)
     (check ((is "a") "a")               => #t))
-
-   (test-case "test assert! failure message"
-    (def e 'needle)
-    (def l ['stack 'of 'hay])
-    (check-exception (assert! (member e l))
-                     (lambda (e)
-                       (pregexp-match
-                        (string-append
-                         "Assertion failed \"sugar-test.ss\"@\\d+\\.31: \\(member e l\\)\n"
-                         "  e => 'needle\n"
-                         "  l => \\['stack 'of 'hay\\]\n")
-                        (error-message e)))))
    ))

--- a/src/std/sugar.ss
+++ b/src/std/sugar.ss
@@ -14,7 +14,6 @@
   with-methods
   with-class-methods
   with-class-method
-  assert!
   while
   until
   hash
@@ -24,10 +23,6 @@
   awhen
   chain
   is)
-
-(import
-  (for-syntax (only-in :gerbil/expander core-bound-identifier?))
-  :std/format)
 
 (defrules defrule ()
   ((_ (name args ...) body ...)
@@ -148,52 +143,6 @@
   ((recur klass method)
    (identifier? #'method)
    (recur klass (method method))))
-
-(begin-syntax
-  ;; original idea from Jack Firth, Sam Phillips, and Alex Knauth for Rackunit:
-  ;; https://github.com/racket/rackunit/issues/149#issuecomment-919208710
-  ;; special-identifier? : Any -> Bool
-  (def (special-identifier? stx)
-    (and (identifier? stx)
-         (or (core-bound-identifier? stx)
-             (and (syntax-local-value stx false) #t))))
-
-  ;; split-sub-exprs : Stx -> [Stx [[Id Stx] ...]]
-  (def (split-sub-exprs stx)
-    (syntax-case stx ()
-      ((f a ...)
-       (not (special-identifier? #'f))
-       (with-syntax (((x ...) (gentemps #'(a ...))))
-         [(syntax/loc stx (f x ...)) #'((x a) ...)]))
-      (_ [stx []])))
-
-  ;; srcloc-string : Stx -> String
-  (def (srcloc-string stx)
-    (def loc (stx-source stx))
-    (cond (loc (call-with-output-string "" (cut ##display-locat loc #t <>)))
-          (else "?"))))
-
-(defsyntax assert!
-  (lambda (stx)
-    (syntax-case stx ()
-      ((_ condition)
-       (with-syntax (((c ((x e) ...)) (split-sub-exprs #'condition))
-                     (message (srcloc-string #'condition)))
-         #'(let ((x e) ...)
-             (assert!/where-helper c 'message 'condition [(cons 'e x) ...]))))
-      ((_ condition message)
-       (with-syntax (((c ((x e) ...)) (split-sub-exprs #'condition)))
-         #'(let ((x e) ...)
-             (assert!/where-helper c message 'condition [(cons 'e x) ...]))))
-      ((_ condition message expr ...)
-       #'(assert!/where-helper condition message 'condition [(cons 'expr expr) ...])))))
-
-(def (assert!/where-helper condition message condition-expr extras)
-  (unless condition
-   (let ()
-    (def hd (format "Assertion failed ~a: ~s" message condition-expr))
-    (def str (apply string-append hd (map (match <> ((cons k v) (format "\n  ~s => ~r" k v))) extras)))
-    (error str))))
 
 (defrule (while test body ...)
   (let lp ()

--- a/src/std/text/csv.ss
+++ b/src/std/text/csv.ss
@@ -46,7 +46,8 @@
 
 (import
   (for-syntax :std/stxutil)
-  :std/error :std/misc/list :std/misc/string :std/srfi/1 :std/srfi/13 :std/stxparam :std/sugar)
+  :std/error :std/misc/list :std/misc/string :std/srfi/1 :std/srfi/13 :std/stxparam :std/sugar
+  :std/assert)
 
 ;;; constants
 (def +line-endings+

--- a/src/std/text/hex-test.ss
+++ b/src/std/text/hex-test.ss
@@ -2,7 +2,7 @@
 
 (import
   :gerbil/gambit/bytes :gerbil/gambit/exceptions
-  :std/error :std/srfi/1 :std/srfi/13 :std/sugar :std/text/hex :std/test)
+  :std/assert :std/error :std/srfi/1 :std/srfi/13 :std/sugar :std/text/hex :std/test)
 
 (def hex-test
   (test-suite "test :std/text/hex"


### PR DESCRIPTION
so that `:std/sugar` doesn't have any runtime dependencies.