### PR TITLE
Fix base58-decode leading zeros

### DIFF
--- a/src/std/text/base58-test.ss
+++ b/src/std/text/base58-test.ss
@@ -1,0 +1,22 @@
+(export base58-test)
+
+(import
+  :gerbil/gambit/bytes
+  :std/text/base58 :std/test)
+
+(def base58-test
+  (test-suite "test :std/text/base58"
+    (test-case "test base58-decode, base58-encode"
+      (for-each (match <> ([str bytes]
+                           (check-equal? (base58-decode str) bytes)
+                           (check-equal? (base58-encode bytes) str)))
+                [["123456789ABCDEFabcdef" #u8(0 163 89 140 109 105 107 241 109 67 181 205 111 52 208)]
+                 ["ToastedCheeseSandwich" #u8(3 190 11 230 157 37 194 9 165 223 221 144 36 40 180 106)]
+                 ["1Mistake99Prob1ems" #u8(0 4 74 24 171 130 219 235 172 113 26 234 188 126)]
+                 ["16Uiu2HAmUXHHL7qEMNmwgynPF3GLGjo8n72TDnMPAgAFYPmnfpv8" #u8(0 37 8 2 18 33 3 235 193 125 55 15 184 96 250 206 87 185 196 180 142 51 120 96 78 195 51 232 148 176 47 140 17 62 124 35 37 197 229)]
+                 ["" #u8()]
+                 ["1" #u8(0)]
+                 ["11" #u8(0 0)]
+                 ["3VNr6P" (@bytes "abcd")]
+                 ["zZ" (@bytes "\r\n")]]))
+    ))

--- a/src/std/text/base58.ss
+++ b/src/std/text/base58.ss
@@ -65,15 +65,12 @@
         (if (and (fx< i (string-length str))
                  (eq? zero (string-ref str i)))
           (lp (fx1+ i))
-          (make-u8vector i)))))
+          (make-u8vector i 0)))))
   (let lp ((i 0) (bn 0))
     (if (fx< i (string-length str))
-      (let* ((char (string-ref str i))
-             (int  (char->integer char))
-             (_    (unless (fx< int 128)
-                     (raise-io-error 'base58-decode "Invalid character" str char))))
+      (let* ((char (string-ref str i)))
         (cond
-         ((alphabet-decode ab int)
+         ((alphabet-decode ab char)
           => (lambda (c)
                (lp (fx1+ i) (+ (* bn 58) c))))
          (else


### PR DESCRIPTION
Calling `make-u8vector` without the fill argument leaves the contents of the u8vector unspecified, so this PR fills the leading zeros u8vector with `0`.

This PR also changes `(alphabet-decode ab int)` to `(alphabet-decode ab char)`, and adds tests for `base58-decode` and `base58-encode`.