### PR TITLE
getopt: add a global help option for describing the program

### DIFF
--- a/src/std/getopt.ss
+++ b/src/std/getopt.ss
@@ -27,7 +27,7 @@
 (def (raise-getopt-error msg . args)
   (raise (make-getopt-error msg args #f (current-getopt-parser))))
 
-(defstruct !getopt (opts cmds args))
+(defstruct !getopt (opts cmds args help))
 (defstruct !top (key help))
 (defstruct (!command !top) (opts args)
   final: #t)
@@ -44,7 +44,7 @@
 (defstruct (!rest !arg) ()
   final: #t)
 
-(def (getopt . args)
+(def (getopt help: (help #f) . args)
   (let lp ((rest args) (opts []) (cmds []) (args []))
     (match rest
       ([hd . rest]
@@ -74,7 +74,7 @@
         (else
          (error "Illegal argument; must be a getopt-object" hd))))
       (else
-       (make-!getopt (reverse opts) (reverse cmds) (reverse args))))))
+       (make-!getopt (reverse opts) (reverse cmds) (reverse args) help)))))
 
 (def (flag id short (long #f)
            help: (help #f))
@@ -252,7 +252,9 @@
        (getopt-display-help gopt program port)))))
 
 (def (display-help-getopt obj program port)
-  (with ((!getopt opts cmds args) obj)
+  (with ((!getopt opts cmds args help) obj)
+    (when help
+      (fprintf port "~a: ~a~n~n" program help))
     (if (null? cmds)
       (begin
         (fprintf port "Usage: ~a ~a"

--- a/src/tools/gxpkg.ss
+++ b/src/tools/gxpkg.ss
@@ -77,17 +77,19 @@
     (command 'help help: "display help; help <command> for command help"
              (optional-argument 'command value: string->symbol)))
   (def gopt
-    (getopt install-cmd
-            uninstall-cmd
-            update-cmd
-            link-cmd
-            unlink-cmd
-            build-cmd
-            clean-cmd
-            list-cmd
-            retag-cmd
-            search-cmd
-            help-cmd))
+    (getopt
+     help: "the Gerbil Package Manager"
+     install-cmd
+     uninstall-cmd
+     update-cmd
+     link-cmd
+     unlink-cmd
+     build-cmd
+     clean-cmd
+     list-cmd
+     retag-cmd
+     search-cmd
+     help-cmd))
 
   (try
    (let ((values cmd opt) (getopt-parse gopt args))

--- a/src/tools/gxtags.ss
+++ b/src/tools/gxtags.ss
@@ -18,14 +18,16 @@
 
 (def (main . args)
   (def gopt
-    (getopt (flag 'append "-a"
-               help: "append to existing tag file")
-            (option 'output "-o" default: "TAGS"
-               help: "explicit name of file for tag table")
-            (flag 'help "-h" "--help"
-               help: "display help")
-            (rest-arguments 'input
-               help: "source file or directory")))
+    (getopt
+     help: "generate emacs tags for Gerbil code"
+     (flag 'append "-a"
+           help: "append to existing tag file")
+     (option 'output "-o" default: "TAGS"
+             help: "explicit name of file for tag table")
+     (flag 'help "-h" "--help"
+           help: "display help")
+     (rest-arguments 'input
+                     help: "source file or directory")))
 
   (def (help what)
     (getopt-display-help what "gxtags"))

--- a/src/tools/gxtest.ss
+++ b/src/tools/gxtest.ss
@@ -15,6 +15,7 @@
 (def (main . args)
   (def gopt
     (getopt
+     help: "run Gerbil tests in the command line"
      (flag 'verbose "-v"
            help: "run in verbose mode where all test execution progress is displayed in stdout.")
      (option 'run "-r" "--run"


### PR DESCRIPTION
We don't have anything describing the program itself; this fixes.