### PR TITLE
Rip dynamic exes

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -64,8 +64,7 @@ compile_runtime () {
 finalize_stage1 () {
   local target_lib="${1}"
   local target_bin="${2}"
-  cp -v gerbil/boot/*.scm \
-        gerbil/interactive/*.ss \
+  cp -v gerbil/interactive/*.ss \
         "${target_lib}"
   (cd "${target_bin}" && ln -sv gerbil gxi)
   (cd "${target_bin}" && ln -sv gerbil gxc)
@@ -75,7 +74,6 @@ finalize_boot () {
   local target_lib="${1}"
   local target_bin="${2}"
   cp -v gerbil/boot/*.scm \
-        gerbil/interactive/*.ss \
         "${target_lib}"
   cp -v gerbil/boot-gxi \
        "${target_bin}"
@@ -86,7 +84,7 @@ stage0 () {
   local target_lib="${GERBIL_STAGE0}/lib"
 
   ## feedback
-  feedback_low "Building gerbil stage0"
+  feedback_low "Building gerbil stage0 (bootstrap)"
 
   ## preparing target directory
   feedback_mid "preparing ${GERBIL_STAGE0}"
@@ -108,7 +106,7 @@ stage0 () {
   rm -f .build.stage0
 
   ## finalize build
-  feedback_mid "finalizing build"
+  feedback_mid "finalizing bootstrap"
   finalize_boot "${target_lib}" "${target_bin}"
 }
 

--- a/src/gerbil/boot/gxi-init.scm
+++ b/src/gerbil/boot/gxi-init.scm
@@ -8,6 +8,7 @@
        (libdir (path-expand "lib" home)))
   (load (path-expand "gx-init.scm" libdir))
   (_gx#init)
+  (set! ##display-exception-hook _gx#display-exception)
   (_gx#load-gxi)
   ;; hook ##begin -- gambit wraps it around -e and scripts
   (gx#eval-syntax '(define-alias ##begin begin))

--- a/src/gerbil/compiler/driver.ss
+++ b/src/gerbil/compiler/driver.ss
@@ -211,7 +211,7 @@ namespace: gxc
         (filter not-string-empty? parts))))
 
   (def (get-libgerbil.so-ld-opts libgerbil.so)
-    (call-with-input-file (string-append libgerbil.so ".link") read))
+    (call-with-input-file (string-append libgerbil.so ".ldd") read))
 
   (def (replace-extension path ext)
     (string-append (path-strip-extension path) ext))
@@ -232,7 +232,7 @@ namespace: gxc
            (gerbil-home      (getenv "GERBIL_HOME" default-gerbil-home))
            (gerbil-libdir    (path-expand "lib" gerbil-home))
            (gerbil-staticdir (path-expand "static" gerbil-libdir))
-           (gxlink           (path-expand "gxlink" gerbil-staticdir))
+           (gxlink           (path-expand "libgerbil-link" gerbil-libdir))
            (gxinit-scm       (path-expand "gx-init-static-exe.scm" gerbil-libdir))
            (tmp              (path-expand
                               (string-append "gxc." (number->string (compile-timestamp-nanos)))

--- a/src/gerbil/prelude/core.ss
+++ b/src/gerbil/prelude/core.ss
@@ -270,6 +270,10 @@ package: gerbil
     gerbil-system system-type
     ;; voodoo doll
     gerbil-runtime-smp?
+    ;; expander loading for executables
+    gerbil-load-expander!
+    ;; our home
+    gerbil-home
     )
 
   (define-alias transcript-on void)

--- a/src/gerbil/test/gxc-test.ss
+++ b/src/gerbil/test/gxc-test.ss
@@ -49,17 +49,12 @@
     (test-case "library module"
       (check (compile-lib lib-source-file) => 0))
 
-    (test-case "static executable"
+    (test-case "executable"
       (let (bin (string-append (path-strip-extension program-source-file) ".bin"))
         (check (compile-exe program-source-file bin) => 0)
         (check (execute bin) => (string-append "hello " (gerbil-system-version-string)))))
 
-    (test-case "optimized static executable"
+    (test-case "optimized executable"
       (let (bin (string-append (path-strip-extension program-source-file) ".opt-bin"))
         (check (compile-exe program-source-file bin "-full-program-optimization") => 0)
-        (check (execute bin) => (string-append "hello " (gerbil-system-version-string)))))
-
-    (test-case "dynamic executable"
-      (let (bin (string-append (path-strip-extension program-source-file) ".dyn-bin"))
-        (check (compile-exe program-source-file bin "-dynamic") => 0)
         (check (execute bin) => (string-append "hello " (gerbil-system-version-string)))))))


### PR DESCRIPTION
On top of #774 

- The restriction on (formerly known as) static binaries is lifted;
  the expander and compiler are now included in libgerbil.
- With that restriction lifted, dynamic executable stubs are no longer
  needed and are unceremoniously removed. We just have executables now.