### PR TITLE
Actors v18: Administrative privilege separation and capabilities

### DIFF
--- a/doc/reference/actor.md
+++ b/doc/reference/actor.md
@@ -782,11 +782,15 @@ ensemble.
 
 ### admin-authorize
 ```scheme
-(admin-authorize privk srv-id authorized-server-id (srv (current-actor-server)))
+(admin-authorize privk srv-id authorized-server-id (srv (current-actor-server))
+                 capabilities: (cap '(admin)))
 ```
 
-Authorizes administrative privileges for `authorized-server-id` in the remote server `srv-id`,
-using the private key `privk`.
+Authorizes the capabilities specified by `cap` with administrative
+privileges for `authorized-server-id` in the remote server `srv-id`,
+using the private key `privk`. `cap` is a list of symbols denoting
+the capabilities of the authorized server; the `admin` capability
+implies all other capabilities.
 
 ### get-admin-pubkey
 ```scheme

--- a/doc/reference/actor.md
+++ b/doc/reference/actor.md
@@ -782,10 +782,10 @@ ensemble.
 
 ### admin-authorize
 ```scheme
-(admin-authorize privk srv-id (srv (current-actor-server)))
+(admin-authorize privk srv-id authorized-server-id (srv (current-actor-server)))
 ```
 
-Authorizes administrative privileges with the remote server `srv-id`,
+Authorizes administrative privileges for `authorized-server-id` in the remote server `srv-id`,
 using the private key `privk`.
 
 ### get-admin-pubkey

--- a/doc/reference/actor.md
+++ b/doc/reference/actor.md
@@ -792,6 +792,15 @@ using the private key `privk`. `cap` is a list of symbols denoting
 the capabilities of the authorized server; the `admin` capability
 implies all other capabilities.
 
+### admin-retract
+```scheme
+(admin-retract srv-id authorized-server-id (srv (current-actor-server)))
+```
+
+Retracts the capabilities previously confered to
+`authorized-server-id` within the context of `srv-id`.  Note that the
+in-process actor server must have `admin` capabilities.
+
 ### get-admin-pubkey
 ```scheme
 (get-admin-pubkey (path (default-admin-pubkey-path)))

--- a/doc/reference/actor.md
+++ b/doc/reference/actor.md
@@ -155,6 +155,21 @@ incremented automatically by the send operators. It is provided
 however in case you want to construct your own envelopes, for instance
 when writing a proxy actor.
 
+### actor-authorized?
+```scheme
+(actor-authorized? actor)
+```
+
+Returns true if the actor (a thread or a handle) are authorized for administrative actions.
+
+All threads within the process are implicitly authorized.
+
+Remote actors must be authorized with the actor server using
+`admin-authorize` if the actor server requires authentication.  This
+happens by default if an administrative public key exists in the
+ensemble directory. If none exists, the actor server will consider all
+actors in the ensemble as authorized.
+
 ### actor-error
 ```scheme
 (defstruct (actor-error <error>) ())
@@ -475,6 +490,7 @@ manually.
 ### start-actor-server!
 ```scheme
 (start-actor-server! cookie:     (cookie (get-actor-server-cookie))
+                     admin:      (admin (get-admin-pubkey))
                      addresses:  (addrs [])
                      identifier: (id (make-random-identifier))
                      ensemble:   (known-servers (default-known-servers)))
@@ -485,6 +501,8 @@ returns the main server thread.
 - `cookie` is the ensemble cookie; normally resides in `$GERBIL_PATH/ensemble/cookie`.
   Note that the administrator has to explicitly create a cookie for the ensemble, it is
   not automatically created.
+- `admin` is the (optional) administrative public key; normally resindes in
+  `$GERBIL_PATH/ensemble/admin.pub`.
 - `addresses` is the list of addresses the server should listen; by default it is empty,
   making this a transient actor server.
 - `identifier` is the server identifier; if you don't specify one, a random server
@@ -602,7 +620,8 @@ Sets the actor server's address cache TTL (in seconds, a real number).
                            announce:  (public-addrs #f)
                            registry:  (registry-addrs #f)
                            roles:     (roles [])
-                           cookie:    (cookie (get-actor-server-cookie)))
+                           cookie:    (cookie (get-actor-server-cookie))
+                           admin:     (admin (get-admin-pubkey)))
 ```
 
 This is the programmatic equivalent of `gxensemble run`; first it
@@ -627,6 +646,8 @@ Options:
 - `roles`: a list of roles the server fullfills in the registry.
 - `cookie`: the cookie to use; by default it uses the ensemble cooke in
   `$GERBIL_PATH/ensemble/cookie`.
+- `admin`: the administrative public key, if any; by default it uses the public
+   key in `$GERBIL_PATH/ensemble/admin.pub` if it exists.
 
 ### ensemble-base-path
 ```scheme
@@ -758,3 +779,39 @@ Looks up a server's addresses in the registry.
 
 Looks up servers (and their addresses) that fulfill `role` in the
 ensemble.
+
+### admin-authorize
+```scheme
+(admin-authorize privk srv-id (srv (current-actor-server)))
+```
+
+Authorizes administrative privileges with the remote server `srv-id`,
+using the private key `privk`.
+
+### get-admin-pubkey
+```scheme
+(get-admin-pubkey (path (default-admin-pubkey-path)))
+```
+
+Loads the administrative public key from the specified `path`, if it exists
+
+### get-admin-privkey
+```scheme
+(get-admin-privkey passphrase (path (default-admin-privkey-path)))
+```
+
+Loads and decrypts the administrative private key from the specified `path`, if it exists
+
+### default-admin-pubkey-path
+```scheme
+(default-admin-pubkey-path)
+```
+
+The default path for the ensemble admin public key; defaults to `$GERBIL_PATH/ensemble/admin.pub`.
+
+### default-admin-privkey-path
+```scheme
+(default-admin-privkey-path)
+```
+
+The default path for the encrypted ensemble admin private key; defaults to `$GERBIL_PATH/ensemble/admin.priv`.

--- a/doc/reference/actor.md
+++ b/doc/reference/actor.md
@@ -491,6 +491,7 @@ manually.
 ```scheme
 (start-actor-server! cookie:     (cookie (get-actor-server-cookie))
                      admin:      (admin (get-admin-pubkey))
+                     auth:       (auth #f)
                      addresses:  (addrs [])
                      identifier: (id (make-random-identifier))
                      ensemble:   (known-servers (default-known-servers)))
@@ -503,6 +504,8 @@ returns the main server thread.
   not automatically created.
 - `admin` is the (optional) administrative public key; normally resindes in
   `$GERBIL_PATH/ensemble/admin.pub`.
+- `auth`: a hash table mapping server ids to capabilities; these are preauthorized
+  server capabilities.
 - `addresses` is the list of addresses the server should listen; by default it is empty,
   making this a transient actor server.
 - `identifier` is the server identifier; if you don't specify one, a random server
@@ -621,7 +624,8 @@ Sets the actor server's address cache TTL (in seconds, a real number).
                            registry:  (registry-addrs #f)
                            roles:     (roles [])
                            cookie:    (cookie (get-actor-server-cookie))
-                           admin:     (admin (get-admin-pubkey)))
+                           admin:     (admin (get-admin-pubkey))
+                           auth:      (auth #f))
 ```
 
 This is the programmatic equivalent of `gxensemble run`; first it
@@ -648,6 +652,8 @@ Options:
   `$GERBIL_PATH/ensemble/cookie`.
 - `admin`: the administrative public key, if any; by default it uses the public
    key in `$GERBIL_PATH/ensemble/admin.pub` if it exists.
+- `auth`: a hash table mapping server ids to capabilities; these are preauthorized
+  server capabilities.
 
 ### ensemble-base-path
 ```scheme

--- a/doc/tutorials/ensemble.md
+++ b/doc/tutorials/ensemble.md
@@ -46,6 +46,7 @@ Commands:
  list-actors                      list actors registered in a server
  list-connections                 list a server's connection
  lookup                           looks up a server by id or role
+ authorize                        authorize capabilities for a server
  cookie                           generate a new ensemble cookie
  admin                            generate a new ensemble administrator key pair
  help                             display help; help <command> for command help
@@ -83,6 +84,27 @@ Usage: gxensemble admin [command-option ...]
 
 Command Options:
  -f --force                       force the action
+```
+
+### Authorizing capabilities
+
+This is an administrative action, that confers capabilities to an
+authorized server within the context of another server.
+See [Administrative Privileges](#administrative-privileges) below.
+
+Here is the usage:
+```
+$ gxensemble help authorize
+Usage: gxensemble authorize [command-option ...] <server-id> <authorized-server-id> [<capabilities>]
+       authorize capabilities for a server
+
+Command Options:
+  --registry <registry>           additional registry addresses; by default the registry is reachable at unix /tmp/ensemble/registry [default: #f]
+
+Arguments:
+ server-id                        the server id
+ authorized-server-id             the server to authorize capabilities for
+ capabilities                     the server capabilities to authorize [default: (admin)]
 ```
 
 ### Starting the ensemble
@@ -509,3 +531,23 @@ This is integrated with the `gxensemble` tool:
   administrative privileges the tool will ask you to enter the
   passphrase in order to unlock and use the private key to elevate
   privileges in the servers involved.
+
+Furthermore, using the administrative key pair, you can confer
+capabilities to servers, within the the context of another server.
+For example, you can confer the `shutdown` capability to another
+server within the context of server.
+
+For example, to allow actors in `my-authorized-server` to shutdown
+`my-server`, you can issue the following command with administrative
+privileges:
+```
+$ gxensemble authorize my-server my-authorized-server "(shutdown)"
+```
+
+::: warning
+In order to effectively and securely confer capabilities to other
+servers by name, it is strongly recommended that you use TLS.
+
+Otherwise anyone in the ensemble can claim your authorized server's id
+and acquire capabilities that are not intended.
+:::

--- a/doc/tutorials/ensemble.md
+++ b/doc/tutorials/ensemble.md
@@ -47,6 +47,7 @@ Commands:
  list-connections                 list a server's connection
  lookup                           looks up a server by id or role
  cookie                           generate a new ensemble cookie
+ admin                            generate a new ensemble administrator key pair
  help                             display help; help <command> for command help
 ```
 
@@ -67,6 +68,22 @@ Usage: gxensemble cookie [command-option ...]
 Command Options:
  -f --force                       force the action
  ```
+
+### Generating and administrative key pair
+
+If you want to limit administrative actions only to administrators,
+you can generate an administraticve key pair with `gxensemble admin`.
+See [Administrative Privileges](#administrative-privileges) below.
+
+Here is the usage:
+```
+$ gxensemble help admin
+Usage: gxensemble admin [command-option ...]
+       generate a new ensemble administrator key pair
+
+Command Options:
+ -f --force                       force the action
+```
 
 ### Starting the ensemble
 
@@ -468,3 +485,27 @@ $ gxensemble shutdown -f
 ... shutting down httpd3
 ... shutting down registry
 ```
+
+## Administrative Privileges
+
+You may have noticed that the `gxensemble` tool has some powerful and
+potentially destructive capabilities. In general, this is fine for
+development or when your ensemble is limited to a single host, but as
+your system grows and spans more hosts and involves more people, it
+might be prudent to limit administrative capabilities to authorized
+administrators.
+
+The actor system in Gerbil allows you to (optionally) use a Ed25519
+key pair that limits administrative actions (shutdown, code loading
+and evaluation, etc) only to entities that can prove that they have
+access to the private key material.
+
+This is integrated with the `gxensemble` tool:
+- You can generate an administrative key pair with the `gxensemble
+  admin` command. The command will ask for a passphrase to encrypt
+  the private key, and will leave the key pair in
+  `$GERBIL_PATH/ensemble/admin.{pub,priv}`.
+- Subsequently, when attempting a senstive action that requires
+  administrative privileges the tool will ask you to enter the
+  passphrase in order to unlock and use the private key to elevate
+  privileges in the servers involved.

--- a/doc/tutorials/ensemble.md
+++ b/doc/tutorials/ensemble.md
@@ -47,6 +47,7 @@ Commands:
  list-connections                 list a server's connection
  lookup                           looks up a server by id or role
  authorize                        authorize capabilities for a server
+ retract                          retract all capabilities granted to a server
  cookie                           generate a new ensemble cookie
  admin                            generate a new ensemble administrator key pair
  help                             display help; help <command> for command help
@@ -105,6 +106,24 @@ Arguments:
  server-id                        the server id
  authorized-server-id             the server to authorize capabilities for
  capabilities                     the server capabilities to authorize [default: (admin)]
+```
+
+### Retracting capabilities
+This is an administrative action, that retracts capabilities from a
+previously authorized server.
+
+Here is the usage:
+```
+$ gxensemble help retract
+Usage: gxensemble retract [command-option ...] <server-id> <authorized-server-id>
+       retract all capabilities granted to a server
+
+Command Options:
+  --registry <registry>           additional registry addresses; by default the registry is reachable at unix /tmp/ensemble/registry [default: #f]
+
+Arguments:
+ server-id                        the server id
+ authorized-server-id             the server to authorize capabilities for
 ```
 
 ### Starting the ensemble
@@ -542,6 +561,12 @@ For example, to allow actors in `my-authorized-server` to shutdown
 privileges:
 ```
 $ gxensemble authorize my-server my-authorized-server "(shutdown)"
+```
+
+You can retract capabilities from a server with the `retract` command
+of the `gxensemble` tool:
+```
+$ gxensemble retract my-server my-authorized-server
 ```
 
 ::: warning

--- a/src/std/actor-v18/admin-test.ss
+++ b/src/std/actor-v18/admin-test.ss
@@ -1,0 +1,28 @@
+;;; -*- Gerbil -*-
+;;; © vyzo
+;;; test for actor server administration utils
+(import :std/test
+        :std/os/temporaries
+        ./admin)
+(export actor-admin-util-test)
+
+(def actor-admin-util-test
+  (test-suite "adminitrative utils"
+    (test-case "keypair generation and authorization"
+      (def pubk-path (make-temporary-file-name "pubk"))
+      (def privk-path (make-temporary-file-name "privk"))
+      (def passphrase "oh so secret")
+
+      (generate-admin-keypair! passphrase pubk-path privk-path)
+
+      (def pubk (get-admin-pubkey pubk-path))
+      (def privk (get-admin-privkey passphrase privk-path))
+
+      (def sig (admin-auth-challenge-sign privk 'a 'b '#u8(1 2 3 4)))
+
+      (check (admin-auth-challenge-verify pubk 'a 'b '#u8(1 2 3 4) sig) => #t)
+      (check (admin-auth-challenge-verify pubk 'a 'b '#u8(1 2 3 4) '#u8(1 2 3 4)) => #f)
+
+
+      (delete-file pubk-path)
+      (delete-file privk-path))))

--- a/src/std/actor-v18/admin.ss
+++ b/src/std/actor-v18/admin.ss
@@ -1,0 +1,114 @@
+;;; -*- Gerbil -*-
+;;; © vyzo
+;;; actor server administration utils
+(import :std/crypto
+        :std/text/utf8
+        :std/misc/ports
+        ./path)
+(export default-admin-pubkey-path
+        default-admin-privkey-path
+        get-admin-pubkey
+        get-admin-privkey
+        generate-admin-keypair!
+        admin-auth-challenge-sign
+        admion-auth-challenge-verify)
+
+(def (default-admin-pubkey-path)
+  (path-expand "admin.pub" (ensemble-base-path)))
+
+(def (default-admin-privkey-path)
+  (path-expand "admin.priv" (ensemble-base-path)))
+
+(def (get-admin-pubkey (path (default-admin-pubkey-path)))
+  (let (path (path-expand path))
+    (if (file-exists? path)
+      (bytes->public-key EVP_PKEY_ED25519 (read-file-u8vector path))
+      #f)))
+
+(def (get-admin-privkey passphrase (path (default-admin-privkey-path)))
+  (let (path (path-expand path))
+    (if (file-exists? path)
+      (let* ((blob (read-file-u8vector path))
+             (cipher (make-cipher))
+             (iv-length (cipher-iv-length cipher))
+             (iv (subu8vector blob 0 iv-length))
+             (ciphertext (subu8vector blob iv-length (u8vector-length blob)))
+             (plaintext
+              (decrypt cipher
+                       (passphrase->key passphrase (cipher-key-length cipher))
+                       iv
+                       ciphertext))
+             (magic-length (u8vector-length privkey-magic))
+             (magic (subu8vector plaintext 0 magic-length))
+             (privkey-bytes (subu8vector plaintext magic-length (u8vector-length plaintext))))
+        (if (equal? magic privkey-magic)
+          (bytes->private-key EVP_PKEY_ED25519 privkey-bytes)
+          (error "incorrect passphrase")))
+      #f)))
+
+(def (generate-admin-keypair! passphrase
+                              (pubk-path  (default-admin-pubkey-path))
+                              (privk-path (default-admin-privkey-path))
+                              force: (force? #f))
+  (let ((pubk-path (path-expand pubk-path))
+        (privk-path (path-expand privk-path)))
+    (unless force?
+      (when (file-exists? pubk-path)
+        (error "public key file already exists" pubk-path))
+      (when (file-exists? privk-path)
+        (error "private key file already exists" privk-path)))
+    (let* ((pkey (keygen/ed25519))
+           (pubk-bytes (public-key->bytes pkey))
+           (privk-bytes (private-key->bytes pkey))
+           (cipher (make-cipher))
+           (iv-length (cipher-iv-length cipher))
+           (iv (random-bytes iv-length))
+           (plaintext (u8vector-append privkey-magic privk-bytes))
+           (ciphertext
+            (encrypt cipher
+                     (passphrase->key passphrase (cipher-key-length cipher))
+                     iv
+                     plaintext))
+           (privk-blob (u8vector-append iv ciphertext))
+           (pubk-path-tmp (string-append pubk-path ".tmp"))
+           (privk-path-tmp (string-append privk-path ".tmp")))
+      (when (file-exists? pubk-path-tmp)
+        (delete-file pubk-path-tmp))
+      (when (file-exists? privk-path-tmp)
+        (delete-file privk-path-tmp))
+      (call-with-output-file pubk-path-tmp
+        (lambda (out) (write-subu8vector pubk-bytes 0 (u8vector-length pubk-bytes) out)))
+      (call-with-output-file privk-path-tmp
+        (lambda (out) (write-subu8vector privk-blob 0 (u8vector-length privk-blob) out)))
+      (rename-file pubk-path-tmp pubk-path)
+      (rename-file privk-path-tmp privk-path))))
+
+(def (admin-auth-challenge-sign privk server-id client-id challenge-bytes)
+  (let (challenge
+        (u8vector-append
+         (string->utf8
+          (string-append "[gerbil:ensemble:auth:"
+                         (symbol->string server-id) ":"
+                         (symbol->string client-id) "]"))
+         challenge-bytes))
+    (digest-sign privk challenge)))
+
+(def (admion-auth-challenge-verify pubk server-id client-id challenge-bytes sig)
+  (let (challenge
+        (u8vector-append
+         (string->utf8
+          (string-append "[gerbil:ensemble:auth:"
+                         (symbol->string server-id) ":"
+                         (symbol->string client-id) "]"))
+         challenge-bytes))
+    (digest-verify pubk sig challenge)))
+
+(def salt "gerbil:ensemble:admin")
+(def (passphrase->key pass size)
+  (scrypt pass salt size))
+
+(def privkey-magic
+  (string->utf8 "%privkey/ed25519%"))
+
+(def (make-cipher)
+  (make-aes-256-cfb-cipher))

--- a/src/std/actor-v18/admin.ss
+++ b/src/std/actor-v18/admin.ss
@@ -11,7 +11,7 @@
         get-admin-privkey
         generate-admin-keypair!
         admin-auth-challenge-sign
-        admion-auth-challenge-verify)
+        admin-auth-challenge-verify)
 
 (def (default-admin-pubkey-path)
   (path-expand "admin.pub" (ensemble-base-path)))
@@ -93,7 +93,7 @@
          challenge-bytes))
     (digest-sign privk challenge)))
 
-(def (admion-auth-challenge-verify pubk server-id client-id challenge-bytes sig)
+(def (admin-auth-challenge-verify pubk server-id client-id challenge-bytes sig)
   (let (challenge
         (u8vector-append
          (string->utf8

--- a/src/std/actor-v18/api.ss
+++ b/src/std/actor-v18/api.ss
@@ -87,7 +87,8 @@
                                 registry:  (registry-addrs #f)
                                 roles:     (roles [])
                                 cookie:    (cookie (get-actor-server-cookie))
-                                admin:     (admin (get-admin-pubkey)))
+                                admin:     (admin (get-admin-pubkey))
+                                auth:      (auth #f))
   (current-logger-options log-level)
   (when log-file
     (let (path
@@ -114,6 +115,7 @@
     ;; start the actor server
     (start-actor-server! cookie: cookie
                          admin:  admin
+                         auth: auth
                          addresses: listen-addrs
                          identifier: server-id
                          ensemble: known-servers)

--- a/src/std/actor-v18/api.ss
+++ b/src/std/actor-v18/api.ss
@@ -24,6 +24,7 @@
   defmessage
   message?
   make-handle handle? handle-proxy handle-ref
+  actor-authorized?
   send-message
   -> ->> --> -->?
   <- <<
@@ -137,6 +138,6 @@
       (remove-from-registry! cookie known-servers server-id))))
 
 (def (remove-from-registry! cookie known-servers server-id)
-  (start-actor-server! cookie: cookie ensemble: known-servers)
+  (start-actor-server! cookie: cookie ensemble: known-servers identifier: server-id)
   (with-catch void (cut ensemble-remove-server! server-id))
   (stop-actor-server!))

--- a/src/std/actor-v18/api.ss
+++ b/src/std/actor-v18/api.ss
@@ -86,7 +86,8 @@
                                 announce:  (public-addrs #f)
                                 registry:  (registry-addrs #f)
                                 roles:     (roles [])
-                                cookie:    (cookie (get-actor-server-cookie)))
+                                cookie:    (cookie (get-actor-server-cookie))
+                                admin:     (admin (get-admin-pubkey)))
   (current-logger-options log-level)
   (when log-file
     (let (path
@@ -112,6 +113,7 @@
             listen-addrs)))
     ;; start the actor server
     (start-actor-server! cookie: cookie
+                         admin:  admin
                          addresses: listen-addrs
                          identifier: server-id
                          ensemble: known-servers)

--- a/src/std/actor-v18/api.ss
+++ b/src/std/actor-v18/api.ss
@@ -12,6 +12,7 @@
         ./server
         ./ensemble
         ./cookie
+        ./admin
         ./path
         ./loader)
 (export
@@ -67,6 +68,8 @@
   set-default-registry-addresses!
   server-address-cache-ttl
   set-server-address-cache-ttl!
+  ;; ./admin
+  (import: ./admin)
   ;; ./ensemble
   (import: ./ensemble)
   ;; ./path

--- a/src/std/actor-v18/ensemble.ss
+++ b/src/std/actor-v18/ensemble.ss
@@ -118,6 +118,8 @@
                                 (srv (current-actor-server))
                                 capabilities: (cap '(admin)))
   (let (remote-root (handle srv (reference srv-id 0)))
+    (unless (and (list? cap) (andmap symbol? cap))
+      (error "Bad argument; expected list of symbols" cap))
     (match (->> remote-root (!admin-auth authorized-server-id cap))
       ((!admin-auth-challenge bytes)
        (let (sig (admin-auth-challenge-sign privk srv-id authorized-server-id bytes))

--- a/src/std/actor-v18/ensemble.ss
+++ b/src/std/actor-v18/ensemble.ss
@@ -114,11 +114,11 @@
 
 ;; authorizes the current server for administrative privileges with the given remote server,
 ;; using the administative private key.
-(defcall-actor (admin-authorize privk srv-id (srv (current-actor-server)))
+(defcall-actor (admin-authorize privk srv-id authorized-server-id (srv (current-actor-server)))
   (let (remote-root (handle srv (reference srv-id 0)))
-    (match (->> remote-root (!admin-auth))
+    (match (->> remote-root (!admin-auth authorized-server-id))
       ((!admin-auth-challenge bytes)
-       (let (sig (admin-auth-challenge-sign privk srv-id (actor-server-identifier srv) bytes))
+       (let (sig (admin-auth-challenge-sign privk srv-id authorized-server-id bytes))
          (->> remote-root (!admin-auth-response sig))))
       (result result)))
   error: "error authorizing administrative privileges" srv-id)

--- a/src/std/actor-v18/ensemble.ss
+++ b/src/std/actor-v18/ensemble.ss
@@ -125,4 +125,11 @@
        (let (sig (admin-auth-challenge-sign privk srv-id authorized-server-id bytes))
          (->> remote-root (!admin-auth-response sig))))
       (result result)))
-  error: "error authorizing administrative privileges" srv-id)
+  error: "error authorizing with administrative privileges" srv-id)
+
+;; retract capabilities confered to a server; the current server must be authorized with
+;; admin capabilities
+(defcall-actor (admin-retract srv-id authorized-server-id (srv (current-actor-server)))
+  (let (remote-root (handle srv (reference srv-id 0)))
+    (->> remote-root (!admin-retract authorized-server-id)))
+  error: "error retracting capabilities" srv-id authorized-server-id)

--- a/src/std/actor-v18/ensemble.ss
+++ b/src/std/actor-v18/ensemble.ss
@@ -114,9 +114,11 @@
 
 ;; authorizes the current server for administrative privileges with the given remote server,
 ;; using the administative private key.
-(defcall-actor (admin-authorize privk srv-id authorized-server-id (srv (current-actor-server)))
+(defcall-actor (admin-authorize privk srv-id authorized-server-id
+                                (srv (current-actor-server))
+                                capabilities: (cap '(admin)))
   (let (remote-root (handle srv (reference srv-id 0)))
-    (match (->> remote-root (!admin-auth authorized-server-id))
+    (match (->> remote-root (!admin-auth authorized-server-id cap))
       ((!admin-auth-challenge bytes)
        (let (sig (admin-auth-challenge-sign privk srv-id authorized-server-id bytes))
          (->> remote-root (!admin-auth-response sig))))

--- a/src/std/actor-v18/loader-test-server.ss
+++ b/src/std/actor-v18/loader-test-server.ss
@@ -7,7 +7,7 @@
         :std/actor-v18/loader)
 (export main)
 
-(def (main server-id server-addrs cookie)
+(def (main server-id server-addrs cookie (admin #f))
   (let ((server-id (string->symbol server-id))
         (server-addrs (call-with-input-string server-addrs read))
         (cookie (call-with-input-string cookie read)))
@@ -16,7 +16,8 @@
     (def srv
       (start-actor-server! cookie: cookie
                            identifier: server-id
-                           addresses: server-addrs))
+                           addresses: server-addrs
+                           admin: (and admin (get-admin-pubkey admin))))
     (def loader
       (start-loader!))
 

--- a/src/std/actor-v18/loader-test.ss
+++ b/src/std/actor-v18/loader-test.ss
@@ -185,7 +185,7 @@
 
 
       ;; now auth
-      (check (admin-authorize privk test-server-id srv) => (void))
+      (check (admin-authorize privk test-server-id (actor-server-identifier srv) srv) => (void))
       (check (remote-eval test-server-id '(+ 1 1)) => 2)
       (let (the-code-hash (remote-load-code test-server-id (string-append gerbil-path "/lib/std/actor-v18/loader-test-support__0.o1")))
         (check the-code-hash ? string?))

--- a/src/std/actor-v18/loader-test.ss
+++ b/src/std/actor-v18/loader-test.ss
@@ -197,7 +197,13 @@
       ;; but still can't shut it down
       (check-exception (remote-stop-server! test-server-id)
                        (actor-error-with? "not authorized"))
-      ;; elevate privileges
+      ;; retract capabilities and make sure we cannot eval any longer
+      (check (admin-retract test-server-id (actor-server-identifier srv) srv)
+             => (void))
+      (check-exception (remote-eval test-server-id '(+ 1 1))
+                       (actor-error-with? "not authorized"))
+
+      ;; grant shutdown capability
       (check (admin-authorize privk test-server-id (actor-server-identifier srv) srv
                               capabilities: '(shutdown))
              => (void))

--- a/src/std/actor-v18/loader-test.ss
+++ b/src/std/actor-v18/loader-test.ss
@@ -11,8 +11,9 @@
         ./server
         ./ensemble
         ./cookie
+        ./admin
         "test-util")
-(export loader-test test-setup! test-cleanup!)
+(export loader-test loader-auth-test test-setup! test-cleanup!)
 
 (extern namespace: #f this-source-file)
 
@@ -57,6 +58,13 @@
                       (object->string [server-addr])
                       (object->string cookie)]]))
 
+(def (start-test-server/admin! server-id server-addr cookie pubk-path)
+  (open-process
+   [path: (path-expand "bin/loader-test-server" gerbil-path)
+          arguments: [(symbol->string server-id)
+                      (object->string [server-addr])
+                      (object->string cookie)
+                      pubk-path]]))
 (def loader-test
   (test-suite "actor loader"
     (test-case "remote library loading and evaluation"
@@ -95,8 +103,6 @@
       ;; clean up
       (delete-file test-server-sock))
 
-    (def code-hash #f)
-
     (test-case "remote code loading and evaluation"
       (def cookie
         (make-random-cookie))
@@ -122,9 +128,7 @@
              => 'OK)
       ;; load the loader-test-support module
       (let (the-code-hash (remote-load-code test-server-id (string-append gerbil-path "/lib/std/actor-v18/loader-test-support__0.o1")))
-        (check the-code-hash ? string?)
-        ;; for the next t4est
-        (set! code-hash the-code-hash))
+        (check the-code-hash ? string?))
       ;; eval hello
       (check (remote-eval test-server-id '(std/actor-v18/loader-test-support#hello 'world))
              => '(hello . world))
@@ -134,3 +138,65 @@
         (displayln (read-line test-server-process #f)))
       ;; clean up
       (delete-file test-server-sock))))
+
+(def loader-auth-test
+  (test-suite "loader administrative privileges"
+    (test-case "remote code loading and evaluation"
+      (def pubk-path
+        (make-temporary-file-name "pubk"))
+      (def privk-path
+        (make-temporary-file-name "privk"))
+      (def passphrase
+        "oh so secret")
+
+      (generate-admin-keypair! passphrase pubk-path privk-path)
+
+      (def privk
+        (get-admin-privkey passphrase privk-path))
+
+      (def cookie
+        (make-random-cookie))
+      (def test-server-id
+        (make-random-identifier))
+      (def test-server-sock
+        (make-temporary-file-name "test-server-sock"))
+      (def test-server-addr
+        [unix: (hostname) test-server-sock])
+      (def test-server-process
+        (start-test-server/admin! test-server-id test-server-addr cookie pubk-path))
+      (def srv
+        (start-actor-server! cookie: cookie))
+
+      ;; wait for the server to be ready
+      (thread-sleep! 1)
+
+      ;; connect
+      (check (connect-to-server! test-server-id [test-server-addr])
+             => [test-server-addr])
+      ;; ping it
+      (check (ping-server test-server-id)
+             => 'OK)
+
+      ;; first try loading without auth; this should fail
+      (check-exception (remote-eval test-server-id '(+ 1 1))
+                       (actor-error-with? "not authorized"))
+      (check-exception (remote-load-code test-server-id (string-append gerbil-path "/lib/std/actor-v18/loader-test-support__0.o1"))
+                       (actor-error-with? "not authorized"))
+
+
+      ;; now auth
+      (check (admin-authorize privk test-server-id srv) => (void))
+      (check (remote-eval test-server-id '(+ 1 1)) => 2)
+      (let (the-code-hash (remote-load-code test-server-id (string-append gerbil-path "/lib/std/actor-v18/loader-test-support__0.o1")))
+        (check the-code-hash ? string?))
+      ;; eval hello
+      (check (remote-eval test-server-id '(std/actor-v18/loader-test-support#hello 'world))
+             => '(hello . world))
+      ;; and shut it down
+      (remote-stop-server! test-server-id)
+      (unless (zero? (process-status test-server-process))
+        (displayln (read-all test-server-process)))
+      ;; clean up
+      (delete-file test-server-sock)
+      (delete-file pubk-path)
+      (delete-file privk-path))))

--- a/src/std/actor-v18/loader.ss
+++ b/src/std/actor-v18/loader.ss
@@ -34,54 +34,61 @@
     (while #t
       (<-
        ((!load-library-module id)
-        ;; don't try to load if the library loader is not initialized
-        ;; cf static binaries
-        (if (&current-module-registry)
-          (begin
-            (infof "loading library module ~a" id)
-            (background
-             'load-library-module
-             (cut load-module id)
-             (lambda (result) (--> (!ok result)))
-             (lambda (exn)
-               (warnf "error loading library module: ~a" exn)
-               (--> (!error (error-message exn))))))
-          (--> (!error "process does not support library loading"))))
+        (if (actor-authorized? @source)
+          ;; don't try to load if the library loader is not initialized
+          ;; cf static binaries
+          (if (&current-module-registry)
+            (begin
+              (infof "loading library module ~a" id)
+              (background
+               'load-library-module
+               (cut load-module id)
+               (lambda (result) (--> (!ok result)))
+               (lambda (exn)
+                 (warnf "error loading library module: ~a" exn)
+                 (--> (!error (error-message exn))))))
+            (--> (!error "process does not support library loading")))
+          (--> (!error "not authorized"))))
 
        ((!load-code code linker)
-        (let (code-hash (hex-encode (sha256 code)))
-          (infof "loading code; hash: ~a" code-hash)
-          (cond
-           ((hash-get loaded code-hash)
-            => (lambda (state)
-                 (infof "code already ~a [~a]" state code-hash)
-                 (--> (!ok state))))
-           (else
-            (hash-put! loaded code-hash 'loading)
-            (let (code-path (path-expand (string-append code-hash ".o1") path))
-              (unless (file-exists? code-path)
-                (call-with-output-file code-path
-                  (lambda (out) (write-subu8vector code 0 (u8vector-length code) out))))
-              (background
-               'load-code
-               (cut ##load code-path void #f #f linker #f)
-               (lambda (_)
-                 (hash-put! loaded code-hash 'loaded)
-                 (--> (!ok code-hash)))
-               (lambda (exn)
-                 (warnf "error loading code [~a]: ~a" code-hash exn)
-                 (hash-put! loaded code-hash 'load-error)
-                 (--> (!error (error-message exn))))))))))
+        (if (actor-authorized? @source)
+          (let (code-hash (hex-encode (sha256 code)))
+            (infof "loading code; hash: ~a" code-hash)
+            (cond
+             ((hash-get loaded code-hash)
+              => (lambda (state)
+                   (infof "code already ~a [~a]" state code-hash)
+                   (--> (!ok state))))
+             (else
+              (hash-put! loaded code-hash 'loading)
+              (let (code-path (path-expand (string-append code-hash ".o1") path))
+                (unless (file-exists? code-path)
+                  (call-with-output-file code-path
+                    (lambda (out) (write-subu8vector code 0 (u8vector-length code) out))))
+                (background
+                 'load-code
+                 (cut ##load code-path void #f #f linker #f)
+                 (lambda (_)
+                   (hash-put! loaded code-hash 'loaded)
+                   (--> (!ok code-hash)))
+                 (lambda (exn)
+                   (warnf "error loading code [~a]: ~a" code-hash exn)
+                   (hash-put! loaded code-hash 'load-error)
+                   (--> (!error (error-message exn)))))))))
+          (--> (!error "not authorized"))))
 
        ((!eval expr)
-        (infof "eval ~a" expr)
-        (background
-         'eval
-         (cut eval expr)
-         (lambda (result) (--> (!ok result)))
-         (lambda (exn)
-           (warnf "error evaluating ~a: ~a" expr exn)
-           (--> (!error (error-message exn))))))
+        (if (actor-authorized? @source)
+          (begin
+            (infof "eval ~a" expr)
+            (background
+             'eval
+             (cut eval expr)
+             (lambda (result) (--> (!ok result)))
+             (lambda (exn)
+               (warnf "error evaluating ~a: ~a" expr exn)
+               (--> (!error (error-message exn))))))
+          (--> (!error "not authorized"))))
 
        ((!continue thunk)
         (thunk))

--- a/src/std/actor-v18/loader.ss
+++ b/src/std/actor-v18/loader.ss
@@ -34,7 +34,7 @@
     (while #t
       (<-
        ((!load-library-module id)
-        (if (actor-authorized? @source)
+        (if (actor-authorized? @source 'loader)
           ;; don't try to load if the library loader is not initialized
           ;; cf static binaries
           (if (&current-module-registry)
@@ -51,7 +51,7 @@
           (--> (!error "not authorized"))))
 
        ((!load-code code linker)
-        (if (actor-authorized? @source)
+        (if (actor-authorized? @source 'loader)
           (let (code-hash (hex-encode (sha256 code)))
             (infof "loading code; hash: ~a" code-hash)
             (cond
@@ -78,7 +78,7 @@
           (--> (!error "not authorized"))))
 
        ((!eval expr)
-        (if (actor-authorized? @source)
+        (if (actor-authorized? @source 'loader)
           (begin
             (infof "eval ~a" expr)
             (background

--- a/src/std/actor-v18/message.ss
+++ b/src/std/actor-v18/message.ss
@@ -63,8 +63,27 @@
 ;; actor handle base type.
 ;; - proxy is the thread that handles messages on behalf of another actor.
 ;; - ref is a reference to an actor; see ./server
-(defstruct handle (proxy ref)
-  unchecked: #t final: #t transparent: #t)
+;; - authorized? is a boolean indicating whether the origin is authorized for
+;;   for administrative actions.
+(defstruct handle (proxy ref authorized?)
+  unchecked: #t final: #t transparent: #t
+  constructor: :init!)
+
+(defmethod {:init! handle}
+  (lambda (self proxy ref (authorized? #f))
+    (set! (&handle-proxy self) proxy)
+    (set! (&handle-ref self) ref)
+    (set! (&handle-authorized? self) authorized?)))
+
+;; checks whether an actor is authorized for administrative actions.
+;; Local (in-process) actors are always authorized.
+;; Remote actors are authorized by the actor server (see ./server) if configured
+;; to require authorization for administrative actions.
+(def (actor-authorized? actor)
+  (cond
+   ((thread? actor) #t)
+   ((handle? actor) (&handle-authorized? actor))
+   (else #f)))
 
 ;; sends a message to an actor
 ;; - actor must be a thread or handle

--- a/src/std/actor-v18/proto.ss
+++ b/src/std/actor-v18/proto.ss
@@ -75,7 +75,7 @@
 (defmessage !eval (expr))
 (defmessage !continue (thunk))
 
-(defmessage !admin-auth ())
+(defmessage !admin-auth (server))
 (defmessage !admin-auth-challenge (bytes))
 (defmessage !admin-auth-response (sig))
 

--- a/src/std/actor-v18/proto.ss
+++ b/src/std/actor-v18/proto.ss
@@ -43,7 +43,7 @@
 ;; reaction macro for shutdown
 (defrule (@shutdown exit ...)
   ((!shutdown)
-   (if (actor-authorized? @source)
+   (if (actor-authorized? @source 'shutdown)
      (begin
        (-->? (!ok (void)))
        exit ...)
@@ -75,7 +75,7 @@
 (defmessage !eval (expr))
 (defmessage !continue (thunk))
 
-(defmessage !admin-auth (server))
+(defmessage !admin-auth (server capabilities))
 (defmessage !admin-auth-challenge (bytes))
 (defmessage !admin-auth-response (sig))
 

--- a/src/std/actor-v18/proto.ss
+++ b/src/std/actor-v18/proto.ss
@@ -78,6 +78,7 @@
 (defmessage !admin-auth (server capabilities))
 (defmessage !admin-auth-challenge (bytes))
 (defmessage !admin-auth-response (sig))
+(defmessage !admin-retract (server))
 
 ;; utilities
 (def (actor-monitor actor peer (sendto ->))

--- a/src/std/actor-v18/proto.ss
+++ b/src/std/actor-v18/proto.ss
@@ -43,8 +43,11 @@
 ;; reaction macro for shutdown
 (defrule (@shutdown exit ...)
   ((!shutdown)
-   (-->? (!ok (void)))
-   exit ...))
+   (if (actor-authorized? @source)
+     (begin
+       (-->? (!ok (void)))
+       exit ...)
+     (-->? (!error "not authorized")))))
 
 ;; package private
 (defmessage !register (name))
@@ -72,6 +75,11 @@
 (defmessage !eval (expr))
 (defmessage !continue (thunk))
 
+(defmessage !admin-auth ())
+(defmessage !admin-auth-challenge (bytes))
+(defmessage !admin-auth-response (sig))
+
+;; utilities
 (def (actor-monitor actor peer (sendto ->))
   (with-catch void (cut thread-join! actor))
   (sendto peer (!actor-dead actor)))

--- a/src/std/actor-v18/registry.ss
+++ b/src/std/actor-v18/registry.ss
@@ -42,7 +42,7 @@
   (def (authorized-for? actor server-id)
     (or (actor-authorized? actor)
         (and (handle? actor)
-             (eq? (reference-server actor) server-id))))
+             (eq? (reference-server (handle-ref actor)) server-id))))
 
   (def (sort-server-list lst)
     (sort lst (lambda (a b) (symbol<? (car a) (car b)))))

--- a/src/std/actor-v18/registry.ss
+++ b/src/std/actor-v18/registry.ss
@@ -39,6 +39,11 @@
   (register-actor! 'registry srv)
   (infof "starting registry ...")
 
+  (def (authorized-for? actor server-id)
+    (or (actor-authorized? actor)
+        (and (handle? actor)
+             (eq? (reference-server actor) server-id))))
+
   (def (sort-server-list lst)
     (sort lst (lambda (a b) (symbol<? (car a) (car b)))))
   (def flush-ticker
@@ -48,14 +53,20 @@
     (while #t
       (<-
        ((!ensemble-add-server id addrs roles)
-        (infof "adding server ~a ~a at ~a" id roles addrs)
-        (&Registry-add-server registry id addrs roles)
-        (--> (!ok (void))))
+        (if (authorized-for? @source id)
+          (begin
+            (infof "adding server ~a ~a at ~a" id roles addrs)
+            (&Registry-add-server registry id addrs roles)
+            (--> (!ok (void))))
+          (--> (!error "not authorized"))))
 
        ((!ensemble-remove-server id)
-        (infof "removing server ~a" id)
-        (&Registry-remove-server registry id)
-        (--> (!ok (void))))
+        (if (authorized-for? @source id)
+          (begin
+            (infof "removing server ~a" id)
+            (&Registry-remove-server registry id)
+            (--> (!ok (void))))
+          (--> (!error "not authorized"))))
 
        ((!ensemble-lookup-server id role)
         (cond

--- a/src/std/actor-v18/server-test.ss
+++ b/src/std/actor-v18/server-test.ss
@@ -339,7 +339,8 @@
                        (actor-error-with? "not authorized"))
 
       ;; now authorize administrative privileges and try again
-      (check (admin-authorize privk remote-srv-id local-srv) => (void))
+      (check (admin-authorize privk remote-srv-id (actor-server-identifier local-srv) local-srv)
+             => (void))
       (check (remote-stop-server! remote-srv-id local-srv) => (void))
       (check (thread-join! remote-srv) => 'shutdown)
 

--- a/src/std/actor-v18/server-test.ss
+++ b/src/std/actor-v18/server-test.ss
@@ -101,9 +101,11 @@
       (def cookie (make-random-cookie))
       (def srv1
         (start-actor-server! cookie: cookie
+                             admin: #f
                              addresses: [addr1]))
       (def srv2
         (start-actor-server! cookie: cookie
+                             admin: #f
                              addresses: [addr2]))
 
       (def srv1-id
@@ -178,11 +180,13 @@
         (def cookie (make-random-cookie))
         (def srv1
           (start-actor-server! cookie: cookie
+                               admin: #f
                                addresses: [addr1]))
         (def srv1-id
           (actor-server-identifier srv1))
         (def srv2
           (start-actor-server! cookie: cookie
+                               admin: #f
                                addresses: []
                                ensemble: (hash-eq (,srv1-id [addr1]))))
         (def srv2-id
@@ -225,9 +229,9 @@
 
       (def cookie (make-random-cookie))
       (def srv1
-        (start-actor-server! cookie: cookie))
+        (start-actor-server! cookie: cookie admin: #f))
       (def srv2
-        (start-actor-server! cookie: cookie))
+        (start-actor-server! cookie: cookie admin: #f))
 
       (def srv1-id
         (actor-server-identifier srv1))
@@ -248,9 +252,9 @@
 
       (def cookie (make-random-cookie))
       (def srv1
-        (start-actor-server! cookie: cookie))
+        (start-actor-server! cookie: cookie admin: #f))
       (def srv2
-        (start-actor-server! cookie: cookie))
+        (start-actor-server! cookie: cookie admin: #f))
 
       (def srv1-id
         (actor-server-identifier srv1))
@@ -278,13 +282,15 @@
         (def cookie1 (make-random-cookie))
         (def srv1
           (start-actor-server! cookie: cookie1
+                               admin: #f
                                addresses: [addr1]))
         (def srv1-id
           (actor-server-identifier srv1))
 
         (def cookie2 (make-random-cookie))
         (def srv2
-          (start-actor-server! cookie: cookie2))
+          (start-actor-server! cookie: cookie2
+                               admin: #f))
         (def srv2-id
           (actor-server-identifier srv2))
 
@@ -332,6 +338,7 @@
 
       (def local-srv
         (start-actor-server! cookie: cookie
+                             admin: #f
                              ensemble: (hash (,remote-srv-id [remote-addr]))))
 
       ;; try to shutdown remote-srv without authorization first; this should fail

--- a/src/std/actor-v18/server.ss
+++ b/src/std/actor-v18/server.ss
@@ -660,7 +660,7 @@
                           (hash-remove! pending-admin-auth src-id)
                           (if (admin-auth-challenge-verify admin id authorized-server-id bytes sig)
                             (begin
-                              (infof "admin privileges authorized for ~a" authorized-server-id)
+                              (infof "admin privileges authorized for ~a; capabilities: ~a" authorized-server-id cap)
                               (hash-update! admin-auth authorized-server-id
                                             (lambda (existing-cap)
                                               (cons (if (eq? src-id authorized-server-id)

--- a/src/std/actor-v18/server.ss
+++ b/src/std/actor-v18/server.ss
@@ -447,14 +447,15 @@
       (lambda (srv-id)
         #t)))
 
-  (def is-admin?
+  (def is-retract-authorized?
     (if admin
-      (lambda (srv-id)
+      (lambda (srv-id authorized-server-id)
         (cond
+         ((eq? srv-id authorized-server-id))
          ((hash-get admin-auth srv-id)
           => (lambda (state) (memq 'admin (cdr state))))
          (else #f)))
-      (lambda (srv-id)
+      (lambda (srv-id authorized-server-id)
         #t)))
 
   (def actor-capabilities
@@ -697,7 +698,7 @@
                    (send-remote-control-reply! src-id msg (!error "unexpected auth response")))))
 
                 ((!admin-retract authorized-server-id)
-                 (if (is-admin? src-id)
+                 (if (is-retract-authorized? src-id authorized-server-id)
                    (begin
                      (infof "capabilities retracted for ~a from ~a" authorized-server-id src-id)
                      (hash-remove! admin-auth authorized-server-id)

--- a/src/std/actor-v18/server.ss
+++ b/src/std/actor-v18/server.ss
@@ -615,7 +615,11 @@
                  ;; update our known address mapping
                  (hash-remove! server-addrs srv-id)
                  ;; and our authorization table
-                 (hash-remove! admin-auth srv-id)
+                 (cond
+                  ((hash-get admin-auth srv-id)
+                   => (lambda (state)
+                        (when (eq? (car state) 'connected)
+                          (hash-remove! admin-auth srv-id)))))
                  (hash-remove! pending-admin-auth srv-id)
                  ;; update the registry
                  (send-to-registry! actor-id msg))

--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -320,6 +320,7 @@
     (gxc: "actor-v18/message" ,@(include-gambit-sharp))
     (gxc: "actor-v18/io" ,@(include-gambit-sharp))
     "actor-v18/cookie"
+    "actor-v18/admin"
     "actor-v18/logger"
     "actor-v18/path"
     "actor-v18/proto"

--- a/src/std/crypto/kdf.ss
+++ b/src/std/crypto/kdf.ss
@@ -2,7 +2,8 @@
 ;;; © vyzo
 ;;; Key Derivation functions
 
-(import ./libcrypto
+(import :gerbil/gambit/foreign
+        ./libcrypto
         ./etc)
 (export scrypt)
 
@@ -10,14 +11,17 @@
   (let (pctx (EVP_PKEY_CTX_new_id EVP_PKEY_SCRYPT #f))
     (unless pctx
       (error "Cannot create SCRYPT key context"))
-    (with-libcrypto-error (EVP_PKEY_derive_init pctx))
-    (with-libcrypto-error (EVP_PKEY_CTX_set1_pbe_pass pctx (as-bytes pass)))
-    (with-libcrypto-error (EVP_PKEY_CTX_set1_scrypt_salt pctx (as-bytes salt)))
-    (with-libcrypto-error (EVP_PKEY_CTX_set_scrypt_N pctx N))
-    (with-libcrypto-error (EVP_PKEY_CTX_set_scrypt_r pctx r))
-    (with-libcrypto-error (EVP_PKEY_CTX_set_scrypt_p pctx p))
-    (let* ((output (make-u8vector size))
-           (outlen (with-libcrypto-error (EVP_PKEY_derive pctx output))))
-      (when (< outlen size)
-        (u8vector-shrink! output outlen))
-      output)))
+    (unwind-protect
+      (begin
+        (with-libcrypto-error (EVP_PKEY_derive_init pctx))
+        (with-libcrypto-error (EVP_PKEY_CTX_set1_pbe_pass pctx (as-bytes pass)))
+        (with-libcrypto-error (EVP_PKEY_CTX_set1_scrypt_salt pctx (as-bytes salt)))
+        (with-libcrypto-error (EVP_PKEY_CTX_set_scrypt_N pctx N))
+        (with-libcrypto-error (EVP_PKEY_CTX_set_scrypt_r pctx r))
+        (with-libcrypto-error (EVP_PKEY_CTX_set_scrypt_p pctx p))
+        (let* ((output (make-u8vector size))
+               (outlen (with-libcrypto-error (EVP_PKEY_derive pctx output))))
+          (when (< outlen size)
+            (u8vector-shrink! output outlen))
+          output))
+      (foreign-release! pctx))))

--- a/src/std/crypto/libcrypto.ss
+++ b/src/std/crypto/libcrypto.ss
@@ -707,7 +707,7 @@ static int ffi_RAND_bytes (___SCMOBJ bytes, int start, int end)
 END-C
 )
 (c-define-type EVP_PKEY "EVP_PKEY")
-(c-define-type EVP_PKEY* (pointer EVP_PKEY (EVP_PKEY*)))
+(c-define-type EVP_PKEY* (pointer EVP_PKEY (EVP_PKEY*) "ffi_release_EVP_PKEY"))
 (c-define-type EVP_PKEY_CTX "EVP_PKEY_CTX")
 (c-define-type EVP_PKEY_CTX* (pointer EVP_PKEY_CTX (EVP_PKEY_CTX*) "ffi_release_EVP_PKEY_CTX"))
 

--- a/src/std/crypto/libcrypto.ss
+++ b/src/std/crypto/libcrypto.ss
@@ -121,6 +121,7 @@ END-C
 END-C
 )
 
+
 ;; funky decls to apease the compiler for discarding const
 ;; sometimes I really hate gcc (which apparently has no working option to turn
 ;;  that shit off -- -Wno-cast-qual doesn't fucking work, at least with 4.5.x)
@@ -168,7 +169,11 @@ END-C
 (c-declare #<<END-C
 static ___SCMOBJ ffi_release_EVP_MD_CTX (void *ptr)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   EVP_MD_CTX_destroy ((EVP_MD_CTX*)ptr); /* NB: renamed _free in 1.1.0 */
+#else
+  EVP_MD_CTX_free ((EVP_MD_CTX*)ptr);
+#endif
   return ___FIX (___NO_ERR);
 }
 
@@ -547,7 +552,7 @@ static ___SCMOBJ ffi_release_EVP_PKEY_CTX (void *ptr)
   return ___FIX (___NO_ERR);
 }
 static EVP_PKEY* ffi_EVP_PKEY_keygen (EVP_PKEY_CTX* ctx) {
-  EVP_PKEY* pkey = NULL; // NB: not initializing this variable leads to occasional segfaults
+  EVP_PKEY* pkey = NULL;
   if (EVP_PKEY_keygen(ctx, &pkey) == 1) {
     return pkey;
   } else {

--- a/src/std/crypto/pkey.ss
+++ b/src/std/crypto/pkey.ss
@@ -4,18 +4,14 @@
 
 (import :gerbil/gambit/bytes
         :gerbil/gambit/foreign
-        :std/crypto/libcrypto
-        :std/crypto/etc
-        (for-syntax :std/stxutil))
+        ./libcrypto
+        ./etc)
 
 (export
   keygen/ed25519 EVP_PKEY_ED25519
   bytes->private-key bytes->public-key
   private-key->bytes public-key->bytes
   digest-sign digest-verify)
-
-(import :gerbil/gambit/ports);;DBG
-
 ;; NB: for other key types, there may be parameters to set before keygen
 (def (keygen/ed25519)
   (def ctx (EVP_PKEY_CTX_new_id EVP_PKEY_ED25519 #f))
@@ -39,7 +35,9 @@
   (cond
    ((zero? len) #f)
    ((= len (bytes-length bytes)) bytes)
-   ((< len (bytes-length bytes)) (subu8vector bytes 0 len))
+   ((< len (bytes-length bytes))
+    (u8vector-shrink! bytes len)
+    bytes)
    (else #f)))
 
 (def (key->bytes pkey bytes get_raw)

--- a/src/std/net/httpd-test.ss
+++ b/src/std/net/httpd-test.ss
@@ -133,6 +133,7 @@
         [unix: (hostname) httpd-actor-server-sock])
       (def httpd-actor-server
         (start-actor-server! cookie: cookie
+                             admin: #f
                              addresses: [httpd-actor-server-addr]))
       (def httpd-actor-server-id
         (actor-server-identifier httpd-actor-server))

--- a/src/std/net/httpd/server.ss
+++ b/src/std/net/httpd/server.ss
@@ -57,12 +57,15 @@
       (while #t
         (<-
          ((!register-handler host path handler)
-          (infof "registering handler in host ~a: ~a" (or host '(any)) path)
-          (try
-           (put-handler! mux host path handler)
-           (--> (!ok (void)))
-           (catch (e)
-             (--> (!error (error-message e))))))
+          (if (actor-authorized? @source)
+            (begin
+              (infof "registering handler in host ~a: ~a" (or host '(any)) path)
+              (try
+               (put-handler! mux host path handler)
+               (--> (!ok (void)))
+               (catch (e)
+                 (--> (!error (error-message e))))))
+            (--> (!error "not authorized"))))
 
          ((!actor-dead thread)
           (try

--- a/src/tools/gxensemble.ss
+++ b/src/tools/gxensemble.ss
@@ -209,6 +209,13 @@
       capabilities-optional-argument
       help: "authorize capabilities for a server"))
 
+  (def retract-cmd
+    (command 'retract
+      registry-option
+      server-id-argument
+      authorized-server-id-argument
+      help: "retract all capabilities granted to a server"))
+
   (def cookie-cmd
     (command 'cookie
       force-flag
@@ -235,6 +242,7 @@
     list-connections-cmd
     lookup-cmd
     authorize-cmd
+    retract-cmd
     cookie-cmd
     admin-cmd))
 
@@ -252,6 +260,7 @@
           (list-connections do-list-connections)
           (lookup           do-lookup)
           (authorize        do-authorize)
+          (retract          do-retract)
           (cookie           do-cookie)
           (admin            do-admin)))
   (cond
@@ -277,6 +286,13 @@
         (capabilities (hash-ref opt 'capabilities)))
     (admin-authorize (get-privkey) server-id authorized-server-id
                      capabilities: capabilities)))
+
+(def (do-retract opt)
+  (start-actor-server-with-options! opt)
+  (let ((server-id (hash-ref opt 'server-id))
+        (authorized-server-id (hash-ref opt 'authorized-server-id)))
+    (maybe-authorize! server-id)
+    (admin-retract server-id authorized-server-id)))
 
 (def (do-lookup opt)
   (start-actor-server-with-options! opt)

--- a/src/tools/gxensemble.ss
+++ b/src/tools/gxensemble.ss
@@ -675,4 +675,4 @@
       (let* ((passphrase (read-password prompt: "Enter passphrase: "))
              (privk (get-admin-privkey passphrase)))
         (set! +admin-privkey+ privk)))
-    (admin-authorize +admin-privkey+ server-id)))
+    (admin-authorize +admin-privkey+ server-id (actor-server-identifier))))


### PR DESCRIPTION
This adds support for (optionally) restricting administrative actions from remote actors to servers authorized using an Ed25519 key pair.

This came up in discussions with @belmarca and I think it is quite a useful addition.

Edit: After discussion with @fare, I added fine-grained capabilities besides admin (admin implies everything else) and the ability for a server to delegate capabilities, provided it can prove it has the administrative private key.