### PR TITLE
gxtest: the missing test runner

### DIFF
--- a/doc/reference/test.md
+++ b/doc/reference/test.md
@@ -1,188 +1,175 @@
 # Testing
 
-The `:std/test` library provides a lightweight testing framework.
+Gerbil comes with a testing library and a testing tool that can be used to run your tests
+in the command line.
 
-::: tip usage
-(import :std/test)
-:::
+## Running tests with gxtest
 
-## Overview
+Test files by convention have the `-test.ss` suffix and are generally more compiled.
+Each test file is a module that should export one or more _test suites_, with a name that
+ends in `-test`. See below for definition of test suites and test cases.
 
-Please write me!
+Once your tests are in place, you can run them using `gxtest`.
+If you invoke it without arguments it will run all the test files in the current directory.
+You can also explicitly pass files or directories to be run, and if you want to run tests
+in a directory recursively you can append `/...` in the directory.
 
-## Interface
-
-### test-suite
-::: tip usage
+For instance, the following will recursively run all tests in the current directory:
 ```
-(test-suite ...)
+gxtest ./...
 ```
-:::
 
-Please document me!
+## Test suites
 
-### test-case
-::: tip usage
-```
-(test-case ...)
-```
-:::
+A test suite is created using the `test-suite` special form from `:std/test` and contains one
+or more _test cases_ created with the `test-case` special form from `:std/test`.
 
-Please document me!
+Test cases contain code executed by the test runner, and in general contain one or more _checks_ with the `check` family of special forms which perform assertions.
 
-### check
-::: tip usage
-```
-(check ...)
-```
-:::
-
-Please document me!
-
-### checkf
-::: tip usage
-```
-(checkf ...)
-```
-:::
-
-Please document me!
-
-### check-eq?
-::: tip usage
-```
-(check-eq? ...)
-```
-:::
-
-Please document me!
-
-### check-not-eq?
-::: tip usage
-```
-(check-not-eq? ...)
-```
-:::
-
-Please document me!
-
-### check-eqv?
-::: tip usage
-```
-(check-eqv? ...)
-```
-:::
-
-Please document me!
-
-### check-not-eqv?
-::: tip usage
-```
-(check-not-eqv? ...)
-```
-:::
-
-Please document me!
-
-### check-equal?
-::: tip usage
-```
-(check-equal? ...)
-```
-:::
-
-Please document me!
-
-### check-not-equal?
-::: tip usage
-```
-(check-not-equal? ...)
-```
-:::
-
-Please document me!
-
-### check-output
-::: tip usage
-```
-(check-output ...)
-```
-:::
-
-Please document me!
-
-### check-predicate
-::: tip usage
-```
-(check-predicate ...)
-```
-:::
-
-Please document me!
-
-### check-exception
-::: tip usage
-```
-(check-exception ...)
-```
-:::
-
-Please document me!
-
-### !check-fail?
-::: tip usage
-```
-(!check-fail? ...)
-```
-:::
-
-Please document me!
-
-### !check-fail-e
-::: tip usage
-```
-(!check-fail-e ...)
-```
-:::
-
-Please document me!
-
-### run-tests!
-::: tip usage
-```
-(run-tests! ...)
-```
-:::
-
-Please document me!
-
-### test-report-summary!
-::: tip usage
-```
-(test-report-summary! ...)
-```
-:::
-
-Please document me!
-
-### run-test-suite!
-::: tip usage
-```
-(run-test-suite! ...)
-```
-:::
-
-Please document me!
-
-### test-result
-::: tip usage
-```
-(test-result ...)
-```
-:::
-
-Please document me!
 
 ## Example
+Here is a small example for unit testing a trivial module:
 
-Please write me!
+```
+$ cat gerbil.pkg
+(package: tmp)
+
+$ cat mylib.ss
+(export myadd)
+
+(def (myadd x y)
+ (+ x y))
+
+$ cat mylib-test.ss
+(import :std/test
+        ./mylib)
+(export mylib-test)
+
+(def mylib-test
+  (test-suite "test mylib"
+    (test-case "test myadd"
+      (check (myadd 1 2) => 3))))
+
+$ gxc -O mylib.ss
+$ gxtest
+=== ./mylib-test.ss [mylib-test]
+Test suite: test mylib
+Test case: test myadd
+... 1 checks OK
+... All tests OK
+OK
+$ echo $?
+0
+```
+
+
+## The standard test library
+
+::: tip To use the test library
+```scheme
+(import :std/test)
+```
+:::
+
+### test-suite
+```scheme
+(test-suite description case ...) -> test-suite
+
+  description := string; description of the test suite
+  case := test-case
+```
+
+### test-case
+```scheme
+(test-case description body ...) -> test-case
+
+  description := string; description of the test case
+  body := code, as in the body of a lambda
+```
+
+### check
+```scheme
+(check expr => value)
+(check expr ? predicate)
+(check equality-function expr value)
+```
+
+Evaluates an `expr` and asserts that its value is the expected one:
+- the first form uses `equal?` to compare the result of `expr` with the expected value.
+- the second form applies the predicate `predicate`.
+- the third form compares the result with `value` using the equality function `equality-function`.
+
+
+### checkf
+```scheme
+(checkf equality-predicate expr value)
+```
+
+Evaulates expr and asserts that the the value is as expected, using the equality-predicate.
+
+### check-eq?
+```scheme
+(check-eq? expr value)
+```
+
+Equivalent to `(checkf eq? expr value)`.
+
+### check-not-eq?
+```scheme
+(check-not-eq? expr value)
+```
+
+Equivalent to `(checkf (? not eq?) expr value)`.
+
+### check-eqv?
+```scheme
+(check-eqv? expr value)
+```
+
+Equivalent to `(checkf eqv? expr value)`.
+
+
+### check-not-eqv?
+```scheme
+(check-not-eqv? expr value)
+```
+
+Equivalent to `(checkf (? not eqv?) expr value)`.
+
+
+### check-equal?
+```scheme
+(check-equal? expr value)
+```
+
+Equivalent to `(checkf equal? expr value)`.
+
+
+### check-not-equal?
+```scheme
+(check-not-equal? expr value)
+```
+
+Equivalent to `(checkf (? not equal?) expr value)`.
+
+### check-output
+```scheme
+(check-output expr output)
+```
+
+Evalutes `expr` capturing its output and asserts it is equal to the expected `output`.
+
+### check-predicate
+```scheme
+(check-predicate expr pred)
+```
+
+Evalutes `expr` and asserts that its value satisfies the predicate `pred`.
+
+### check-exception
+```scheme
+(check-exception expr exn-pred)
+```
+:::
+
+Evalutes `expr` and asserts that it raises an exception that satisfies the predicate `exn-pred`.

--- a/src/std/test.ss
+++ b/src/std/test.ss
@@ -15,9 +15,12 @@
   check-equal? check-not-equal?
   check-output check-predicate check-exception
   !check-fail? !check-fail-e
-  run-tests! test-report-summary!
+  run-tests!
   run-test-suite!
-  test-result)
+  set-test-verbose!
+  test-begin!
+  test-result
+  test-report-summary!)
 
 (defstruct !check-fail (e value loc))
 (defstruct !check-error (exn check loc))

--- a/src/tools/build-deps
+++ b/src/tools/build-deps
@@ -24,5 +24,16 @@
    std/pregexp
    std/sort
    std/srfi/13
-   std/sugar)))
+   std/sugar))
+ (gerbil/tools/gxtest
+  (exe: "gxtest")
+  (gerbil/core
+   gerbil/expander
+   gerbil/gambit
+   std/format
+   std/getopt
+   std/iter
+   std/srfi/13
+   std/sugar
+   std/test)))
 

--- a/src/tools/build.ss
+++ b/src/tools/build.ss
@@ -5,7 +5,8 @@
 (defbuild-script
   '((exe: "gxprof")
     (exe: "gxtags")
-    (exe: "gxpkg"))
+    (exe: "gxpkg")
+    (exe: "gxtest"))
   libdir: (path-expand "lib" (getenv "GERBIL_HOME"))
   bindir: (path-expand "bin" (getenv "GERBIL_HOME"))
   debug: #f)

--- a/src/tools/gxtest.ss
+++ b/src/tools/gxtest.ss
@@ -1,0 +1,101 @@
+;;; -*- Gerbil -*-
+;;; © vyzo
+;;; tool to run tests without the need of glue code
+(import :gerbil/gambit
+        :gerbil/expander
+        :std/sugar
+        :std/getopt
+        :std/iter
+        :std/format
+        :std/test
+        :std/srfi/13)
+(export main)
+
+(def (main . args)
+  (def gopt
+    (getopt
+     (flag 'verbose "-v"
+           help: "run in verbose mode where all test execution progress is displayed in stdout")
+     (flag 'help "-h" "--help"
+           help: "display help")
+     (rest-arguments 'args
+                     help: "test files or directories to execut tests in; appending /... to a directory will recursively execute or tests in it. By default all tests in the current directory are executed")))
+
+  (def (help what)
+    (getopt-display-help what "gxtest"))
+
+  (try
+   (let (opt (getopt-parse gopt args))
+     (let-hash opt
+       (cond
+        (.?help (help gopt))
+        ((null? .args)
+         (run-tests ["."] .?verbose))
+        (else
+         (run-tests .args .?verbose)))))
+   (catch (getopt-error? exn)
+     (help exn)
+     (exit 1))
+   (catch (e)
+     (display-exception e (current-error-port))
+     (exit 2))))
+
+(def (run-tests args verbose?)
+  (_gx#load-expander!)
+  (set-test-verbose! verbose?)
+  (test-begin!)
+  (let* ((files (collect-files args))
+         (suites (prepare-suites files)))
+    (for ([file suite-name suite] suites)
+      (displayln "=== " file " [" suite-name "]")
+      (force-output)
+      (run-test-suite! suite)))
+  (displayln (test-result)))
+
+(def (collect-files args)
+  (reverse
+   (for/fold (result []) (arg args)
+     (cond
+      ((string-suffix? "/..." arg)
+       (collect-files-r (substring arg 0 (- (string-length arg) 4)) result))
+      ((eq? (file-type arg) 'directory)
+       (for/fold (result result) (file (directory-files arg))
+         (if (string-suffix? "-test.ss" file)
+           (cons (string-append arg "/" file) result)
+           result)))
+      ((string-suffix? "-test.ss" arg)
+       (cons arg result))
+      (else result)))))
+
+(def (collect-files-r dir result)
+  (for/fold (result result) (arg (directory-files dir))
+    (cond
+     ((member arg '("." ".."))
+      result)
+     ((eq? (file-type (string-append dir "/" arg)) 'directory)
+      (collect-files-r (string-append dir "/" arg) result))
+     ((string-suffix? "-test.ss" arg)
+      (cons (string-append dir "/" arg) result))
+     (else result))))
+
+(def (prepare-suites files)
+  (reverse
+   (for/fold (result []) (file files)
+     (let (ctx (try-import-module file))
+       (if ctx
+         (for/fold (result result) (exported (module-context-export ctx))
+           (if (and (= (module-export-phi exported) 0)
+                    (string-suffix? "-test" (symbol->string (module-export-name exported))))
+             (let (bind (core-resolve-module-export exported))
+               (cons [file (module-export-name exported) (eval (binding-id bind))]
+                     result))
+             result))
+         result)))))
+
+(def (try-import-module file)
+  (try
+   (import-module file #f #t)
+   (catch (e)
+     (eprintf "*** Error importing ~a: " file)
+     (display-exception e (current-error-port))
+     #f)))

--- a/src/tools/gxtest.ss
+++ b/src/tools/gxtest.ss
@@ -73,9 +73,8 @@
          (if (string-suffix? "-test.ss" file)
            (cons (string-append arg "/" file) result)
            result)))
-      ((string-suffix? "-test.ss" arg)
-       (cons arg result))
-      (else result)))))
+      (else
+       (cons arg result))))))
 
 (def (collect-files-r dir result)
   (for/fold (result result) (arg (directory-files dir))

--- a/src/tools/gxtest.ss
+++ b/src/tools/gxtest.ss
@@ -15,11 +15,11 @@
   (def gopt
     (getopt
      (flag 'verbose "-v"
-           help: "run in verbose mode where all test execution progress is displayed in stdout")
+           help: "run in verbose mode where all test execution progress is displayed in stdout.")
      (flag 'help "-h" "--help"
            help: "display help")
      (rest-arguments 'args
-                     help: "test files or directories to execut tests in; appending /... to a directory will recursively execute or tests in it. By default all tests in the current directory are executed")))
+                     help: "test files or directories to execut tests in; appending /... to a directory will recursively execute or tests in it. If no arguments are passed, all tests in the current directory are executed.")))
 
   (def (help what)
     (getopt-display-help what "gxtest"))

--- a/src/tools/gxtest.ss
+++ b/src/tools/gxtest.ss
@@ -50,7 +50,10 @@
       (displayln "=== " file " [" suite-name "]")
       (force-output)
       (run-test-suite! suite)))
-  (displayln (test-result)))
+  (let (result (test-result))
+    (displayln result)
+    (unless (eq? result 'OK)
+      (exit 42))))
 
 (def (collect-files args)
   (reverse


### PR DESCRIPTION
This adds a new tool for running your tests in the command line.
Similar to `go test`, you can run tests in the current directory with `gxtest`, and recurse with `gxtest ./...`.
This tools has been sorely missing and I finally got around to writing it; and I am lovin it already.