### PR TITLE
Some getopt improvements: call-with-getopt

### DIFF
--- a/doc/reference/getopt.md
+++ b/doc/reference/getopt.md
@@ -101,7 +101,7 @@ Returns true if the object is a getopt command or command specifier.
 This shim around getopt parsing eliminates all the repetitive
 boilerplate around argument parsing with getopt.
 
-It creates a getopt parser that parses with options `gopt`, automatically
+It creates a getopt parser that parses with options `gopts`, automatically
 including a help option or command accordingly.
 
 It then uses the parser to pare `args`, handling the exceptions and

--- a/src/std/build-deps
+++ b/src/std/build-deps
@@ -204,7 +204,9 @@
    gerbil/gambit/ports
    std/misc/repr))
  (std/assert "assert" (gerbil/core gerbil/expander std/format std/sugar))
- (std/getopt "getopt" (gerbil/core std/error std/format))
+ (std/getopt
+  "getopt"
+  (gerbil/core gerbil/gambit/exceptions std/error std/format std/sugar))
  (std/logger
   "logger"
   (gerbil/core

--- a/src/tools/gxpkg.ss
+++ b/src/tools/gxpkg.ss
@@ -73,56 +73,44 @@
   (def search-cmd
     (command 'search help: "search the package directory"
              (rest-arguments 'keywords help: "keywords to search for")))
-  (def help-cmd
-    (command 'help help: "display help; help <command> for command help"
-             (optional-argument 'command value: string->symbol)))
-  (def gopt
-    (getopt
-     help: "the Gerbil Package Manager"
-     install-cmd
-     uninstall-cmd
-     update-cmd
-     link-cmd
-     unlink-cmd
-     build-cmd
-     clean-cmd
-     list-cmd
-     retag-cmd
-     search-cmd
-     help-cmd))
 
-  (try
-   (let ((values cmd opt) (getopt-parse gopt args))
-     (let-hash opt
-       (case cmd
-         ((install)
-          (install-pkgs .pkg))
-         ((uninstall)
-          (uninstall-pkgs .pkg .?force))
-         ((update)
-          (update-pkgs .pkg))
-         ((link)
-          (link-pkg .pkg .src))
-         ((unlink)
-          (unlink-pkgs .pkg .?force))
-         ((build)
-          (build-pkgs .pkg))
-         ((clean)
-          (clean-pkgs .pkg))
-         ((list)
-          (list-pkgs))
-         ((retag)
-          (retag-pkgs))
-         ((search)
-          (search-pkgs .keywords))
-         ((help)
-          (getopt-display-help-topic gopt .?command "gxkpg")))))
-   (catch (getopt-error? exn)
-     (getopt-display-help exn "gxpkg" (current-error-port))
-     (exit 1))
-   (catch (e)
-     (display-exception e (current-error-port))
-     (exit 2))))
+  (call-with-getopt gxpkg-main args
+    program: "gxpkg"
+    help: "The Gerbil Package Manager"
+    install-cmd
+    uninstall-cmd
+    update-cmd
+    link-cmd
+    unlink-cmd
+    build-cmd
+    clean-cmd
+    list-cmd
+    retag-cmd
+    search-cmd))
+
+(def (gxpkg-main cmd opt)
+  (let-hash opt
+    (case cmd
+      ((install)
+       (install-pkgs .pkg))
+      ((uninstall)
+       (uninstall-pkgs .pkg .?force))
+      ((update)
+       (update-pkgs .pkg))
+      ((link)
+       (link-pkg .pkg .src))
+      ((unlink)
+       (unlink-pkgs .pkg .?force))
+      ((build)
+       (build-pkgs .pkg))
+      ((clean)
+       (clean-pkgs .pkg))
+      ((list)
+       (list-pkgs))
+      ((retag)
+       (retag-pkgs))
+      ((search)
+       (search-pkgs .keywords)))))
 
 ;;; commands
 (defrules fold-pkgs ()

--- a/src/tools/gxtags.ss
+++ b/src/tools/gxtags.ss
@@ -17,36 +17,20 @@
 (export main make-tags)
 
 (def (main . args)
-  (def gopt
-    (getopt
-     help: "generate emacs tags for Gerbil code"
-     (flag 'append "-a"
-           help: "append to existing tag file")
-     (option 'output "-o" default: "TAGS"
-             help: "explicit name of file for tag table")
-     (flag 'help "-h" "--help"
-           help: "display help")
-     (rest-arguments 'input
-                     help: "source file or directory")))
+  (call-with-getopt gxtags-main args
+    program: "gxtags"
+    help: "generate emacs tags for Gerbil code"
+    (flag 'append "-a"
+      help: "append to existing tag file")
+    (option 'output "-o" default: "TAGS"
+      help: "explicit name of file for tag table")
+    (rest-arguments 'input
+      help: "source file or directory")))
 
-  (def (help what)
-    (getopt-display-help what "gxtags"))
-
-  (try
-   (let (opt (getopt-parse gopt args))
-     (if (hash-get opt 'help)
-       (help gopt)
-       (let (inputs (hash-get opt 'input))
-         (if (null? inputs)
-           (begin
-             (help gopt)
-             (exit 1))
-           (run (hash-get opt 'input)
-                (hash-get opt 'output)
-                (hash-get opt 'append))))))
-   (catch (getopt-error? exn)
-     (help exn)
-     (exit 1))))
+(def (gxtags-main opt)
+  (run (hash-ref opt 'input ["."])
+       (hash-get opt 'output)
+       (hash-get opt 'append)))
 
 (def (run inputs tagfile append?)
   (_gx#load-expander!)

--- a/src/tools/gxtest.ss
+++ b/src/tools/gxtest.ss
@@ -14,9 +14,9 @@
 (export main)
 
 (def (main . args)
-  (def gopt
-    (getopt
-     help: "run Gerbil tests in the command line"
+  (call-with-getopt gxtest-main args
+    program: "gxtest"
+    help: "run Gerbil tests in the command line"
      (flag 'verbose "-v"
            help: "run in verbose mode where all test execution progress is displayed in stdout.")
      (option 'run "-r" "--run"
@@ -24,29 +24,16 @@
      ;; TODO this should be a multi-option for multiple features
      (option 'features "-D"
              help: "define one or more conditional expansion feature (comma separated) for enabling tests that require external services")
-     (flag 'help "-h" "--help"
-           help: "display help")
      (rest-arguments 'args
                      help: "test files or directories to execute tests in; appending /... to a directory will recursively execute or tests in it. If no arguments are passed, all tests in the current directory are executed.")))
 
-  (def (help what)
-    (getopt-display-help what "gxtest"))
-
-  (try
-   (let (opt (getopt-parse gopt args))
-     (let-hash opt
-       (cond
-        (.?help (help gopt))
-        ((null? .args)
-         (run-tests ["."] .run .features .?verbose))
-        (else
-         (run-tests .args .run .features .?verbose)))))
-   (catch (getopt-error? exn)
-     (help exn)
-     (exit 1))
-   (catch (e)
-     (display-exception e (current-error-port))
-     (exit 2))))
+(def (gxtest-main opt)
+  (let-hash opt
+    (cond
+     ((null? .args)
+      (run-tests ["."] .run .features .?verbose))
+     (else
+      (run-tests .args .run .features .?verbose)))))
 
 (def (run-tests args filter features verbose?)
   (def import-errors [])


### PR DESCRIPTION
Adds a call-with-getopt entry point to eliminate boilerplate.