### PR TITLE
fix ar situation: don't put the ldd inside libgerbil.a

### DIFF
--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -56,11 +56,8 @@ You can configure the use of a specific compiler by
 configuring with the `CC=compiler` variable and setting the
 `GERBIL_GCC` environment variable to point to your preferred compiler.
 
-On another note about the LLVM toolchain: some versions of LLVM's `ar`
-are not capable of recording dynamic library dependencies inside archives.
-In this case you should set the `GERBIL_AR` environment variable to point
-to a more capable version of ar, like GNU ar.  This only applies if
-you have configured the system without `--enable-shared`.
+If you are having problems with your system's ar, you can also set the
+`GERBIL_AR` environment variable to point to a specific `ar` that works.
 
 Finally, Gerbil consults the `GERBIL_BUILD_CORES` environment variable
 to determine whether to build its code in parallel, e.g.

--- a/src/build/build-libgerbil.ss
+++ b/src/build/build-libgerbil.ss
@@ -387,22 +387,21 @@
     (when (file-exists? libgerbil)
       (delete-file libgerbil))
     (displayln "... build " libgerbil)
-    (if (eq? mode 'shared)
-      (let (shared-ld-opts  (filter (? (not string-empty?)) (string-split ld-options #\space)))
+    (let (libgerbil-ldd (filter (? (not string-empty?)) (string-split ld-options #\space)))
+      (if (eq? mode 'shared)
         (invoke-gcc ["-shared" "-o" libgerbil
                      shared-ld-opts ...
                      gx-gambc-o-paths ...
                      static-module-o-paths ...
                      builtin-modules-o-path
                      link-o-path])
-        (call-with-output-file (string-append libgerbil ".ldd")
-          (cut write shared-ld-opts <>)))
-      (invoke-ar ["cql" ld-options
-                  libgerbil
-                  gx-gambc-o-paths ...
-                  static-module-o-paths ...
-                  builtin-modules-o-path
-                  link-o-path]))
+        (invoke-ar ["cq" libgerbil
+                    gx-gambc-o-paths ...
+                    static-module-o-paths ...
+                    builtin-modules-o-path
+                    link-o-path]))
+      (call-with-output-file (string-append libgerbil ".ldd")
+        (cut write libgerbil-ldd <>)))
     ;; cleanup
     (for (f [gx-gambc-c-paths ...
              static-module-c-paths ...

--- a/src/gerbil/compiler/driver.ss
+++ b/src/gerbil/compiler/driver.ss
@@ -185,19 +185,8 @@ namespace: gxc
            (lp rest))
           (else [])))))
 
-  (def (get-libgerbil.a-ld-opts libgerbil.a)
-    (let* ((proc (open-input-process [path: (gerbil-ar) arguments: ["p" libgerbil.a "__.LIBDEP"]
-                                            stderr-redirection: #f]))
-           (output (read-line proc #f)))
-      (unless (zero? (process-status proc))
-        (raise-compile-error "Compilation error; process exit with nonzero status"
-                             "ar"))
-      (let* ((line (substring output 0 (1- (string-length output)))) ; drop the NUL terminator
-             (parts (string-split line #\space)))                    ; TODO deal with space madness
-        (filter not-string-empty? parts))))
-
-  (def (get-libgerbil.so-ld-opts libgerbil.so)
-    (call-with-input-file (string-append libgerbil.so ".ldd") read))
+  (def (get-libgerbil-ld-opts libgerbil)
+    (call-with-input-file (string-append libgerbil ".ldd") read))
 
   (def (replace-extension path ext)
     (string-append (path-strip-extension path) ext))
@@ -250,9 +239,9 @@ namespace: gxc
            (libgerbil-ld-opts
             (cond
              ((file-exists? libgerbil.so)
-              (get-libgerbil.so-ld-opts libgerbil.so))
+              (get-libgerbil-ld-opts libgerbil.so))
              ((file-exists? libgerbil.a)
-              (get-libgerbil.a-ld-opts libgerbil.a))
+              (get-libgerbil-ld-opts libgerbil.a))
              (else
               (raise-compile-error "libgerbil does not exist" libgerbil.a libgerbil.so))))
            (gerbil-rpath


### PR DESCRIPTION
Seems to be causing problems with various ars, so we get rid of it and do the same thing we do with libgerbil.so.