### PR TITLE
don't build deprecated stdlib packages by default

### DIFF
--- a/configure
+++ b/configure
@@ -27,6 +27,7 @@ Options understood and processed by Gerbil:
   --enable-shared       use shared libraries for libgerbil and libgambit
 
 Gerbil Standard Library features:
+  --enable-deprecated   Enable building of deprecated packages
   --enable-libxml       Enable or disable libxml based libraries; disabled by default
   --disable-libxml
   --enable-libyaml      Enable or disable libyaml based libraries; disabled by default
@@ -103,6 +104,11 @@ while [ $# -gt 0 ]; do
         --enable-shared)
             gerbil_shared=t
             gambit_config="${gambit_config} $1"
+            shift
+            ;;
+
+        --enable-deprecated)
+            std_enable_feature deprecated
             shift
             ;;
 

--- a/src/std/actor-v13/rpc-test.ss
+++ b/src/std/actor-v13/rpc-test.ss
@@ -1,255 +1,257 @@
 ;;; -*- Gerbil -*-
 ;;; (C) vyzo at hackzen.org
 ;;; :std/actor-v13 unit-test
+(import :std/build-config)
+(cond-expand
+  (config-enable-deprecated
+   (import :gerbil/gambit
+           :std/test
+           :std/event
+           ../actor-v13)
+   (export actor-v13-rpc-test
+           actor-v13-rpc-stream-test)
 
-(import :gerbil/gambit
-        :std/test
-        :std/event
-        ../actor-v13)
-(export actor-v13-rpc-test
-        actor-v13-rpc-stream-test)
+   (defproto hello
+     call: (hello a)
+     stream: (hello-stream a))
 
-(defproto hello
-  call: (hello a)
-  stream: (hello-stream a))
+   (bind-protocol! 'foo hello::proto)
 
-(bind-protocol! 'foo hello::proto)
+   (def (hello-server remoted)
+     (rpc-register remoted 'foo)
+     (let lp ()
+       (<- ((!hello.hello val k)
+            (!!value @source val k)
+            (lp))
+           ((!rpc.shutdown)
+            (void))
+           (content
+            (displayln "unexpected message " @message " " content)
+            (lp)))))
 
-(def (hello-server remoted)
-  (rpc-register remoted 'foo)
-  (let lp ()
-    (<- ((!hello.hello val k)
-         (!!value @source val k)
-         (lp))
-        ((!rpc.shutdown)
-         (void))
-        (content
-         (displayln "unexpected message " @message " " content)
-         (lp)))))
+   (def (hello-void-server remoted)
+     (rpc-register remoted 'foo)
+     (let lp ()
+       (<- ((!rpc.shutdown)
+            (void))
+           (ignore
+            (lp)))))
 
-(def (hello-void-server remoted)
-  (rpc-register remoted 'foo)
-  (let lp ()
-    (<- ((!rpc.shutdown)
-         (void))
-        (ignore
-         (lp)))))
+   (def rpc-server-address1 "127.0.0.1:9000")
+   (def rpc-server-address2 "127.0.0.1:9001")
+   (def rpc-server-address3 "127.0.0.1:9002")
+   (def rpc-server-address4 "127.0.0.1:9003")
+   (def rpc-server-address5 "127.0.0.1:9004")
+   (def rpc-server-address6 "127.0.0.1:9005")
+   (def rpc-server-address7 "127.0.0.1:9006")
+   (def rpc-server-address8 "127.0.0.1:9007")
+   (def rpc-server-address9 "127.0.0.1:9008")
+   (def rpc-server-address10 "127.0.0.1:9009")
+   (def rpc-cookie "/tmp/actor-test-cookie")
+   (rpc-generate-cookie! rpc-cookie)
 
-(def rpc-server-address1 "127.0.0.1:9000")
-(def rpc-server-address2 "127.0.0.1:9001")
-(def rpc-server-address3 "127.0.0.1:9002")
-(def rpc-server-address4 "127.0.0.1:9003")
-(def rpc-server-address5 "127.0.0.1:9004")
-(def rpc-server-address6 "127.0.0.1:9005")
-(def rpc-server-address7 "127.0.0.1:9006")
-(def rpc-server-address8 "127.0.0.1:9007")
-(def rpc-server-address9 "127.0.0.1:9008")
-(def rpc-server-address10 "127.0.0.1:9009")
-(def rpc-cookie "/tmp/actor-test-cookie")
-(rpc-generate-cookie! rpc-cookie)
+   (def actor-v13-rpc-test
+     (test-suite "test :std/actor RPC"
+       (test-case "test RPC NULL proto"
+         (def remoted (start-rpc-server! rpc-server-address1))
+         (def hellod  (spawn hello-server remoted))
+         (thread-sleep! 0.1)
+         (check (!!rpc.resolve remoted 'foo) => hellod)
 
-(def actor-v13-rpc-test
-  (test-suite "test :std/actor RPC"
-    (test-case "test RPC NULL proto"
-      (def remoted (start-rpc-server! rpc-server-address1))
-      (def hellod  (spawn hello-server remoted))
-      (thread-sleep! 0.1)
-      (check (!!rpc.resolve remoted 'foo) => hellod)
+         (def locald  (start-rpc-server!))
+         (def rfoo
+           (rpc-connect locald 'foo rpc-server-address1))
+         (check (!!hello.hello rfoo 'a timeout: 1) => 'a)
 
-      (def locald  (start-rpc-server!))
-      (def rfoo
-        (rpc-connect locald 'foo rpc-server-address1))
-      (check (!!hello.hello rfoo 'a timeout: 1) => 'a)
+         (stop-rpc-server! remoted)
+         (stop-rpc-server! locald))
 
-      (stop-rpc-server! remoted)
-      (stop-rpc-server! locald))
+       (test-case "test RPC COOKIE proto"
+         (def remoted
+           (start-rpc-server! rpc-server-address2 proto: (rpc-cookie-proto rpc-cookie)))
+         (def hellod
+           (spawn hello-server remoted))
+         (thread-sleep! 0.1)
+         (check (!!rpc.resolve remoted 'foo) => hellod)
 
-    (test-case "test RPC COOKIE proto"
-      (def remoted
-        (start-rpc-server! rpc-server-address2 proto: (rpc-cookie-proto rpc-cookie)))
-      (def hellod
-        (spawn hello-server remoted))
-      (thread-sleep! 0.1)
-      (check (!!rpc.resolve remoted 'foo) => hellod)
+         (def locald
+           (start-rpc-server! proto: (rpc-cookie-proto rpc-cookie)))
+         (def rfoo
+           (rpc-connect locald 'foo rpc-server-address2))
+         (check (!!hello.hello rfoo 'a timeout: 1) => 'a)
 
-      (def locald
-        (start-rpc-server! proto: (rpc-cookie-proto rpc-cookie)))
-      (def rfoo
-        (rpc-connect locald 'foo rpc-server-address2))
-      (check (!!hello.hello rfoo 'a timeout: 1) => 'a)
+         (stop-rpc-server! remoted)
+         (stop-rpc-server! locald))
 
-      (stop-rpc-server! remoted)
-      (stop-rpc-server! locald))
+       (test-case "test RPC CIPHER proto"
+         (def remoted
+           (start-rpc-server! rpc-server-address3 proto: (rpc-cipher-proto)))
+         (def hellod
+           (spawn hello-server remoted))
+         (thread-sleep! 0.1)
+         (check (!!rpc.resolve remoted 'foo) => hellod)
 
-    (test-case "test RPC CIPHER proto"
-      (def remoted
-        (start-rpc-server! rpc-server-address3 proto: (rpc-cipher-proto)))
-      (def hellod
-        (spawn hello-server remoted))
-      (thread-sleep! 0.1)
-      (check (!!rpc.resolve remoted 'foo) => hellod)
+         (def locald
+           (start-rpc-server! proto: (rpc-cipher-proto)))
+         (def rfoo
+           (rpc-connect locald 'foo rpc-server-address3))
+         (check (!!hello.hello rfoo 'a timeout: 1) => 'a)
 
-      (def locald
-        (start-rpc-server! proto: (rpc-cipher-proto)))
-      (def rfoo
-        (rpc-connect locald 'foo rpc-server-address3))
-      (check (!!hello.hello rfoo 'a timeout: 1) => 'a)
+         (stop-rpc-server! remoted)
+         (stop-rpc-server! locald))
 
-      (stop-rpc-server! remoted)
-      (stop-rpc-server! locald))
+       (test-case "test RPC COOKIE-CIPHER proto"
+         (def remoted
+           (start-rpc-server! rpc-server-address4 proto: (rpc-cookie-cipher-proto rpc-cookie)))
+         (def hellod
+           (spawn hello-server remoted))
+         (thread-sleep! 0.1)
+         (check (!!rpc.resolve remoted 'foo) => hellod)
 
-    (test-case "test RPC COOKIE-CIPHER proto"
-      (def remoted
-        (start-rpc-server! rpc-server-address4 proto: (rpc-cookie-cipher-proto rpc-cookie)))
-      (def hellod
-        (spawn hello-server remoted))
-      (thread-sleep! 0.1)
-      (check (!!rpc.resolve remoted 'foo) => hellod)
+         (def locald
+           (start-rpc-server! proto: (rpc-cookie-cipher-proto rpc-cookie)))
+         (def rfoo
+           (rpc-connect locald 'foo rpc-server-address4))
+         (check (!!hello.hello rfoo 'a timeout: 1) => 'a)
 
-      (def locald
-        (start-rpc-server! proto: (rpc-cookie-cipher-proto rpc-cookie)))
-      (def rfoo
-        (rpc-connect locald 'foo rpc-server-address4))
-      (check (!!hello.hello rfoo 'a timeout: 1) => 'a)
+         (stop-rpc-server! remoted)
+         (stop-rpc-server! locald))
 
-      (stop-rpc-server! remoted)
-      (stop-rpc-server! locald))
+       (test-case "test RPC errors"
+         (def locald (start-rpc-server!))
+         (def rfoo
+           (make-remote locald 'foo rpc-server-address8 hello::proto))
 
-    (test-case "test RPC errors"
-      (def locald (start-rpc-server!))
-      (def rfoo
-        (make-remote locald 'foo rpc-server-address8 hello::proto))
+         (check (with-catch values (cut !!hello.hello rfoo 'a)) ? rpc-error?)
 
-      (check (with-catch values (cut !!hello.hello rfoo 'a)) ? rpc-error?)
+         (def remoted (start-rpc-server! rpc-server-address8))
+         (thread-sleep! 0.1)
+         (check (with-catch values (cut !!hello.hello rfoo 'a)) ? remote-error?)
 
-      (def remoted (start-rpc-server! rpc-server-address8))
-      (thread-sleep! 0.1)
-      (check (with-catch values (cut !!hello.hello rfoo 'a)) ? remote-error?)
+         (def hellod
+           (spawn hello-void-server remoted))
+         (thread-sleep! 0.1)
+         (check (!!rpc.resolve remoted 'foo) => hellod)
+         (check (with-catch values (cut !!hello.hello rfoo 'a timeout: 1)) ? rpc-error?)
 
-      (def hellod
-        (spawn hello-void-server remoted))
-      (thread-sleep! 0.1)
-      (check (!!rpc.resolve remoted 'foo) => hellod)
-      (check (with-catch values (cut !!hello.hello rfoo 'a timeout: 1)) ? rpc-error?)
+         (stop-rpc-server! remoted)
+         (stop-rpc-server! locald))
 
-      (stop-rpc-server! remoted)
-      (stop-rpc-server! locald))
+       (test-case "test RPC monitors"
+         (def remoted (start-rpc-server! rpc-server-address10))
+         (def hellod  (spawn hello-server remoted))
+         (thread-sleep! 0.1)
+         (check (!!rpc.resolve remoted 'foo) => hellod)
 
-    (test-case "test RPC monitors"
-      (def remoted (start-rpc-server! rpc-server-address10))
-      (def hellod  (spawn hello-server remoted))
-      (thread-sleep! 0.1)
-      (check (!!rpc.resolve remoted 'foo) => hellod)
+         (def locald  (start-rpc-server!))
+         (def rfoo
+           (rpc-connect locald 'foo rpc-server-address10))
+         (check (!!hello.hello rfoo 'a timeout: 1) => 'a)
 
-      (def locald  (start-rpc-server!))
-      (def rfoo
-        (rpc-connect locald 'foo rpc-server-address10))
-      (check (!!hello.hello rfoo 'a timeout: 1) => 'a)
+         (!!rpc.monitor locald rfoo)
+         (thread-sleep! 1.0)
 
-      (!!rpc.monitor locald rfoo)
-      (thread-sleep! 1.0)
+         (stop-rpc-server! remoted)
+         (check (<- ((!rpc.disconnect r) r)) => rfoo)
 
-      (stop-rpc-server! remoted)
-      (check (<- ((!rpc.disconnect r) r)) => rfoo)
+         (stop-rpc-server! locald))))
 
-      (stop-rpc-server! locald))))
+   (def (hello-stream-server remoted N)
+     (rpc-register remoted 'foo)
+     (let lp ()
+       (<- ((!hello.hello-stream _ k)
+            (let lp2 ((n 0))
+              (if (< n N)
+                (begin
+                  (!!yield n k)
+                  (!!sync k)
+                  (<- ((!continue (eq? k))
+                       (lp2 (1+ n)))))
+                (begin
+                  (!!end k)
+                  (lp)))))
+           ((!rpc.shutdown)
+            (void)))))
 
-(def (hello-stream-server remoted N)
-  (rpc-register remoted 'foo)
-  (let lp ()
-    (<- ((!hello.hello-stream _ k)
-         (let lp2 ((n 0))
-           (if (< n N)
-             (begin
-               (!!yield n k)
-               (!!sync k)
-               (<- ((!continue (eq? k))
-                    (lp2 (1+ n)))))
-             (begin
-               (!!end k)
-               (lp)))))
-        ((!rpc.shutdown)
-         (void)))))
+   (def (hello-stream-close-server remoted)
+     (rpc-register remoted 'foo)
+     (let lp ()
+       (<- ((!hello.hello-stream _ k)
+            (let (source @source)
+              (let lp2 ((n 0))
+                (!!yield n k)
+                (!!sync k)
+                (<- ((!continue k)
+                     (lp2 (1+ n)))
+                    ((!close k)
+                     (!!end source k)
+                     (lp))))))
+           ((!rpc.shutdown)
+            (void)))))
 
-(def (hello-stream-close-server remoted)
-  (rpc-register remoted 'foo)
-  (let lp ()
-    (<- ((!hello.hello-stream _ k)
-         (let (source @source)
-           (let lp2 ((n 0))
-             (!!yield n k)
-             (!!sync k)
-             (<- ((!continue k)
-                  (lp2 (1+ n)))
-                 ((!close k)
-                  (!!end source k)
-                  (lp))))))
-        ((!rpc.shutdown)
-         (void)))))
+   (def actor-v13-rpc-stream-test
+     (test-suite "test :std/actor RPC stream"
+       (test-case "test basic RPC stream"
+         (def N 5)
+         (def remoted (start-rpc-server! rpc-server-address5))
+         (def hellod  (spawn hello-stream-server remoted N))
+         (thread-sleep! 0.1)
+         (check (!!rpc.resolve remoted 'foo) => hellod)
+         (def locald  (start-rpc-server!))
+         (def rfoo
+           (rpc-connect locald 'foo rpc-server-address5))
 
-(def actor-v13-rpc-stream-test
-  (test-suite "test :std/actor RPC stream"
-    (test-case "test basic RPC stream"
-      (def N 5)
-      (def remoted (start-rpc-server! rpc-server-address5))
-      (def hellod  (spawn hello-stream-server remoted N))
-      (thread-sleep! 0.1)
-      (check (!!rpc.resolve remoted 'foo) => hellod)
-      (def locald  (start-rpc-server!))
-      (def rfoo
-        (rpc-connect locald 'foo rpc-server-address5))
+         (let (k (!!hello.hello-stream rfoo "stream"))
+           (let lp ((n 0))
+             (when (< n N)
+               (<- ((!yield x (eq? k))
+                    (check x => n)
+                    (<- ((!sync (eq? k))
+                         (!!continue k)
+                         (lp (1+ n))))))))
+           (let (end (thread-receive))
+             (check end ? message?)
+             (check (message-e end) ? !end?)))
 
-      (let (k (!!hello.hello-stream rfoo "stream"))
-        (let lp ((n 0))
-          (when (< n N)
-            (<- ((!yield x (eq? k))
-                 (check x => n)
-                 (<- ((!sync (eq? k))
-                      (!!continue k)
-                      (lp (1+ n))))))))
-        (let (end (thread-receive))
-          (check end ? message?)
-          (check (message-e end) ? !end?)))
+         (stop-rpc-server! remoted)
+         (stop-rpc-server! locald))
 
-      (stop-rpc-server! remoted)
-      (stop-rpc-server! locald))
+       (test-case "test RPC stream ports"
+         (def N 5)
+         (def remoted (start-rpc-server! rpc-server-address6))
+         (def hellod  (spawn hello-stream-server remoted N))
+         (thread-sleep! 0.1)
+         (check (!!rpc.resolve remoted 'foo) => hellod)
+         (def locald  (start-rpc-server!))
+         (def rfoo
+           (rpc-connect locald 'foo rpc-server-address6))
 
-    (test-case "test RPC stream ports"
-             (def N 5)
-      (def remoted (start-rpc-server! rpc-server-address6))
-      (def hellod  (spawn hello-stream-server remoted N))
-      (thread-sleep! 0.1)
-      (check (!!rpc.resolve remoted 'foo) => hellod)
-      (def locald  (start-rpc-server!))
-      (def rfoo
-        (rpc-connect locald 'foo rpc-server-address6))
+         (let ((values inp close) (!!pipe (!!hello.hello-stream rfoo "stream")))
+           (let lp ((n 0))
+             (when (< n N)
+               (check (read inp) => n)
+               (lp (1+ n))))
+           (check (read inp) ? eof-object?))
 
-      (let ((values inp close) (!!pipe (!!hello.hello-stream rfoo "stream")))
-        (let lp ((n 0))
-          (when (< n N)
-            (check (read inp) => n)
-            (lp (1+ n))))
-        (check (read inp) ? eof-object?))
+         (stop-rpc-server! remoted)
+         (stop-rpc-server! locald))
 
-      (stop-rpc-server! remoted)
-      (stop-rpc-server! locald))
+       (test-case "test RPC stream close"
+         (def remoted (start-rpc-server! rpc-server-address9))
+         (def hellod  (spawn hello-stream-close-server remoted))
+         (thread-sleep! 0.1)
+         (check (!!rpc.resolve remoted 'foo) => hellod)
+         (def locald  (start-rpc-server!))
+         (def rfoo
+           (rpc-connect locald 'foo rpc-server-address9))
 
-    (test-case "test RPC stream close"
-      (def remoted (start-rpc-server! rpc-server-address9))
-      (def hellod  (spawn hello-stream-close-server remoted))
-      (thread-sleep! 0.1)
-      (check (!!rpc.resolve remoted 'foo) => hellod)
-      (def locald  (start-rpc-server!))
-      (def rfoo
-        (rpc-connect locald 'foo rpc-server-address9))
+         (let ((values inp close) (!!pipe (!!hello.hello-stream rfoo "stream")))
+           (close)
+           (let lp ((n 0))
+             (let (next (read inp))
+               (unless (eof-object? next)
+                 (lp (1+ n)))))
+           (check (read inp) ? eof-object?))
 
-      (let ((values inp close) (!!pipe (!!hello.hello-stream rfoo "stream")))
-        (close)
-        (let lp ((n 0))
-          (let (next (read inp))
-            (unless (eof-object? next)
-              (lp (1+ n)))))
-        (check (read inp) ? eof-object?))
-
-      (stop-rpc-server! remoted)
-      (stop-rpc-server! locald))))
+         (stop-rpc-server! remoted)
+         (stop-rpc-server! locald))))))

--- a/src/std/actor-v13/xdr-test.ss
+++ b/src/std/actor-v13/xdr-test.ss
@@ -1,65 +1,67 @@
 ;;; -*- Gerbil -*-
 ;;; (C) vyzo at hackzen.org
 ;;; :std/actor-v13/xdr unit-test
+(import :std/build-config)
+(cond-expand
+  (config-enable-deprecated
+   (import :gerbil/gambit/random
+           :gerbil/gambit/os
+           :std/test
+           :std/net/bio
+           :std/iter
+           ./xdr)
+   (export actor-v13-xdr-test)
 
-(import :gerbil/gambit/random
-        :gerbil/gambit/os
-        :std/test
-        :std/net/bio
-        :std/iter
-        ./xdr)
-(export actor-v13-xdr-test)
+   (def actor-v13-xdr-test
+     (test-suite "test :std/actor-v13/xdr"
 
-(def actor-v13-xdr-test
-  (test-suite "test :std/actor-v13/xdr"
+       (def (check-serialize obj (obj-e values))
+         (let (p (open-serializer-output-buffer))
+           (xdr-write obj p)
+           (let (q (open-input-buffer (chunked-output-u8vector p)))
+             (check (obj-e (xdr-read q)) => (obj-e obj)))))
 
-    (def (check-serialize obj (obj-e values))
-        (let (p (open-serializer-output-buffer))
-          (xdr-write obj p)
-          (let (q (open-input-buffer (chunked-output-u8vector p)))
-            (check (obj-e (xdr-read q)) => (obj-e obj)))))
+       (def (check-serialize-opaque obj)
+         (let (p (open-serializer-output-buffer))
+           (xdr-write (opaque obj) p)
+           (let (q (open-input-buffer (chunked-output-u8vector p)))
+             (check (opaque-value (xdr-read q)) => obj))))
 
-    (def (check-serialize-opaque obj)
-        (let (p (open-serializer-output-buffer))
-          (xdr-write (opaque obj) p)
-          (let (q (open-input-buffer (chunked-output-u8vector p)))
-            (check (opaque-value (xdr-read q)) => obj))))
-
-    (test-case "test primitive object serialization"
-      ;; primitive objects
-      (check-serialize #!void)
-      (check-serialize #f)
-      (check-serialize #t)
-      (check-serialize '())
-      (check-serialize 'a)
-      (check-serialize 'b)
-      (check-serialize 'c)
-      (check-serialize '(a . b))
-      (check-serialize '(a b c))
-      (for (x (in-iota 10))
-        (let* ((base (expt 10 x))
-               (int (+ base (random-integer base))))
-          (check-serialize x)
-          (check-serialize (- x))
-          (check-serialize base)
-          (check-serialize (- base))
-          (check-serialize int)
-          (check-serialize (- int))))
-      (for-each check-serialize
-                '(1.0 -1.0 3.5 -3.5 100.234 -100.234 1.234e6 -1.234e6
-                      +inf.0 -inf.0))
-      (check-serialize 'a-symbol)
-      (check-serialize a-keyword:)
-      (check-serialize "a string")
-      (check-serialize (values 1 2 3))
-      (check-serialize '#u8(127 0 0 1))
-      (check-serialize '(#u8(127 0 0 1) . 8080))
-      (check-serialize (random-u8vector 1000))
-      (check-serialize (list (random-u8vector 200) (random-u8vector 200) (random-u8vector 200)))
-      (check-serialize (list->hash-table '((a . 1) (b . 2) (c . 3))))
-      (check-serialize (list->hash-table-eq '((a . 1) (b . 2) (c . 3))))
-      (check-serialize (current-time) time->seconds)
-      (check-serialize 3+5i)
-      (check-serialize 3/5)
-      (check-serialize '#!eof)
-      (check-serialize-opaque 1))))
+       (test-case "test primitive object serialization"
+         ;; primitive objects
+         (check-serialize #!void)
+         (check-serialize #f)
+         (check-serialize #t)
+         (check-serialize '())
+         (check-serialize 'a)
+         (check-serialize 'b)
+         (check-serialize 'c)
+         (check-serialize '(a . b))
+         (check-serialize '(a b c))
+         (for (x (in-iota 10))
+           (let* ((base (expt 10 x))
+                  (int (+ base (random-integer base))))
+             (check-serialize x)
+             (check-serialize (- x))
+             (check-serialize base)
+             (check-serialize (- base))
+             (check-serialize int)
+             (check-serialize (- int))))
+         (for-each check-serialize
+                   '(1.0 -1.0 3.5 -3.5 100.234 -100.234 1.234e6 -1.234e6
+                         +inf.0 -inf.0))
+         (check-serialize 'a-symbol)
+         (check-serialize a-keyword:)
+         (check-serialize "a string")
+         (check-serialize (values 1 2 3))
+         (check-serialize '#u8(127 0 0 1))
+         (check-serialize '(#u8(127 0 0 1) . 8080))
+         (check-serialize (random-u8vector 1000))
+         (check-serialize (list (random-u8vector 200) (random-u8vector 200) (random-u8vector 200)))
+         (check-serialize (list->hash-table '((a . 1) (b . 2) (c . 3))))
+         (check-serialize (list->hash-table-eq '((a . 1) (b . 2) (c . 3))))
+         (check-serialize (current-time) time->seconds)
+         (check-serialize 3+5i)
+         (check-serialize 3/5)
+         (check-serialize '#!eof)
+         (check-serialize-opaque 1))))))

--- a/src/std/build-features.ss
+++ b/src/std/build-features.ss
@@ -1,5 +1,8 @@
 ;; This file is meant to be include'd by build-config.ss
 
+;; build deprecated packaages
+(enable deprecated #f)
+
 ;; build std/xml libraries - requires libxml2
 (enable libxml #f)
 

--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -199,10 +199,8 @@
     "net/socks"
     "net/request"
     "net/websocket"
-    ;; temporary deprecated until it has been ported
-    ,@(if config-enable-deprecated
-        '("net/wamp")
-        '())
+    ;; TODO temporarily disable wamp until it has been ported
+    ;; "net/wamp"
     (gxc: "net/repl" ,@(include-gambit-sharp))
     ;; std/os
     (gxc: "os/error" ,@(include-gambit-sharp))

--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -231,26 +231,28 @@
     "os/pid"
     "os/temporaries"
     "os/hostname"
-    ;; :std/net/bio
-    "net/bio/input"
-    "net/bio/output"
-    "net/bio/buffer"
-    "net/bio/file"
-    "net/bio"
-    ;; :std/net/socket
-    "net/socket/base"
-    "net/socket/basic-socket"
-    "net/socket/api"
-    "net/socket/buffer"
-    "net/socket/basic-server"
-    ,@(cond-expand
-        (linux
-         '("net/socket/epoll-server"))
-        (bsd
-         '("net/socket/kqueue-server"))
-        (else '()))
-    "net/socket/server"
-    "net/socket"
+    ,@(if config-enable-deprecated
+        ;; :std/net/bio -- DEPRECATED
+        ["net/bio/input"
+         "net/bio/output"
+         "net/bio/buffer"
+         "net/bio/file"
+         "net/bio"
+         ;; :std/net/socket -- DEPRECATED
+         "net/socket/base"
+         "net/socket/basic-socket"
+         "net/socket/api"
+         "net/socket/buffer"
+         "net/socket/basic-server"
+         (cond-expand
+           (linux
+            '("net/socket/epoll-server"))
+           (bsd
+            '("net/socket/kqueue-server"))
+           (else '())) ...
+         "net/socket/server"
+         "net/socket"]
+        [])
     ;; :std/net/httpd
     "net/httpd/base"
     "net/httpd/control"
@@ -347,18 +349,20 @@
     "actor-v18/api"
     "actor"
     ;; DEPRECATEED: actor-v13
-    (gxc: "actor-v13/message" ,@(include-gambit-sharp))
-    (gxc: "actor-v13/xdr"  ,@(include-gambit-sharp))
-    (gxc: "actor-v13/proto")
-    "actor-v13/rpc/base"
-    "actor-v13/rpc/proto/message"
-    "actor-v13/rpc/proto/null"
-    "actor-v13/rpc/proto/cookie"
-    "actor-v13/rpc/proto/cipher"
-    "actor-v13/rpc/connection"
-    "actor-v13/rpc/server"
-    "actor-v13/rpc"
-    "actor-v13"
+    ,@(if config-enable-deprecated
+        [[gxc: "actor-v13/message" (include-gambit-sharp) ...]
+         [gxc: "actor-v13/xdr"  (include-gambit-sharp) ...]
+         [gxc: "actor-v13/proto"]
+         "actor-v13/rpc/base"
+         "actor-v13/rpc/proto/message"
+         "actor-v13/rpc/proto/null"
+         "actor-v13/rpc/proto/cookie"
+         "actor-v13/rpc/proto/cipher"
+         "actor-v13/rpc/connection"
+         "actor-v13/rpc/server"
+         "actor-v13/rpc"
+         "actor-v13"]
+        [])
     "web/fastcgi"
     "web/rack"
     "db/dbi"

--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -199,7 +199,10 @@
     "net/socks"
     "net/request"
     "net/websocket"
-    "net/wamp"
+    ;; temporary deprecated until it has been ported
+    ,@(if config-enable-deprecated
+        '("net/wamp")
+        '())
     (gxc: "net/repl" ,@(include-gambit-sharp))
     ;; std/os
     (gxc: "os/error" ,@(include-gambit-sharp))

--- a/src/std/net/socket/server-test.ss
+++ b/src/std/net/socket/server-test.ss
@@ -1,87 +1,90 @@
 ;;; -*- Gerbil -*-
 ;;; (C) vyzo at hackzen.org
 ;;; Socket server tests
+(import :std/build-config)
 (cond-expand
-  ((or linux bsd)
-   (import :gerbil/gambit
-           :gerbil/gambit/threads
-           :std/misc/threads
-           :std/net/socket
-           :std/net/socket/base
-           :std/os/socket
-           :std/error
-           :std/sugar
-           :std/test)
-   (export server-test test-setup! test-cleanup!)
+  (config-enable-deprecated
+   (cond-expand
+     ((or linux bsd)
+      (import :gerbil/gambit
+              :gerbil/gambit/threads
+              :std/misc/threads
+              :std/net/socket
+              :std/net/socket/base
+              :std/os/socket
+              :std/error
+              :std/sugar
+              :std/test)
+      (export server-test test-setup! test-cleanup!)
 
-   (def server-address "localhost:4242")
+      (def server-address "localhost:4242")
 
-   (def (echo sock)
-     (def buf (make-u8vector 256))
-     (try
-      (let lp ()
-        (def len (ssocket-recv sock buf))
-        (if (= len 0)
-          (begin
-            (ssocket-close sock)
-            (values))
-          (begin
-            (ssocket-send-all sock buf 0 len)
-            (lp))))
-      (catch (io-error? exn)
-        (display-exception exn)
-        (values))))
+      (def (echo sock)
+        (def buf (make-u8vector 256))
+        (try
+         (let lp ()
+           (def len (ssocket-recv sock buf))
+           (if (= len 0)
+             (begin
+               (ssocket-close sock)
+               (values))
+             (begin
+               (ssocket-send-all sock buf 0 len)
+               (lp))))
+         (catch (io-error? exn)
+           (display-exception exn)
+           (values))))
 
-   (def (run-echo-server address)
-     (def sock (ssocket-listen address))
-     (let lp ()
-       (spawn echo (ssocket-accept sock))
-       (lp)))
+      (def (run-echo-server address)
+        (def sock (ssocket-listen address))
+        (let lp ()
+          (spawn echo (ssocket-accept sock))
+          (lp)))
 
-   (def (start-echo-server! address)
-     (parameterize ((current-socket-server #f))
-       (start-socket-server!)
-       (let (echo-server (spawn/group 'echo-server run-echo-server address))
-         (values (current-socket-server) echo-server))))
+      (def (start-echo-server! address)
+        (parameterize ((current-socket-server #f))
+          (start-socket-server!)
+          (let (echo-server (spawn/group 'echo-server run-echo-server address))
+            (values (current-socket-server) echo-server))))
 
-   (def (stop-echo-server! server)
-     (let (tgroup (thread-thread-group server))
-       (thread-group-kill! tgroup)))
+      (def (stop-echo-server! server)
+        (let (tgroup (thread-thread-group server))
+          (thread-group-kill! tgroup)))
 
-   (def (send+recv sock txt)
-     (def len (string-length txt))
-     (def buf (make-u8vector len))
-     (ssocket-send-all sock (string->bytes txt))
-     (ssocket-recv-all sock buf 0 len 5)
-     (bytes->string buf))
+      (def (send+recv sock txt)
+        (def len (string-length txt))
+        (def buf (make-u8vector len))
+        (ssocket-send-all sock (string->bytes txt))
+        (ssocket-recv-all sock buf 0 len 5)
+        (bytes->string buf))
 
-   (def socket-server #f)
-   (def echo-server #f)
+      (def socket-server #f)
+      (def echo-server #f)
 
-   (def (test-setup!)
-     (let-values (((my-socket-server my-echo-server)
-                   (start-echo-server! server-address)))
-       (set! socket-server my-socket-server)
-       (set! echo-server my-echo-server)
-       (thread-sleep! 0.2)))
+      (def (test-setup!)
+        (let-values (((my-socket-server my-echo-server)
+                      (start-echo-server! server-address)))
+          (set! socket-server my-socket-server)
+          (set! echo-server my-echo-server)
+          (thread-sleep! 0.2)))
 
-   (def (test-cleanup!)
-     (stop-echo-server! echo-server)
-     (stop-socket-server! socket-server))
+      (def (test-cleanup!)
+        (stop-echo-server! echo-server)
+        (stop-socket-server! socket-server))
 
-   (def server-test
-     (test-suite "test :std/net/socket"
-       (test-case "test socket-server"
-         (def sock (ssocket-connect server-address))
-         (check (send+recv sock "Hello") => "Hello")
-         (check (send+recv sock "Test") => "Test")
-         (check (send+recv sock "1.2.3.4.5") => "1.2.3.4.5")
-         (ssocket-close sock))
+      (def server-test
+        (test-suite "test :std/net/socket"
+          (test-case "test socket-server"
+            (def sock (ssocket-connect server-address))
+            (check (send+recv sock "Hello") => "Hello")
+            (check (send+recv sock "Test") => "Test")
+            (check (send+recv sock "1.2.3.4.5") => "1.2.3.4.5")
+            (ssocket-close sock))
 
-       (test-case "test socket-server multiple connections"
-         (def conn-1 (ssocket-connect server-address))
-         (def conn-2 (ssocket-connect server-address))
-         (check (send+recv conn-2 "BBB") => "BBB")
-         (check (send+recv conn-1 "AAA") => "AAA")
-         (ssocket-close conn-1)
-         (ssocket-close conn-2))))))
+          (test-case "test socket-server multiple connections"
+            (def conn-1 (ssocket-connect server-address))
+            (def conn-2 (ssocket-connect server-address))
+            (check (send+recv conn-2 "BBB") => "BBB")
+            (check (send+recv conn-1 "AAA") => "AAA")
+            (ssocket-close conn-1)
+            (ssocket-close conn-2))))))))


### PR DESCRIPTION
The build time is getting long, and this also adds code mass for legacy code; so don't do it by default.