### PR TITLE
requests: add http-any

### DIFF
--- a/doc/reference/requests.md
+++ b/doc/reference/requests.md
@@ -134,6 +134,20 @@ Like `http-get` procedure but instead executes HTTP DELETE method on `url`.
 
 Like `http-get` procedure but instead executes HTTP OPTIONS method on the `url`.
 
+### http-any
+``` scheme
+(http-any method url [headers: #f] [cookies: #f] [params: #f] [data: #f] [auth: #f]) -> request | error
+
+  method  := a symbol to define which HTTP method to use, like 'GET or 'PATCH
+  url     := a string to tell which URL the HTTP client should connect to
+  headers := alist of extra HTTP headers to set in request
+  cookies := alist of cookie name/value pairs to set in request
+  params  := alist of query param name/value pairs set in request
+  data    := request data given as octet vector or string
+  auth    := a list with a keyword head, like [basic: user password]
+```
+
+Like the other http procedures but allows you to specify your own HTTP method.
 
 ## Request Objects
 

--- a/src/std/net/request.ss
+++ b/src/std/net/request.ss
@@ -15,7 +15,7 @@
         :std/text/utf8
         :std/text/zlib)
 (export
-  http-get http-head http-post http-put http-delete http-options
+  http-get http-head http-post http-put http-delete http-options http-any
   request? request-url request-status request-status-text
   request-headers
   request-encoding request-encoding-set!
@@ -181,6 +181,18 @@
   (let ((url (url-target-e url params))
         (headers (make-http/1.1-headers headers cookies auth)))
     (http-request 'OPTIONS url headers data [] redirect)))
+
+(def (http-any     method
+                   url
+                   redirect: (redirect #t)
+                   headers:  (headers #f)
+                   cookies:  (cookies #f)
+                   params:   (params #f)
+                   data:     (data #f)
+                   auth:     (auth #f))
+  (let ((url (url-target-e url params))
+        (headers (make-http/1.1-headers headers cookies auth)))
+    (http-request method url headers data [] redirect)))
 
 (def url-rx
   (pregexp "(?:(https?)://)?([^/:]+)(:[0-9]+)?(/.*)?"))


### PR DESCRIPTION
I wanted to make a PATCH request and realised I couldn't.

A potential improvement is to expose the list of acceptable methods from the module.