### PR TITLE
Fix docker instructions to match the current published image name

### DIFF
--- a/doc/guide/README.md
+++ b/doc/guide/README.md
@@ -101,17 +101,17 @@ The latest Gerbil images are available via [Docker Hub](https://hub.docker.com/u
 
 Ubuntu based version:
 ```bash
-docker pull gerbil/scheme
+docker pull gerbil/ubuntu
 ```
 
 To get to the REPL:
 ```bash
-docker run -it gerbil/scheme
+docker run -it gerbil/ubuntu
 ```
 
 To get a bash shell where you can compile programs:
 ```bash
-docker run -it gerbil/scheme bash
+docker run -it gerbil/ubuntu bash
 ```
 
 Or you can build your own container using the [Dockerfile](https://github.com/vyzo/gerbil/blob/master/Dockerfile)


### PR DESCRIPTION
Gerbil getting started docs say to pull a docker image with tag `gerbil/scheme` but there is no such image on Docker Hub at present. There is an image `docker/ubuntu` which works as expected. This PR fixes the doc to match the existing image tag.