### PR TITLE
Fix assert! on keyword functions

### DIFF
--- a/src/std/assert-test.ss
+++ b/src/std/assert-test.ss
@@ -15,4 +15,12 @@
                            "Assertion failed \"assert-test.ss\"@\\d+\\.33: \\(member e l\\)\n"
                            "  e => 'needle\n"
                            "  l => \\['stack 'of 'hay\\]\n")
+                          (error-message e)))))
+
+    (test-case "test assert! on keyword functions"
+      (assert! (true 0 a: 1))
+      (check-exception (assert! (false 0 a: 1))
+                       (lambda (e)
+                         (pregexp-match
+                          "Assertion failed \"assert-test.ss\"@\\d+\\.33: \\(false 0 a: 1\\)\n"
                           (error-message e)))))))

--- a/src/std/assert.ss
+++ b/src/std/assert.ss
@@ -21,7 +21,7 @@
   (def (split-sub-exprs stx)
     (syntax-case stx ()
       ((f a ...)
-       (not (special-identifier? #'f))
+       (and (not (special-identifier? #'f)) (not (stx-ormap stx-keyword? #'(a ...))))
        (with-syntax (((x ...) (gentemps #'(a ...))))
          [(syntax/loc stx (f x ...)) #'((x a) ...)]))
       (_ [stx []])))


### PR DESCRIPTION
The `assert!` implementation just merged in #643 didn't work on calls to keyword functions. This PR fixes it so that it never tries to treat keywords as extra-exprs.