### PR TITLE
libgerbil as a shared library

### DIFF
--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -134,10 +134,13 @@ alternatively, you could symlink the installed `gxi` and `gxc` binaries
 into a directory already in your `$PATH`.
 You may also define `GERBIL_HOME`, or leave it undefined (or unexported)
 and let Gerbil autodetect where it was installed.
+
 I (vyzo) have the following in my `.bashrc`:
 ```
 export GERBIL_HOME=$HOME/gerbil
 add_path $GERBIL_HOME/bin
+add_ldpath $GERBIL_HOME/lib
+add_path $HOME/.gerbil/bin
 ```
 
 ## Write some code

--- a/doc/guide/intro.md
+++ b/doc/guide/intro.md
@@ -806,21 +806,23 @@ hello world
 
 The difference between the 3 executable compilation modes can be summarized as follows:
 - By default, a statically linked executable is generated, linking to the precompiled
-  gerbil standard library. Note that the executable may some have dynamic library
-  dependencies from stdlib foreign code , and also links to `libgambit`.
-  If you have configured your   gambit with `--enable-shared`, then this will be
-  a dynamic library dependency.
+  gerbil standard library. If the system was configured with `--enable-shared`, then this
+  will be a shared library; otherwise it will be a static library archive.
+  Note that the executable may some have additionl dynamic library
+  dependencies from stdlib foreign code , and also links to `libgambit` which will be
+  a shared library when the system is configured with `--enable-shared`.
 - When `-full-program-optimization` is passed to `gxc`, then the compiler will perform
   full program optimization with all gerbil library dependencies. This will result
-  both in smaller executable size and better performance, albeit at the cost of
-  increased compilation time; this can be minutes for complex programs, while
+  both in better performance, albeit at the cost of increased compilation time;
+  this can be minutes for complex programs, while
   separately linked executables compile in a second. Furthermore, because
   dependencies are compiled in together, you can apply declarations like `(not safe)`
   to the whole program using the `-prelude` directive. This can result
   in potentially significant performance gains at the expense of safety.
 - When `-dynamic` is passed to `gxc`, then a dynamic executable stub will be generated,
   which will depend on the Gerbil runtime environment being present at execution time.
-  Dynamic executables do have some advantages over static executables however:
+  Dynamic executables are very useful for development and do have some advantages over
+  static executables:
   - they compile instantly and are tiny
   - they can use the expander and the compiler; note that this restriction will be
     lifted from static executables in a future release.

--- a/src/build/build-libgerbil.ss
+++ b/src/build/build-libgerbil.ss
@@ -72,11 +72,14 @@
     ([static-include: modf]
      #f)))
 
-(def (fold-cc-options stdlib-spec)
-  (let (base (string-append "-D___LIBRARY -I " (gerbil-static-dir)))
+(def (fold-cc-options stdlib-spec mode)
+  (let* ((base (if (eq? mode 'shared)
+                 "-D___SHARED"
+                 "-D___LIBRARY"))
+         (base (string-append base " -I " (gerbil-static-dir))))
     (fold-options "-cc-options" stdlib-spec base)))
 
-(def (fold-ld-options stdlib-spec)
+(def (fold-ld-options stdlib-spec mode)
   (let (base default-ld-options)
     (fold-options "-ld-options" stdlib-spec base)))
 
@@ -216,16 +219,28 @@
   (static-module-file f ".o"))
 
 (def +gerbil-home+ #f)
+
+(def +gerbil-lib-dir+ #f)
+(def (gerbil-lib-dir)
+  (if +gerbil-lib-dir+
+    +gerbil-lib-dir+
+    (let (lib-dir (path-expand "lib" +gerbil-home+))
+      (set! +gerbil-lib-dir+ lib-dir)
+      lib-dir)))
+
 (def +gerbil-static-dir+ #f)
 (def (gerbil-static-dir)
   (if +gerbil-static-dir+
     +gerbil-static-dir+
-    (let (static-dir (path-expand "lib/static" +gerbil-home+))
+    (let (static-dir (path-expand "static" (gerbil-lib-dir)))
       (set! +gerbil-static-dir+ static-dir)
       static-dir)))
 
 (def (invoke-gsc args)
   (invoke-process default-gerbil-gsc args))
+
+(def (invoke-gcc args)
+  (invoke-process default-gerbil-gcc args))
 
 (def (invoke-ar args)
   (invoke-process default-gerbil-ar args))
@@ -241,70 +256,97 @@
       (displayln "process " program " exited with non-zero status " status)
       (error "error executing process" program status))))
 
-(def (main)
+(def (build-libgerbil mode)
+  (let* ((build-spec (build-spec))
+         (stdlib-spec (filter-map filter-build-spec build-spec))
+         (cc-options (fold-cc-options stdlib-spec mode))
+         (ld-options (fold-ld-options stdlib-spec mode))
+         (stdlib-modules (map car stdlib-spec))
+         (all-modules (append gerbil-prelude-gambit stdlib-modules))
+         (ordered-modules (order-modules all-modules))
+         (static-module-scm-files (map static-module-scm-file ordered-modules))
+         (static-module-scm-paths (map static-file-path static-module-scm-files))
+         (static-module-c-paths   (map static-module-c-file static-module-scm-paths))
+         (static-module-o-paths   (map static-module-o-file static-module-c-paths))
+         (gx-gambc-scm-files (map static-module-scm-file gerbil-runtime))
+         (gx-gambc-scm-paths (map static-file-path gx-gambc-scm-files))
+         (gx-gambc-c-paths   (map static-module-c-file gx-gambc-scm-paths))
+         (gx-gambc-o-paths   (map static-module-o-file gx-gambc-c-paths))
+         (link-c-path (static-file-path "gxlink.c"))
+         (link-o-path (static-module-o-file link-c-path))
+         (gx-gambc-macros (static-file-path "gx-gambc#.scm"))
+         (include-gx-gambc-macros (string-append "(include \"" gx-gambc-macros "\")"))
+         (gsc-gx-macros
+          (if (gerbil-runtime-smp?)
+            ["-e" "(define-cond-expand-feature|enable-smp|)"
+             "-e" include-gx-gambc-macros]
+            ["-e" include-gx-gambc-macros]))
+         (gsc-gx-features
+          '("-e" "(define-cond-expand-feature|gerbil-separate-compilation|)"))
+         (libgerbil
+          (if (eq? mode 'shared)
+            (path-expand "libgerbil.so" (gerbil-lib-dir))
+            (path-expand "libgerbil.a"  (gerbil-lib-dir)))))
+    ;; compile each .scm to .c separately to avoid using too much memory
+    (for (scm-path [gx-gambc-scm-paths ... static-module-scm-paths ...])
+      (displayln "... compile " scm-path)
+      (invoke-gsc [gsc-runtime-opts
+                   ... "-c"
+                   gsc-debug-opts ...
+                   gsc-gx-macros ...
+                   gsc-gx-features ...
+                   scm-path]))
+    ;; link them
+    (displayln "... link " link-c-path)
+    (invoke-gsc [gsc-runtime-opts
+                 ... "-link" "-o" link-c-path
+                 gx-gambc-c-paths ...
+                 static-module-c-paths ...])
+    ;; build them
+    (for (c-path [gx-gambc-c-paths ... static-module-c-paths ... link-c-path])
+      (displayln "... compile " c-path)
+      (invoke-gsc [gsc-runtime-opts
+                   ... "-obj"
+                   "-cc-options" cc-options
+                   c-path]))
+    ;; and collect them
+    (when (file-exists? libgerbil)
+      (delete-file libgerbil))
+    (displayln "... build " libgerbil)
+    (if (eq? mode 'shared)
+      (let (shared-ld-opts  (filter (? (not string-empty?)) (string-split ld-options #\space)))
+        (invoke-gcc ["-shared" "-o" libgerbil
+                     shared-ld-opts ...
+                     gx-gambc-o-paths ...
+                     static-module-o-paths ...
+                     link-o-path])
+        (call-with-output-file (string-append libgerbil ".link")
+          (cut write shared-ld-opts <>)))
+      (invoke-ar ["cql" ld-options
+                  libgerbil
+                  gx-gambc-o-paths ...
+                  static-module-o-paths ...
+                  link-o-path]))
+    ;; cleanup
+    (for (f [gx-gambc-c-paths ... static-module-c-paths ...
+                              gx-gambc-o-paths ... static-module-o-paths ...])
+      (delete-file f))))
+
+(def (auto-build-mode)
+  (if (member "--enable-shared" (string-split (configure-command-string) #\'))
+    'shared
+    'library))
+
+(def (main . args)
   (let (gerbil-home (getenv "GERBIL_HOME" default-gerbil-home))
     (unless gerbil-home
       (error "Cannot determine GERBIL_HOME"))
     (set! +gerbil-home+ gerbil-home)
-    (let* ((build-spec (build-spec))
-           (stdlib-spec (filter-map filter-build-spec build-spec))
-           (cc-options (fold-cc-options stdlib-spec))
-           (ld-options (fold-ld-options stdlib-spec))
-           (stdlib-modules (map car stdlib-spec))
-           (all-modules (append gerbil-prelude-gambit stdlib-modules))
-           (ordered-modules (order-modules all-modules))
-           (static-module-scm-files (map static-module-scm-file ordered-modules))
-           (static-module-scm-paths (map static-file-path static-module-scm-files))
-           (static-module-c-paths   (map static-module-c-file static-module-scm-paths))
-           (static-module-o-paths   (map static-module-o-file static-module-c-paths))
-           (gx-gambc-scm-files (map static-module-scm-file gerbil-runtime))
-           (gx-gambc-scm-paths (map static-file-path gx-gambc-scm-files))
-           (gx-gambc-c-paths   (map static-module-c-file gx-gambc-scm-paths))
-           (gx-gambc-o-paths   (map static-module-o-file gx-gambc-c-paths))
-           (link-c-path (static-file-path "gxlink.c"))
-           (link-o-path (static-module-o-file link-c-path))
-           (gx-gambc-macros (static-file-path "gx-gambc#.scm"))
-           (include-gx-gambc-macros (string-append "(include \"" gx-gambc-macros "\")"))
-           (gsc-gx-macros
-            (if (gerbil-runtime-smp?)
-              ["-e" "(define-cond-expand-feature|enable-smp|)"
-               "-e" include-gx-gambc-macros]
-              ["-e" include-gx-gambc-macros]))
-           (gsc-gx-features
-            '("-e" "(define-cond-expand-feature|gerbil-separate-compilation|)"))
-           (libgerbil.a (static-file-path "libgerbil.a")))
-      ;; compile each .scm to .c separately to avoid using too much memory
-      (for (scm-path [gx-gambc-scm-paths ... static-module-scm-paths ...])
-        (displayln "... compile " scm-path)
-        (invoke-gsc [gsc-runtime-opts
-                     ... "-c"
-                     gsc-debug-opts ...
-                     gsc-gx-macros ...
-                     gsc-gx-features ...
-                     scm-path]))
-      ;; link them
-      (displayln "... link " link-c-path)
-      (invoke-gsc [gsc-runtime-opts
-                   ... "-link" "-o" link-c-path
-                   gx-gambc-c-paths ...
-                   static-module-c-paths ...])
-      ;; build them
-      (for (c-path [gx-gambc-c-paths ... static-module-c-paths ... link-c-path])
-        (displayln "... compile " c-path)
-        (invoke-gsc [gsc-runtime-opts
-                   ... "-obj"
-                   "-cc-options" cc-options
-                   c-path]))
-      ;; and collect them
-      (when (file-exists? libgerbil.a)
-        (delete-file libgerbil.a))
-      (displayln "... collect " libgerbil.a)
-      (invoke-ar ["cql" ld-options
-                  libgerbil.a
-                  gx-gambc-o-paths ...
-                  static-module-o-paths ...
-                  link-o-path])
-      ;; cleanup
-      (for (f [gx-gambc-c-paths ... static-module-c-paths ...
-               gx-gambc-o-paths ... static-module-o-paths ...])
-        (delete-file f)))))
+
+    (match args
+      ([] (build-libgerbil (auto-build-mode)))
+      (["shared"] (build-libgerbil 'shared))
+      (["library"] (build-libgerbil 'library))
+      (else
+       (displayln "Usage: build-libgerbil [shared|library]")
+       (exit 1)))))

--- a/src/gerbil/compiler/driver.ss
+++ b/src/gerbil/compiler/driver.ss
@@ -261,16 +261,20 @@ namespace: gxc
            (gsc-opts         (get-gsc-link-opts))
            (gsc-cc-opts      (get-gsc-cc-opts gerbil-staticdir))
            (output-ld-opts   (get-output-ld-opts))
+           (libgerbil.a      (path-expand "libgerbil.a" gerbil-libdir))
+           (libgerbil.so     (path-expand "libgerbil.so" gerbil-libdir))
            (libgerbil-ld-opts
-            (let ((libgerbil.a (path-expand "libgerbil.a" gerbil-libdir))
-                  (libgerbil.so (path-expand "libgerbil.so" gerbil-libdir)))
-              (cond
-               ((file-exists? libgerbil.a)
-                (get-libgerbil.a-ld-opts libgerbil.a))
-               ((file-exists? libgerbil.so)
-                (get-libgerbil.so-ld-opts libgerbil.so))
-               (else
-                (raise-compile-error "libgerbil does not exist" libgerbil.a libgerbil.so))))))
+            (cond
+             ((file-exists? libgerbil.so)
+              (get-libgerbil.so-ld-opts libgerbil.so))
+             ((file-exists? libgerbil.a)
+              (get-libgerbil.a-ld-opts libgerbil.a))
+             (else
+              (raise-compile-error "libgerbil does not exist" libgerbil.a libgerbil.so))))
+           (gerbil-rpath
+            (if (file-exists? libgerbil.so)
+              (string-append "-Wl,-rpath=" gerbil-libdir ":" gambit-libdir)
+              (string-append "-Wl,-rpath=" gambit-libdir))))
       (with-output-to-scheme-file output-scm
         (cut generate-stub gxinit-scm))
       (when (current-compile-invoke-gsc)
@@ -297,6 +301,7 @@ namespace: gxc
                  bin-o
                  output-o output_-o
                  output-ld-opts ...
+                 gerbil-rpath
                  "-L" gerbil-libdir "-lgerbil"
                  "-L" gambit-libdir "-lgambit"
                  libgerbil-ld-opts ...])


### PR DESCRIPTION
build and use libgerbil as an .so when --enable-shared

And not only our binaries build fast, they are also tiny when we are using shared libraries!