### PR TITLE
Fix configure and Makefile

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -36,7 +36,7 @@ mandir = @mandir@
 
 LIBS = @LIBS@
 
-gerbil_home = ${prefix}/lib/${PACKAGE_SHORTNAME}
+gerbil_home = ${prefix}
 gerbil_bin = "$(gerbil_home)/bin"
 gerbil_lib = "${gerbil_home}/lib"
 gerbil_share = "${gerbil_home}/share"

--- a/Makefile.in
+++ b/Makefile.in
@@ -41,10 +41,6 @@ gerbil_bin = "$(gerbil_home)/bin"
 gerbil_lib = "${gerbil_home}/lib"
 gerbil_share = "${gerbil_home}/share"
 
-
-gerbil_bin_linkdir = "${prefix}/bin"
-gerbil_share_linkdir = "${prefix}/share"
-
 gerbil_make_conf = @gerbil_make_conf@
 
 gerbil: configure
@@ -63,7 +59,6 @@ stdlib:
 lang:
 	cd src && LDFLAGS="$(LIBS)" ./build.sh lang
 
-
 r7rs-large:
 	cd src && LDFLAGS="$(LIBS)" ./build.sh r7rs-large
 
@@ -77,15 +72,11 @@ stage1:
 	cd src && LDFLAGS="$(LIBS)" ./build.sh stage1
 
 layout:
-		cd src && LDFLAGS="$(LIBS)" ./build.sh layout
+	cd src && LDFLAGS="$(LIBS)" ./build.sh layout
 
 tags:
 	cd src && LDFLAGS="$(LIBS)" ./build.sh tags
 
 install:
-	mkdir -p ${gerbil_bin} ${gerbil_share} ${gerbil_bin_linkdir} ${gerbil_share_linkdir}
+	mkdir -p ${gerbil_bin} ${gerbil_lib} ${gerbil_share}
 	cd src && ./install
-	cp -a --link --remove-destination ${gerbil_bin}/* ${gerbil_bin_linkdir}  || \
-	cp -a ${gerbil_bin}/* ${gerbil_bin_linkdir}
-	cp -a --link --remove-destination ${gerbil_share}/* ${gerbil_share_linkdir}  || \
-	cp -a ${gerbil_share}/* ${gerbil_share_linkdir}

--- a/configure
+++ b/configure
@@ -1831,7 +1831,7 @@ if test ${enable_zlib+y}
 then :
   enableval=$enable_zlib; ENABLE_ZLIB=$enableval
 else $as_nop
-  ENABLE_ZLIB=no
+  ENABLE_ZLIB=yes
 fi
 
 
@@ -2750,7 +2750,7 @@ cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1
 _ACAWK
 cat >>"\$ac_tmp/subs1.awk" <<_ACAWK &&
   for (key in S) S_is_set[key] = 1
-  FS = "$(printf '\a')"
+  FS = ""
 
 }
 {

--- a/configure.ac
+++ b/configure.ac
@@ -70,7 +70,7 @@ fi
 AC_ARG_ENABLE(zlib,
 AS_HELP_STRING([--disable-zlib], [build std/text/zlib libraries - requires zlib (default is --enable-zlib]),
 ENABLE_ZLIB=$enableval,
-ENABLE_ZLIB=no)
+ENABLE_ZLIB=yes)
 
 if test "$ENABLE_ZLIB" = yes; then
 gerbil_make_conf="$gerbil_make_conf --enable-zlib"


### PR DESCRIPTION
The thing was flat out broken; instead of installing under prefix it installed under `prefix/gerbi/something` and linked the binaries. This is the wrong thing to do: when the user says prefix he means prefix, not some random directory underneath.