### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/gerbil/prelude/gambit/fixnum.ss
+++ b/src/gerbil/prelude/gambit/fixnum.ss
@@ -5,7 +5,7 @@ package: gerbil/gambit
 
 (export #t)
 (extern namespace: #f
-  fxarithmetic-shift-left fxarithmetic-shift-right fxarithmetic-shift-left
+  fxarithmetic-shift-left fxarithmetic-shift-right fxarithmetic-shift
   fxbit-count fxfirst-set-bit fxif fxlength
   fxquotient fxremainder
   fxwrap* fxwrap+ fxwrap-

--- a/src/std/interface.ss
+++ b/src/std/interface.ss
@@ -93,7 +93,7 @@
                      (let (info (syntax-local-value spec false))
                        (unless (interface-info? info)
                          (raise-syntax-error #f "Bad syntax; not an interface type" stx spec))
-                       (foldl cons methods (interface-info-methods info)))
+                       (foldl cons methods (map syntax-local-introduce (interface-info-methods info))))
                      (cons spec methods)))
                  []
                  specs))


### PR DESCRIPTION
Cherry picked from #728.
Summary:
- fix issues with the syntax quoting in mixin interface methods; syntax-local-introduce is appropiate
- don't generate dynamic method bindings for interfaces, it defeats the purpose.
- fix a typo in `:gerbil/gambit/fixnum`
- improve check failure reporting in `:std/test` to also display the expected value.