### PR TITLE
introduce context dependent variation of exe: build spec

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -203,7 +203,7 @@ build_stage1 () {
 ## commands
 build_stdlib () {
   feedback_low "Building gerbil stdlib"
-  (cd std && ./build.ss)
+  (cd std && ./build.ss) || die
 }
 
 build_libgerbil () {
@@ -213,22 +213,22 @@ build_libgerbil () {
 
 build_lang () {
   feedback_low "Building gerbil languages"
-  (cd lang && ./build.ss)
+  (cd lang && ./build.ss) || die
 }
 
 build_r7rs_large() {
   feedback_low "Building R7RS large"
-  (cd r7rs-large && ./build.ss)
+  (cd r7rs-large && ./build.ss) || die
 }
 
 build_srfi() {
     feedback_low "Building SRFI shims"
-    (cd srfi && ./build.ss)
+    (cd srfi && ./build.ss) || die
 }
 
 build_tools () {
   feedback_low "Building gerbil tools"
-  (cd tools && ./build.ss)
+  (cd tools && ./build.ss) || die
   for tool in tools/gx*.ss; do
       toolname=$(basename $tool .ss)
       (cd "${GERBIL_BUILD_PREFIX}/bin" && ln -sf gerbil $toolname)

--- a/src/gerbil/main.ss
+++ b/src/gerbil/main.ss
@@ -63,6 +63,9 @@ package: gerbil
   '(("compile" . "gxc")
     ("interactive" . "gxi")))
 
+(def builtin-tools-subcommand-synonyms
+  '(("build" "gxpkg" "build")))
+
 (def (print-usage! program-name)
   (displayln "Usage: " program-name " [option ...] arguments ...")
   (displayln)
@@ -77,6 +80,7 @@ package: gerbil
   (displayln "Builtin Tools:")
   (displayln "  interactive                      the gerbil interpreter (gxi)")
   (displayln "  compile                          the gerbil compiler (gxc)")
+  (displayln "  build                            the gerbil build tool (gxkpg build)")
   (displayln "  pkg                              the gerbil package manager (gxpkg)")
   (displayln "  test                             the gerbil test runner (gxtest)")
   (displayln "  tags                             the gerbil tag generator (gxtags)")
@@ -188,6 +192,8 @@ package: gerbil
        (tool-main (string-append "gx" hd) rest))
       ((assoc hd builtin-tools-synonyms)
        => (lambda (p) (tool-main (cdr p) rest)))
+      ((assoc hd builtin-tools-subcommand-synonyms)
+       => (lambda (sub) (tool-main (cadr p) (append (cdr p) rest))))
       ((member hd '("-h" "--help" "help"))
        (print-usage! program-name))
       ((member hd '("-v" "--version" "version"))

--- a/src/gerbil/main.ss
+++ b/src/gerbil/main.ss
@@ -193,7 +193,7 @@ package: gerbil
       ((assoc hd builtin-tools-synonyms)
        => (lambda (p) (tool-main (cdr p) rest)))
       ((assoc hd builtin-tools-subcommand-synonyms)
-       => (lambda (sub) (tool-main (cadr p) (append (cdr p) rest))))
+       => (lambda (sub) (tool-main (cadr sub) (append (cdr sub) rest))))
       ((member hd '("-h" "--help" "help"))
        (print-usage! program-name))
       ((member hd '("-v" "--version" "version"))

--- a/src/std/build-script.ss
+++ b/src/std/build-script.ss
@@ -9,10 +9,12 @@
 (def (build-main args build-spec keys that-file)
   (def srcdir (path-normalize (path-directory that-file)))
   (def (build) (apply make build-spec srcdir: srcdir keys))
+  (def (clean) (apply make-clean build-spec srcdir: srcdir keys))
   (match args
-    (["meta"] (write '("spec" "compile")) (newline))
+    (["meta"] (write '("spec" "compile" "clean")) (newline))
     (["spec"] (pretty-print build-spec))
     (["compile"] (build))
+    (["clean"] (clean))
     ([] (build))))
 
 (defsyntax (defbuild-script stx)

--- a/src/std/make.ss
+++ b/src/std/make.ss
@@ -768,15 +768,15 @@ TODO:
 (def (compile-exe/context mod opts settings)
   (cond
    ((or (settings-build-release settings)
-        (getenv "GERBUIL_BUILD_RELEASE" #f))
+        (getenv "GERBIL_BUILD_RELEASE" #f))
     (cond
      ((or (settings-build-optimized settings)
-          (getenv "GERBUIL_BUILD_OPTIMIZED" #f))
+          (getenv "GERBIL_BUILD_OPTIMIZED" #f))
       (compile-optimized-exe/static-linkage mod opts settings))
       (else
        (compile-exe/static-linkage mod opts settings))))
    ((or (settings-build-optimized settings)
-        (getenv "GERBUIL_BUILD_OPTIMIZED" #f))
+        (getenv "GERBIL_BUILD_OPTIMIZED" #f))
     (compile-optimized-exe mod opts settings))
    (else
     (compile-exe mod opts settings))))

--- a/src/std/make.ss
+++ b/src/std/make.ss
@@ -28,6 +28,7 @@
 (extern namespace: #f with-cons-load-path load-path)
 
 (export make
+        make-clean
         shell-config
         env-cppflags
         env-ldflags
@@ -506,6 +507,20 @@ TODO:
    deterministic-order: #f max-workers: (max (settings-parallelize settings) 1))
 
   (when (verbose>=? 3) (writeln [Step: 5 "All built"])))
+
+(def (make-clean . args)
+  (defvalues (positionals keywords) (separate-keyword-arguments args #t))
+  (def buildspec (match positionals ([x] x) (_ (error "invalid arguments" make positionals))))
+  (def settings (apply make-settings keywords))
+
+  (for-each
+    (lambda (spec)
+      (for-each
+        (lambda (f)
+          (displayln "... remove " f)
+          (delete-file-or-directory f))
+        (spec-outputs spec settings)))
+    buildspec))
 
 (defstruct build-failure (item exception))
 

--- a/src/std/make.ss
+++ b/src/std/make.ss
@@ -97,8 +97,7 @@ TODO:
    libdir-prefix parallelize
    full-program-optimization
    build-release
-   build-optimized
-   )
+   build-optimized)
   transparent: #t constructor: :init!)
 
 (defmethod {:init! settings}

--- a/src/tools/gxpkg.ss
+++ b/src/tools/gxpkg.ss
@@ -158,9 +158,9 @@
 
 (def (build-pkgs pkgs release? optimized?)
   (when release?
-    (setenv "GERBUIL_BUILD_RELEASE" "t"))
+    (setenv "GERBIL_BUILD_RELEASE" "t"))
   (when optimized?
-    (setenv "GERBUIL_BUILD_OPTIMIZED" "t"))
+    (setenv "GERBIL_BUILD_OPTIMIZED" "t"))
   (if (null? pkgs)
     ;; do local build
     (pkg-build "." #f)

--- a/src/tools/gxpkg.ss
+++ b/src/tools/gxpkg.ss
@@ -44,25 +44,27 @@
 (def (main . args)
   (def install-cmd
     (command 'install help: "install one or more packages"
-             (rest-arguments 'pkg help: "package to install")))
+      (rest-arguments 'pkg help: "package to install")))
   (def uninstall-cmd
     (command 'uninstall help: "uninstall one or more packages"
-             (flag 'force "-f" help: "force uninstall even if there are orphaned dependencies")
-             (rest-arguments 'pkg help: "package to uninstall")))
+      (flag 'force "-f" help: "force uninstall even if there are orphaned dependencies")
+      (rest-arguments 'pkg help: "package to uninstall")))
   (def update-cmd
     (command 'update help: "update one or more packages"
-             (rest-arguments 'pkg help: "package to update; all for all packages")))
+      (rest-arguments 'pkg help: "package to update; all for all packages")))
   (def link-cmd
     (command 'link help: "link a local development package"
-             (argument 'pkg help: "package to link")
-             (argument 'src help: "path to package source directory")))
+      (argument 'pkg help: "package to link")
+      (argument 'src help: "path to package source directory")))
   (def unlink-cmd
     (command 'unlink help: "unlink one or more local development packages"
-             (flag 'force "-f" help: "force unlink even if there are orphaned dependencies")
-             (rest-arguments 'pkg help: "package to unlink")))
+      (flag 'force "-f" help: "force unlink even if there are orphaned dependencies")
+      (rest-arguments 'pkg help: "package to unlink")))
   (def build-cmd
     (command 'build help: "rebuild one or more packages and their dependents"
-             (rest-arguments 'pkg help: "package to build; all for all packages")))
+      (flag 'build-release "-R" "--release" help: "build released (static) executables")
+      (flag 'build-optimized "-O" "--optimized" help: "build full program optimized executables")
+      (rest-arguments 'pkg help: "package to build; all for all packages")))
   (def clean-cmd
     (command 'clean help: "clean compilation artefacts from one or more packages"
              (rest-arguments 'pkg help: "package to clean")))
@@ -102,7 +104,7 @@
       ((unlink)
        (unlink-pkgs .pkg .?force))
       ((build)
-       (build-pkgs .pkg))
+       (build-pkgs .pkg .?release .?optimized))
       ((clean)
        (clean-pkgs .pkg))
       ((list)
@@ -154,7 +156,11 @@
 (def (unlink-pkgs pkgs force?)
   (for-each (cut pkg-unlink <> force?) pkgs))
 
-(def (build-pkgs pkgs)
+(def (build-pkgs pkgs release? optimized?)
+  (when release?
+    (setenv "GERBUIL_BUILD_RELEASE" "t"))
+  (when optimized?
+    (setenv "GERBUIL_BUILD_OPTIMIZED" "t"))
   (for-each pkg-build pkgs))
 
 (def (clean-pkgs pkgs)

--- a/src/tools/gxpkg.ss
+++ b/src/tools/gxpkg.ss
@@ -327,7 +327,7 @@
                     coprocess: void
                     stdout-redirection: #f)
        (when dependents?
-         (for-each pkg-build (pkg-dependents pkg))))))))
+         (for-each pkg-build (pkg-dependents pkg)))))))
 
 (def (pkg-clean pkg)
   (def gpath (getenv "GERBIL_PATH" "~/.gerbil"))


### PR DESCRIPTION
This is the make side:
- By defining build-release (setenv `GERBIL_BUILD_RELEASE=t`), exe: means static-exe:
- By defining build-optimized (setenv `GERBIL_BUILD_OPTIMIZED=t`), exe means optimized-exe:
- By defining both, exe means optimized-static-exe:

This is the `gxpkg build` side:
- pass `--release` flag to build with build-release defined
- pass `--optimized` flag to build with build-optimized defined
- invoke `gxpkg build` to do it in the current directory; no package linking needed any more.

And this is the `gerbil` bach synonym:
- `gerbil build [--release] [--optimized]` means `gxpkg build ...`

It also adds a `clean` command to builds scripts, and moves the clean logic out of gxpkg and into make, where we have the spec outputs anyway.

See #780