### PR TITLE
Tweaks to the std library

### DIFF
--- a/src/std/crypto/etc.ss
+++ b/src/std/crypto/etc.ss
@@ -126,14 +126,12 @@
           buf)
         #f))))
 
-(def *urandom* (open-input-file "/dev/urandom"))
-
 (def (random-bytes len)
   (let (bytes (make-u8vector len))
     (random-bytes! bytes 0 len)
     bytes))
 
 (def (random-bytes! bytes (start 0) (end (u8vector-length bytes)))
-  (let (count (read-subu8vector bytes start end *urandom*))
-    (unless (eq? count (##fx- end start))
-      (error "Could not read enough random bytes" count start end))))
+  (let (result (RAND_bytes bytes start end))
+    (unless (= result 1)
+      (raise-libcrypto-error "Error in RAND_bytes"))))

--- a/src/std/crypto/libcrypto.ss
+++ b/src/std/crypto/libcrypto.ss
@@ -58,7 +58,8 @@ package: std/crypto
      EVP_PKEY_keygen_init EVP_PKEY_keygen
      EVP_PKEY_new_raw_private_key EVP_PKEY_new_raw_public_key
      EVP_PKEY_get_raw_private_key EVP_PKEY_get_raw_public_key
-     EVP_DigestSign EVP_DigestVerify EVP_MD_CTX_set_pkey_ctx)
+     EVP_DigestSign EVP_DigestVerify EVP_MD_CTX_set_pkey_ctx
+     RAND_bytes)
 
 (declare (not safe))
 
@@ -68,6 +69,7 @@ package: std/crypto
 #include <openssl/dh.h>
 #include <openssl/bn.h>
 #include <openssl/hmac.h>
+#include <openssl/rand.h>
 END-C
 )
 
@@ -586,6 +588,12 @@ static int ffi_EVP_DigestVerify(EVP_MD_CTX *ctx, ___SCMOBJ sig, ___SCMOBJ tbs)
 #if OPENSSL_VERSION_NUMBER < 0x10101000L
 void EVP_MD_CTX_set_pkey_ctx(EVP_MD_CTX *ctx, EVP_PKEY_CTX *pctx) { return; }
 #endif
+
+static int ffi_RAND_bytes (___SCMOBJ bytes, int start, int end)
+{
+  return RAND_bytes (U8_DATA (bytes) + start, end - start);
+}
+
 END-C
 )
 (c-define-type EVP_PKEY "EVP_PKEY")
@@ -613,4 +621,6 @@ END-C
 (define-c-lambda EVP_DigestVerify (EVP_MD_CTX* scheme-object scheme-object) int "ffi_EVP_DigestVerify")
 
 (define-c-lambda EVP_MD_CTX_set_pkey_ctx (EVP_MD_CTX* EVP_PKEY_CTX*) void)
+
+(define-c-lambda RAND_bytes (scheme-object int int) int "ffi_RAND_bytes")
 );ffi

--- a/src/std/db/_sqlite.scm
+++ b/src/std/db/_sqlite.scm
@@ -70,9 +70,13 @@ END-C
 (define-const SQLITE_NULL)
 (define-const SQLITE_TEXT)
 
+(define-const SQLITE_PREPARE_PERSISTENT)
+(define-const SQLITE_PREPARE_NORMALIZE)
+(define-const SQLITE_PREPARE_NO_VTAB)
+
 (c-declare #<<END-C
 static int ffi_sqlite3_open (sqlite3**, const char *path, int flags);
-static int ffi_sqlite3_prepare (sqlite3_stmt**, sqlite3* db, const char *sql);
+static int ffi_sqlite3_prepare (sqlite3_stmt**, sqlite3* db, const char *sql, int prepFlags);
 static int ffi_sqlite3_bind_blob (sqlite3_stmt* stmt, int col, ___SCMOBJ data);
 static int ffi_sqlite3_bind_text (sqlite3_stmt* stmt, int col, const char *str);
 static void ffi_sqlite3_column_blob (sqlite3_stmt* stmt, int col, ___SCMOBJ bytes);
@@ -105,7 +109,7 @@ END-C
   "ffi_sqlite3_open")
 (define-c-lambda sqlite3_close (sqlite3*) int
   "sqlite3_close_v2")
-(define-c-lambda sqlite3_prepare (sqlite3_stmt** sqlite3* UTF-8-string) int
+(define-c-lambda sqlite3_prepare (sqlite3_stmt** sqlite3* UTF-8-string int) int
   "ffi_sqlite3_prepare")
 (define-c-lambda sqlite3_stmt_readonly (sqlite3_stmt*) bool
   "sqlite3_stmt_readonly")
@@ -168,11 +172,12 @@ static int ffi_sqlite3_open (sqlite3** db, const char *path, int flags)
  return r;
 }
 
-static int ffi_sqlite3_prepare (sqlite3_stmt** stmt, sqlite3* db, const char *sql)
+static int ffi_sqlite3_prepare (sqlite3_stmt** stmt, sqlite3* db, const char *sql, int prepFlags)
 {
- int r = sqlite3_prepare_v2 (db, sql, strlen (sql), stmt, NULL);
+ int r = sqlite3_prepare_v3 (db, sql, strlen (sql), prepFlags, stmt, NULL);
  if (r != SQLITE_OK) {
   sqlite3_finalize (*stmt);
+  *stmt = NULL;
  }
  return r;
 }

--- a/src/std/db/_sqlite.ssi
+++ b/src/std/db/_sqlite.ssi
@@ -22,6 +22,9 @@ package: std/db
   SQLITE_BLOB
   SQLITE_NULL
   SQLITE_TEXT
+  SQLITE_PREPARE_PERSISTENT
+  SQLITE_PREPARE_NORMALIZE
+  SQLITE_PREPARE_NO_VTAB
   make_sqlite3_ptr_ptr
   sqlite3_ptr
   make_sqlite3_stmt_ptr_ptr

--- a/src/std/db/sqlite.ss
+++ b/src/std/db/sqlite.ss
@@ -34,7 +34,7 @@
 (defmethod {prepare sqlite-connection}
   (lambda (self sql)
     (let* ((ptr (make_sqlite3_stmt_ptr_ptr))
-           (r (sqlite3_prepare ptr (connection-e self) sql)))
+           (r (sqlite3_prepare ptr (connection-e self) sql 0)))
       (if (##fx= r SQLITE_OK)
         (make-sqlite-statement (sqlite3_stmt_ptr ptr))
         (raise-sqlite-error 'sqlite-prepare r)))))

--- a/src/std/getopt.ss
+++ b/src/std/getopt.ss
@@ -275,7 +275,7 @@
         (fprintf port "~nCommands:~n")
         (for-each (match <>
                     ((!command key help)
-                     (fprintf port " ~a:~a ~a~n"
+                     (fprintf port " ~a ~a ~a~n"
                               key
                               (tabs key)
                               (or help "?"))))
@@ -327,19 +327,19 @@
 (def (display-arg-help args port)
   (for-each (match <>
               ((!reqarg key help)
-               (fprintf port " ~a:~a ~a~n"
+               (fprintf port " ~a ~a ~a~n"
                         key (tabs key) (or help "?")))
               ((!optarg key help _ default)
-               (fprintf port " ~a:~a ~a [default: ~a]~n"
+               (fprintf port " ~a ~a ~a [default: ~a]~n"
                         key (tabs key) (or help "?")
                         default))
               ((!rest key help)
-               (fprintf port " ~a:~a ~a~n"
+               (fprintf port " ~a ~a ~a~n"
                         key (tabs key) (or help "?"))))
             args))
 
 (def (tabs . strs)
-  (def tablen 31) ; take : into account
+  (def tablen 31)
   (def (string-e str)
     (if (symbol? str)
       (symbol->string str)


### PR DESCRIPTION
- Use sqlite3_prepare_v3 instead of _v2
- Use libcrypto instead of urandom for random-bytes, which is cheaper and more portable