### PR TITLE
Enable openssl for now, and appropriate usage of LDFLAGS

### DIFF
--- a/configure
+++ b/configure
@@ -24,6 +24,7 @@ Options understood and processed by Gerbil:
                         defaults to ${default_gambit_tag}
   --enable-march=ARCH   specify the machine architecture; it can be empty.
                         defaults to native
+  --enable-shared       use shared libraries for libgerbil and libgambit
 
 Gerbil Standard Library features:
   --enable-libxml       Enable or disable libxml based libraries; disabled by default
@@ -88,6 +89,12 @@ while [ $# -gt 0 ]; do
 
         --enable-march=*)
             gambit_march=$(echo "$1" | cut -d = -f 2-)
+            shift
+            ;;
+
+        --enable-shared)
+            gerbil_shared=t
+            gambit_config="${gambit_config} $1"
             shift
             ;;
 
@@ -196,9 +203,17 @@ else
 fi
 
 if [ -z "${LDFLAGS}" ]; then
-    LDFLAGS="${ldflags_rpath}=${gerbil_prefix}/lib -lssl"
+    if [ "${gerbil_shared}" = "t" ]; then
+        LDFLAGS="${ldflags_rpath}=${gerbil_prefix}/lib -lssl"
+    else
+        LDFLAGS="-lssl"
+    fi
 else
-    LDFLAGS="${LDFLAGS} ${ldflags_rpath}=${gerbil_prefix}/lib -lssl"
+    if [ "${gerbil_shared}" = "t" ]; then
+        LDFLAGS="${LDFLAGS} ${ldflags_rpath}=${gerbil_prefix}/lib -lssl"
+    else
+        LDFLAGS="${LDFLAGS} -lssl"
+    fi
 fi
 
 git submodule init || die

--- a/configure
+++ b/configure
@@ -60,7 +60,7 @@ std_disable_feature() {
 
 readonly gerbil_version="v$(git describe --tags --always)"
 readonly default_gambit_tag=v4.9.5
-readonly default_gambit_config="--enable-targets='' --enable-single-host --enable-dynamic-clib --enable-default-runtime-options=t8,f8,-8 --enable-trust-c-tco"
+readonly default_gambit_config="--enable-targets='' --enable-single-host --enable-dynamic-clib --enable-default-runtime-options=t8,f8,-8 --enable-trust-c-tco --enable-openssl"
 prefix="/opt/gerbil"
 readonly cflags_opt="-foptimize-sibling-calls"
 readonly ldflags_rpath="-Wl,-rpath"

--- a/configure
+++ b/configure
@@ -172,7 +172,7 @@ while [ $# -gt 0 ]; do
             ;;
 
         LDFLAGS=*)
-            lags=$(echo "$1" | cut -d = -f 2-)
+            flags=$(echo "$1" | cut -d = -f 2-)
             if [ -z "${LDFLAGS}" ]; then
                 LDFLAGS="${flags}"
             else
@@ -196,9 +196,9 @@ else
 fi
 
 if [ -z "${LDFLAGS}" ]; then
-    LDFLAGS="${ldflags_rpath}=${gerbil_prefix}/lib"
+    LDFLAGS="${ldflags_rpath}=${gerbil_prefix}/lib -lssl"
 else
-    LDFLAGS="${LDFLAGS} ${ldflags_rpath}=${gerbil_prefix}/lib"
+    LDFLAGS="${LDFLAGS} ${ldflags_rpath}=${gerbil_prefix}/lib -lssl"
 fi
 
 git submodule init || die

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,8 +43,6 @@ RUN case ${distro} in \
 FROM base as gerbil
 ARG cores
 ARG gerbil_version
-ENV CFLAGS="--enable-openssl"
-ENV LDFLAGS="-lssl"
 RUN cd /opt && git clone https://github.com/vyzo/gerbil gerbil-src
 RUN cd /opt/gerbil-src && git fetch -a && git fetch --tags && git checkout ${gerbil_version} \
     && ./configure \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,6 +43,8 @@ RUN case ${distro} in \
 FROM base as gerbil
 ARG cores
 ARG gerbil_version
+ENV CFLAGS="--enable-openssl"
+ENV LDFLAGS="-lssl"
 RUN cd /opt && git clone https://github.com/vyzo/gerbil gerbil-src
 RUN cd /opt/gerbil-src && git fetch -a && git fetch --tags && git checkout ${gerbil_version} \
     && ./configure \

--- a/src/build/build-libgerbil.ss
+++ b/src/build/build-libgerbil.ss
@@ -23,9 +23,9 @@
 
 (cond-expand
  (netbsd
-  (def default-ld-options "-lm"))
+  (def default-ld-options "-lm -lssl"))
  (else
-  (def default-ld-options "-ldl -lm")))
+  (def default-ld-options "-ldl -lm -lssl")))
 
 (def stdlib-exclude
   '("gambit-sharp"                      ; _gambit#.scm wrapper


### PR DESCRIPTION
Until gerbil TLS/SSL is ready, we want to --enable-openssl in gambit so that we don't break existing net/request users.

This fixes the situation and also fixes the handling of `LDFLAGS` as there were bugz.