### PR TITLE
fix: do not hard-code gcc

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -53,7 +53,7 @@ target_setup () {
 
 compile_gxi () {
   feedback_low "Compiling gxi shim"
-  (cd gerbil && gcc -O2 -o gxi gxi.c)
+  (cd gerbil && ${CC:-cc} -O2 -o gxi gxi.c)
 }
 
 compile_runtime () {


### PR DESCRIPTION
Use generic C compiler name instead of using hard-coded gcc. OpenBSD uses clang as default c compiler on most archs so this allows it to build gerbil.
The ports in OpenBSD provide gcc as well but in that case the binary is named egcc so it will not match the name either.
Use the standard CC variable to look up c compiler to use and default to cc.