### PR TITLE
fix for LibreSSL 3.5

### DIFF
--- a/src/std/crypto/libcrypto-rfc5114.c
+++ b/src/std/crypto/libcrypto-rfc5114.c
@@ -107,11 +107,22 @@ static BIGNUM* get_bn(BIGNUM **bn, const char *hex) {
 #define make_dh(param)                          \
   DH *DH_get_##param(void) {                    \
     DH *dh = DH_new ();                         \
+    BIGNUM *p, *q, *g;                          \
     if (!dh) return NULL;                       \
-    dh->p = get_bn(&bn_dh##param##_p, dh##param##_p); \
-    dh->g = get_bn(&bn_dh##param##_g, dh##param##_g); \
-    dh->q = get_bn(&bn_dh##param##_q, dh##param##_q); \
-    if (!dh->p || !dh->q || !dh->g) {                 \
+    p = get_bn(&bn_dh##param##_p, dh##param##_p); \
+    g = get_bn(&bn_dh##param##_g, dh##param##_g); \
+    q = get_bn(&bn_dh##param##_q, dh##param##_q); \
+    if (!p || !q || !g) {                             \
+      BN_free(p);                                     \
+      BN_free(q);                                     \
+      BN_free(g);                                     \
+      DH_free(dh);                                    \
+      return NULL;                                    \
+    }                                                 \
+    if (!DH_set0_pqg(dh, p, q, g)) {                  \
+      BN_free(p);                                     \
+      BN_free(q);                                     \
+      BN_free(g);                                     \
       DH_free(dh);                                    \
       return NULL;                                    \
     }                                                 \

--- a/src/std/crypto/libcrypto.ss
+++ b/src/std/crypto/libcrypto.ss
@@ -372,7 +372,7 @@ END-C
 (c-declare #<<END-C
 static HMAC_CTX *ffi_create_HMAC_CTX ()
 {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L ||  defined (LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   HMAC_CTX *ctx = (HMAC_CTX*)malloc (sizeof (HMAC_CTX));
   if (ctx) {
     HMAC_CTX_init (ctx);
@@ -385,7 +385,7 @@ static HMAC_CTX *ffi_create_HMAC_CTX ()
 
 static ___SCMOBJ ffi_release_HMAC_CTX (void *ptr)
 {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L ||  defined (LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   HMAC_CTX_cleanup ((HMAC_CTX*) ptr);
   free (ptr);
 #else
@@ -465,7 +465,7 @@ static ___SCMOBJ ffi_DH_free (void *dh)
 
 static BIGNUM *ffi_DH_pub_key (DH *dh)
 {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L ||  defined (LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
  return dh->pub_key;
 #else
  BIGNUM const *pub;


### PR DESCRIPTION
LibreSSL 3.5 has made HMAC_CTX and DH opaque so code using it should be switched to use accessor functions.

Lifted from OpenBSD port patches.