### PR TITLE
add keyword-rest utility function

### DIFF
--- a/src/gerbil/prelude/core.ss
+++ b/src/gerbil/prelude/core.ss
@@ -262,7 +262,7 @@ package: gerbil
     ;; Module loading
     load-module
     ;; keyword argument dispatch
-    keyword-dispatch
+    keyword-dispatch keyword-rest
     ;; gerbil specifics
     gerbil-version-string gerbil-system-version-string system-version
     ;; system type information

--- a/src/gerbil/runtime/gx-gambc0.scm
+++ b/src/gerbil/runtime/gx-gambc0.scm
@@ -1753,6 +1753,10 @@
              (%%apply K (cons keys args)))
            (K keys)))))))
 
+(define (keyword-rest kwt . drop)
+  (for-each (lambda (kw) (hash-remove! kwt kw)) drop)
+  (hash-fold (lambda (k v r) (cons* k v r)) '() kwt))
+
 (eval-if-bound string-concatenate (void) (define string-concatenate append-strings))
 (eval-if-bound vector-concatenate (void) (define vector-concatenate append-vectors))
 (eval-if-bound u8vector-concatenate (void) (define u8vector-concatenate append-u8vectors))


### PR DESCRIPTION
This is a utility function, in the runtime, to easily chain keyword argument handlers.
It converts a keyword table to a rest argument list, removing the specified (presumably already processed) keywords.

Example:
```
(def (foo a: a b: b c: c)
   ....)

(def (bar #!key kws d: d)
   (apply foo (kreyword-rest kws d:)))
```