### PR TITLE
misc: tty arities and symbolic exports

### DIFF
--- a/src/gerbil/prelude/core.ssxi.ss
+++ b/src/gerbil/prelude/core.ssxi.ss
@@ -790,8 +790,6 @@ package: gerbil
  create-symbolic-link
 
  tty-history-set! tty-history-max-length-set!
- tty-text-attributes-set! tty-mode-reset tty-mode-set!
- tty-type-set!
 
  input-port-timeout-set!
  output-port-timeout-set!
@@ -838,7 +836,9 @@ package: gerbil
  bitwise-merge
  extract-bit-field test-bit-field? clear-bit-field
  fxif
- random-source-pseudo-randomize!)
+ random-source-pseudo-randomize!
+ tty-text-attributes-set!
+ tty-type-set!)
 
 (declare-primitive/4
  replace-bit-field copy-bit-field)
@@ -912,7 +912,8 @@ package: gerbil
  (make-condition-variable 0 1)
  (make-thread-group 0 1 2)
  (thread-interrupt! 1 2)
- (thread-init! 2 3 4))
+ (thread-init! 2 3 4)
+ (tty-mode-set! 5 6))
 
 ;; exceptions
 (declare-primitive/1

--- a/src/gerbil/prelude/gambit/os.ss
+++ b/src/gerbil/prelude/gambit/os.ss
@@ -97,6 +97,6 @@ package: gerbil/gambit
   ;; tty stuff
   tty?
   tty-history tty-history-set! tty-history-max-length-set!
-  tty-text-attributes-set! tty-mode-reset tty-mode-set!
+  tty-text-attributes-set! tty-mode-set!
   tty-type-set!
   )

--- a/src/std/misc/symbol.ss
+++ b/src/std/misc/symbol.ss
@@ -2,14 +2,7 @@
 ;;; © vyzo
 ;;; symbolic utilities
 (import :gerbil/gambit/threads)
-(export symbol<?
-        symbol<=?
-        symbol>?
-        symbol>=?
-        compare-symbol<?
-        compare-symbol<=?
-        compare-symbol>?
-        compare-symbol>=?)
+(export #t)
 
 ;; caching symbol as string comparison
 (def (compare-symbolic cmp-e mx?)


### PR DESCRIPTION
Closes #707 

a potpuri:
- tty-mode-reset does not have a public primitive; there is only `#tty-mode-reset`
- fix arities for tty functions, they were mostly broken
- fix `std/misc/symbol` exports while at it.