### PR TITLE
Some utilities for working with temporary files

### DIFF
--- a/doc/reference/os.md
+++ b/doc/reference/os.md
@@ -481,3 +481,30 @@ Please document me!
 :::
 
 Please document me!
+
+## Temporary Files
+::: tip To use bindings from this module
+```scheme
+(import :std/os/temporaries)
+```
+:::
+
+### make-temporary-file-name
+```scheme
+(make-temporary-file-name name) -> string
+
+  name := string; prefix of temporary filename in /tmp
+```
+
+Creates a new temporary file name in /tmp and with name prefix `name`.
+It makes  `mktemp` sane by appending the current timestamp in nanosecods.
+
+### call-with-temporary-file-name
+```scheme
+(call-with-temporary-file-name name fun) -> any
+  name := string; prefix of temporary filename in /tmp
+  fun := lambda (string) -> any
+```
+
+Creates a temporary filename and invokes `fun` with it, deleting the
+temporary filename on unwind if it has been created.

--- a/doc/reference/os.md
+++ b/doc/reference/os.md
@@ -507,4 +507,4 @@ It makes  `mktemp` sane by appending the current timestamp in nanosecods.
 ```
 
 Creates a temporary filename and invokes `fun` with it, deleting the
-temporary filename on unwind if it has been created.
+temporary file on unwind if it has been created.

--- a/src/std/build-deps
+++ b/src/std/build-deps
@@ -590,6 +590,9 @@
    std/os/signalfd
    std/sugar))
  (std/os/pid "os/pid" (gerbil/core std/foreign))
+ (std/os/temporaries
+  "os/temporaries"
+  (gerbil/core gerbil/gambit/os std/foreign std/sugar))
  (std/net/bio/file
   "net/bio/file"
   (gerbil/core

--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -187,6 +187,7 @@
         (else '()))
     "os/signal-handler"
     "os/pid"
+    "os/temporaries"
     ;; :std/net/bio
     "net/bio/input"
     "net/bio/output"

--- a/src/std/os/temporaries.ss
+++ b/src/std/os/temporaries.ss
@@ -5,7 +5,8 @@
 (import :gerbil/gambit/os
         :std/foreign
         :std/sugar)
-(export #t)
+(export make-temporary-file-name
+        call-with-temporary-file-name)
 
 (def (call-with-temporary-file-name name fun)
   (def tmp (make-temporary-file-name name))

--- a/src/std/os/temporaries.ss
+++ b/src/std/os/temporaries.ss
@@ -1,0 +1,26 @@
+;;; -*- Gerbil -*-
+;;; © vyzo
+;;; [incomplete] OS temporary file interface
+
+(import :gerbil/gambit/os
+        :std/foreign
+        :std/sugar)
+(export #t)
+
+(def (call-with-temporary-file-name name fun)
+  (def tmp (make-temporary-file-name name))
+  (try
+   (fun tmp)
+   (finally
+    (when (file-exists? tmp)
+      (delete-file tmp)))))
+
+(def (make-temporary-file-name name)
+  (let (tmp (mktemp (string-append "/tmp/" name ".XXXXXX")))
+    (when (string-empty? tmp)
+      (error "Cannot create temporary file" name))
+    (string-append tmp "." (number->string (time->seconds (current-time))))))
+
+(begin-ffi (mktemp)
+  (c-declare "#include <stdlib.h>")
+  (define-c-lambda mktemp (char-string) char-string))


### PR DESCRIPTION
Adds `:std/os/temporaries` with a reasonably sane frontend to mktemp.