### PR TITLE
gxpkg new command

### DIFF
--- a/configure
+++ b/configure
@@ -61,8 +61,9 @@ std_disable_feature() {
 }
 
 readonly gerbil_version="v$(git describe --tags --always)"
+readonly gerbil_targets=""
 readonly default_gambit_tag=v4.9.5
-readonly default_gambit_config="--enable-targets='' --enable-single-host --enable-dynamic-clib --enable-default-runtime-options=t8,f8,-8 --enable-trust-c-tco"
+readonly default_gambit_config="--enable-targets=${gerbil_targets} --enable-single-host --enable-dynamic-clib --enable-default-runtime-options=t8,f8,-8 --enable-trust-c-tco"
 prefix="/opt/gerbil"
 readonly cflags_opt="-foptimize-sibling-calls"
 readonly ldflags_rpath="-Wl,-rpath"

--- a/src/gerbil/main.ss
+++ b/src/gerbil/main.ss
@@ -53,7 +53,7 @@ package: gerbil
     "gerbil/compiler"))
 
 (def builtin-tool-commands
-  '(("new"         "gxkpg" "new")
+  '(("new"         "gxpkg" "new")
     ("build"       "gxpkg" "build")
     ("clean"       "gxpkg" "clean")
     ("pkg"         "gxpkg")
@@ -65,10 +65,10 @@ package: gerbil
     ("compile"     "gxc")))
 
 (def builtin-tool-help
-  '(("new"         "gxkpg" "help" "new")
+  '(("new"         "gxpkg" "help" "new")
     ("build"       "gxpkg" "help" "build")
     ("clean"       "gxpkg" "help" "clean")
-    ("pkg"         "gxkpg" "help")
+    ("pkg"         "gxpkg" "help")
     ("test"        "gxtest" "-h")
     ("tags"        "gxtags" "-h")
     ("prof"        "gxprof" "-h")
@@ -89,7 +89,7 @@ package: gerbil
   (displayln)
   (displayln "Commands:")
   (displayln "  new                              create a new project template (gxpkg new)")
-  (displayln "  build                            build a gerbil package (gxkpg build)")
+  (displayln "  build                            build a gerbil package (gxpkg build)")
   (displayln "  clean                            clean build artifactacts for a package (gxpkg clean)")
   (displayln "  pkg                              invoke the gerbil package manager (gxpkg)")
   (displayln "  test                             run tests (gxtest)")

--- a/src/gerbil/main.ss
+++ b/src/gerbil/main.ss
@@ -205,17 +205,17 @@ package: gerbil
        (print-usage! program-name))
       ((equal? "help" hd)
        (match rest
-         ([cmd . rest]
+         ([cmd]
           (cond
            ((assoc cmd builtin-tool-help)
-            => (lambda (help-cmd) (tool-main (cadr help-cmd) (cdr help-cmd) rest)))
+            => (lambda (help-cmd) (tool-main (car help-cmd) (cdr help-cmd))))
            (else
             (displayln "no help for topic " cmd)
             (print-usage! program-name))))
          (else
           (print-usage! program-name))))
       ((assoc hd builtin-tool-commands)
-       => (lambda (cmd) (tool-main (cadr cmd) (append (cdr cmd) rest))))
+       => (lambda (cmd) (tool-main (car cmd) (append (cdr cmd) rest))))
       ((member hd '("-v" "--version" "version"))
        (displayln (gerbil-system-version-string)))
       (else

--- a/src/gerbil/main.ss
+++ b/src/gerbil/main.ss
@@ -64,11 +64,23 @@ package: gerbil
     ("interactive" "gxi")
     ("compile"     "gxc")))
 
+(def builtin-tool-help
+  '(("new"         "gxkpg" "help" "new")
+    ("build"       "gxpkg" "help" "build")
+    ("clean"       "gxpkg" "help" "clean")
+    ("pkg"         "gxkpg" "help")
+    ("test"        "gxtest" "-h")
+    ("tags"        "gxtags" "-h")
+    ("prof"        "gxprof" "-h")
+    ("ensemble"    "gxensemble" "help")
+    ("interactive" "gxi" "-h")
+    ("compile"     "gxc" "-h")))
+
 (def (print-usage! program-name)
   (displayln "Usage: " program-name " [option ...] arguments ...")
   (displayln)
   (displayln "Options: ")
-  (displayln "  -h|--help|help                   display this help message exit")
+  (displayln "  -h|--help                        display this help message exit")
   (displayln "  -v|--version|version             display the system version and exit")
   (displayln)
   (displayln "Arguments: ")
@@ -86,8 +98,9 @@ package: gerbil
   (displayln "  ensemble                         invoke the gerbil actor ensemble manager (gxensemble)")
   (displayln "  interactive                      invoke the gerbil interpreter (gxi)")
   (displayln "  compile                          invoke the gerbil compiler (gxc)")
+  (displayln "  help <cmd>                       display help for a tool command")
   (displayln)
-  (displayln "Try " program-name " <tool> [-h|--help|help] for help on tool usage" ))
+  (displayln "Try " program-name " help <cmd> for help on tool command usage" ))
 
 (extern namespace: #f
   gerbil-runtime-init!)
@@ -188,10 +201,21 @@ package: gerbil
   (match args
     ([hd . rest]
      (cond
+      ((member hd '("-h" "--help"))
+       (print-usage! program-name))
+      ((equal? "help" hd)
+       (match rest
+         ([cmd . rest]
+          (cond
+           ((assoc cmd builtin-tool-help)
+            => (lambda (help-cmd) (tool-main (cadr help-cmd) (cdr help-cmd) rest)))
+           (else
+            (displayln "no help for topic " cmd)
+            (print-usage! program-name))))
+         (else
+          (print-usage! program-name))))
       ((assoc hd builtin-tool-commands)
        => (lambda (cmd) (tool-main (cadr cmd) (append (cdr cmd) rest))))
-      ((member hd '("-h" "--help" "help"))
-       (print-usage! program-name))
       ((member hd '("-v" "--version" "version"))
        (displayln (gerbil-system-version-string)))
       (else

--- a/src/gerbil/main.ss
+++ b/src/gerbil/main.ss
@@ -52,20 +52,17 @@ package: gerbil
     "gerbil/compiler/ssxi"
     "gerbil/compiler"))
 
-(def builtin-tools
-  '("pkg"
-    "test"
-    "tags"
-    "prof"
-    "ensemble"))
-
-(def builtin-tools-synonyms
-  '(("compile" . "gxc")
-    ("interactive" . "gxi")))
-
-(def builtin-tools-subcommand-synonyms
-  '(("new" "gxkpg" "new")
-    ("build" "gxpkg" "build")))
+(def builtin-tool-commands
+  '(("new"         "gxkpg" "new")
+    ("build"       "gxpkg" "build")
+    ("clean"       "gxpkg" "clean")
+    ("pkg"         "gxkpg")
+    ("test"        "gxtest")
+    ("tags"        "gxtags")
+    ("prof"        "gxprof")
+    ("ensemble"    "gxensemble")
+    ("interactive" "gxi")
+    ("compile"     "gxc")))
 
 (def (print-usage! program-name)
   (displayln "Usage: " program-name " [option ...] arguments ...")
@@ -75,19 +72,20 @@ package: gerbil
   (displayln "  -v|--version|version             display the system version and exit")
   (displayln)
   (displayln "Arguments: ")
-  (displayln "  <tool> tool-arg ...              execute a builtin gerbil tool")
+  (displayln "  <cmd> cmd-arg ...                execute a builtin tool command")
   (displayln "  arg ...                          drop to the gerbil interpreter")
   (displayln)
-  (displayln "Builtin Tools:")
-  (displayln "  interactive                      the gerbil interpreter (gxi)")
-  (displayln "  compile                          the gerbil compiler (gxc)")
-  (displayln "  new                              the gerbil package template tool (gxpkg new)")
-  (displayln "  build                            the gerbil build tool (gxkpg build)")
-  (displayln "  pkg                              the gerbil package manager (gxpkg)")
-  (displayln "  test                             the gerbil test runner (gxtest)")
-  (displayln "  tags                             the gerbil tag generator (gxtags)")
-  (displayln "  prof                             the gerbil profiler (gxprof)")
-  (displayln "  ensemble                         the gerbil actor ensemble manager (gxensemble)")
+  (displayln "Commands:")
+  (displayln "  new                              create a new project template (gxpkg new)")
+  (displayln "  build                            build a gerbil package (gxkpg build)")
+  (displayln "  clean                            clean build artifactacts for a package (gxpkg clean)")
+  (displayln "  pkg                              invoke the gerbil package manager (gxpkg)")
+  (displayln "  test                             run tests (gxtest)")
+  (displayln "  tags                             create emacs tags (gxtags)")
+  (displayln "  prof                             profile a dynamic executable module (gxprof)")
+  (displayln "  ensemble                         invoke the gerbil actor ensemble manager (gxensemble)")
+  (displayln "  interactive                      invoke the gerbil interpreter (gxi)")
+  (displayln "  compile                          invoke the gerbil compiler (gxc)")
   (displayln)
   (displayln "Try " program-name " <tool> [-h|--help|help] for help on tool usage" ))
 
@@ -190,12 +188,8 @@ package: gerbil
   (match args
     ([hd . rest]
      (cond
-      ((member hd builtin-tools)
-       (tool-main (string-append "gx" hd) rest))
-      ((assoc hd builtin-tools-synonyms)
-       => (lambda (p) (tool-main (cdr p) rest)))
-      ((assoc hd builtin-tools-subcommand-synonyms)
-       => (lambda (sub) (tool-main (cadr sub) (append (cdr sub) rest))))
+      ((assoc hd builtin-tool-commands)
+       => (lambda (cmd) (tool-main (cadr cmd) (append (cdr cmd) rest))))
       ((member hd '("-h" "--help" "help"))
        (print-usage! program-name))
       ((member hd '("-v" "--version" "version"))

--- a/src/gerbil/main.ss
+++ b/src/gerbil/main.ss
@@ -64,7 +64,8 @@ package: gerbil
     ("interactive" . "gxi")))
 
 (def builtin-tools-subcommand-synonyms
-  '(("build" "gxpkg" "build")))
+  '(("new" "gxkpg" "new")
+    ("build" "gxpkg" "build")))
 
 (def (print-usage! program-name)
   (displayln "Usage: " program-name " [option ...] arguments ...")
@@ -80,6 +81,7 @@ package: gerbil
   (displayln "Builtin Tools:")
   (displayln "  interactive                      the gerbil interpreter (gxi)")
   (displayln "  compile                          the gerbil compiler (gxc)")
+  (displayln "  new                              the gerbil package template tool (gxpkg new)")
   (displayln "  build                            the gerbil build tool (gxkpg build)")
   (displayln "  pkg                              the gerbil package manager (gxpkg)")
   (displayln "  test                             the gerbil test runner (gxtest)")

--- a/src/gerbil/main.ss
+++ b/src/gerbil/main.ss
@@ -208,14 +208,14 @@ package: gerbil
          ([cmd]
           (cond
            ((assoc cmd builtin-tool-help)
-            => (lambda (help-cmd) (tool-main (car help-cmd) (cdr help-cmd))))
+            => (lambda (help-cmd) (tool-main (cadr help-cmd) (cdr help-cmd))))
            (else
             (displayln "no help for topic " cmd)
             (print-usage! program-name))))
          (else
           (print-usage! program-name))))
       ((assoc hd builtin-tool-commands)
-       => (lambda (cmd) (tool-main (car cmd) (append (cdr cmd) rest))))
+       => (lambda (cmd) (tool-main (cadr cmd) (append (cdr cmd) rest))))
       ((member hd '("-v" "--version" "version"))
        (displayln (gerbil-system-version-string)))
       (else

--- a/src/gerbil/main.ss
+++ b/src/gerbil/main.ss
@@ -56,7 +56,7 @@ package: gerbil
   '(("new"         "gxkpg" "new")
     ("build"       "gxpkg" "build")
     ("clean"       "gxpkg" "clean")
-    ("pkg"         "gxkpg")
+    ("pkg"         "gxpkg")
     ("test"        "gxtest")
     ("tags"        "gxtags")
     ("prof"        "gxprof")
@@ -208,14 +208,14 @@ package: gerbil
          ([cmd]
           (cond
            ((assoc cmd builtin-tool-help)
-            => (lambda (help-cmd) (tool-main (cadr help-cmd) (cdr help-cmd))))
+            => (lambda (help-cmd) (tool-main (cadr help-cmd) (cddr help-cmd))))
            (else
             (displayln "no help for topic " cmd)
             (print-usage! program-name))))
          (else
           (print-usage! program-name))))
       ((assoc hd builtin-tool-commands)
-       => (lambda (cmd) (tool-main (cadr cmd) (append (cdr cmd) rest))))
+       => (lambda (cmd) (tool-main (cadr cmd) (append (cddr cmd) rest))))
       ((member hd '("-v" "--version" "version"))
        (displayln (gerbil-system-version-string)))
       (else

--- a/src/tools/gxpkg.ss
+++ b/src/tools/gxpkg.ss
@@ -65,10 +65,10 @@
     (command 'build help: "rebuild one or more packages and their dependents"
       (flag 'build-release "-R" "--release" help: "build released (static) executables")
       (flag 'build-optimized "-O" "--optimized" help: "build full program optimized executables")
-      (rest-arguments 'pkg help: "package to build; all for all packages")))
+      (rest-arguments 'pkg help: "package to build; all for all packages, omit to build in current directory")))
   (def clean-cmd
     (command 'clean help: "clean compilation artefacts from one or more packages"
-      (rest-arguments 'pkg help: "package to clean")))
+      (rest-arguments 'pkg help: "package to clean; all for all packages, omit to clean in current directory")))
   (def new-cmd
     (command 'new help: "Create a new package template in the current directory"
       (option 'package "-p" "--package"

--- a/src/tools/gxpkg.ss
+++ b/src/tools/gxpkg.ss
@@ -76,7 +76,9 @@
         default: (getenv "USER"))
       (option 'name "-n" "--name"
         help: "The package name; defaults to the current directory name"
-        default: (path-strip-directory (current-directory)))))
+        default: (path-strip-directory (current-directory)))
+      (option 'name "-l" "--link"
+        help: "Link this package with a package name; for example: github.com/your-user/your-package")))
   (def list-cmd
     (command 'list help: "list installed packages"))
   (def retag-cmd
@@ -104,7 +106,7 @@
   (let-hash opt
     (case cmd
       ((new)
-       (new-pkg .package .name))
+       (new-pkg .package .name .link))
       ((build)
        (build-pkgs .pkg .?release .?optimized))
       ((clean)
@@ -218,7 +220,7 @@
       (force once)
       +pkg-root-dir+)))
 
-(def (pkg-new prefix name)
+(def (pkg-new prefix name maybe-link)
   (def (create-template file template . args)
     (call-with-output-file file
       (lambda (output)
@@ -234,7 +236,9 @@
   (create-template [path: "build.ss" permissions: #o755] build.ss-template
                    name: name)
   ;; TODO create Makefile template
-  )
+  ;; ...
+  (when maybe-link
+    (pkg-link maybe-link (current-directory))))
 
 (def (pkg-install pkg)
   (def (git-clone-url pkg)

--- a/src/tools/gxpkg.ss
+++ b/src/tools/gxpkg.ss
@@ -106,7 +106,7 @@
   (let-hash opt
     (case cmd
       ((new)
-       (new-pkg .package .name .link))
+       (pkg-new .package .name .link))
       ((build)
        (build-pkgs .pkg .?release .?optimized))
       ((clean)
@@ -226,7 +226,7 @@
       (lambda (output)
         (apply write-template template output args))))
 
-  (create-template "gerbil.pkg" gerbi.pkg-template
+  (create-template "gerbil.pkg" gerbil.pkg-template
                    package: prefix)
   (create-directory "bin")
   (create-directory name)

--- a/src/tools/gxpkg.ss
+++ b/src/tools/gxpkg.ss
@@ -76,8 +76,10 @@
         default: (getenv "USER"))
       (option 'name "-n" "--name"
         help: "The package name; defaults to the current directory name"
-        default: (path-strip-directory (current-directory)))
-      (option 'name "-l" "--link"
+        default: (path-strip-directory
+                  (let (path (path-normalize (current-directory)))
+                    (substring path 0 (1- (string-length path))))))
+      (option 'link "-l" "--link"
         help: "Optionally link this package with a public package name; for example: github.com/your-user/your-package")))
   (def list-cmd
     (command 'list help: "list installed packages"))
@@ -228,7 +230,6 @@
 
   (create-template "gerbil.pkg" gerbil.pkg-template
                    package: prefix)
-  (create-directory "bin")
   (create-directory name)
   (create-template (path-expand "main.ss" name) main.ss-template
                    name: name)
@@ -525,6 +526,7 @@
 ;;; templates
 (def gerbil.pkg-template #<<END
 (package: ${package})
+
 END
 )
 
@@ -543,7 +545,7 @@ END
     ;; ...
     ))
 
-(def ${name}-main
+(def* ${name}-main
   ((opt)
    (${name}-main/options opt))
   ((cmd opt)
@@ -556,6 +558,7 @@ END
 ;;; Implement this if your CLI has commands
 (def (${name}-main/command cmd opt)
   (error "Implement me!"))
+
 END
 )
 
@@ -566,6 +569,7 @@ END
 
 ;;; Your library support code
 ;;; ...
+
 END
 )
 
@@ -576,6 +580,7 @@ END
 
 (defbuild-script
   '("${name}/lib"
-    (exe: "${name}/main" bin: "bin/${name}")))
+    (exe: "${name}/main" bin: "${name}")))
+
 END
 )

--- a/src/tools/gxpkg.ss
+++ b/src/tools/gxpkg.ss
@@ -78,7 +78,7 @@
         help: "The package name; defaults to the current directory name"
         default: (path-strip-directory (current-directory)))
       (option 'name "-l" "--link"
-        help: "Link this package with a package name; for example: github.com/your-user/your-package")))
+        help: "Optionally link this package with a public package name; for example: github.com/your-user/your-package")))
   (def list-cmd
     (command 'list help: "list installed packages"))
   (def retag-cmd

--- a/src/tools/gxpkg.ss
+++ b/src/tools/gxpkg.ss
@@ -236,8 +236,11 @@
   (create-template (path-expand "lib.ss" name) lib.ss-template)
   (create-template [path: "build.ss" permissions: #o755] build.ss-template
                    name: name)
+  (create-template ".gitignore" gitignore-template)
+
   ;; TODO create Makefile template
   ;; ...
+
   (when maybe-link
     (pkg-link maybe-link (current-directory))))
 
@@ -581,6 +584,13 @@ END
 (defbuild-script
   '("${name}/lib"
     (exe: "${name}/main" bin: "${name}")))
+
+END
+)
+
+(def gitignore-template #<<END
+*~
+build-deps
 
 END
 )


### PR DESCRIPTION
Implements  `gerbil new` as a synonym for `gxpkg new`; this creates a new package template in the current directory.