### PR TITLE
configure: drop native march for OpenBSD

### DIFF
--- a/configure
+++ b/configure
@@ -66,7 +66,15 @@ prefix="/opt/gerbil"
 readonly cflags_opt="-foptimize-sibling-calls"
 readonly ldflags_rpath="-Wl,-rpath"
 
-gambit_march="native"
+case $(uname) in
+    OpenBSD)
+        gambit_march=""
+        ;;
+    *)
+        gambit_march="native"
+        ;;
+esac
+
 gambit_tag="${default_gambit_tag}"
 gambit_config="${default_gambit_config}"
 


### PR DESCRIPTION
llvm just can't deal with it in that BSD.