### PR TITLE
Revert "fix arity declarations for random procedures"

### DIFF
--- a/src/gerbil/prelude/core.ssxi.ss
+++ b/src/gerbil/prelude/core.ssxi.ss
@@ -530,6 +530,7 @@ package: gerbil
  repl-input-port repl-output-port
  console-port
  default-random-source
+ random-real
  make-random-source
  system-version system-version-string
  configure-command-string system-stamp
@@ -704,6 +705,8 @@ package: gerbil
 
  open-event-queue
 
+ random-integer
+ random-u8vector random-f64vector
  random-source?
  random-source-state-ref
  random-source-randomize!
@@ -1185,10 +1188,3 @@ package: gerbil
  (f64vector-copy! 3 4 5)
  (subf64vector-move! 5)
  (f64vector-shrink! 2))
-
-;; random variadics
-(declare-primitive*
- (random-real 0 1)
- (random-integer 1 2)
- (random-u8vector 1 2)
- (random-f64vector 1 2))


### PR DESCRIPTION
Reverts vyzo/gerbil#682

It turns out that the random procs don't accept a source, but instead you have to make them from the source with the `random-source-make-*` procedures; facepalm.